### PR TITLE
feat: implement PostHog metrics tracking for search and ingest operat…

### DIFF
--- a/apps/webapp/app/services/posthog.server.test.ts
+++ b/apps/webapp/app/services/posthog.server.test.ts
@@ -1,0 +1,148 @@
+import { posthogService } from './posthog.server';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fetch from 'node-fetch';
+
+// Mock node-fetch
+vi.mock('node-fetch');
+
+// Mock environment variables
+vi.mock('~/env.server', () => ({
+  env: {
+    POSTHOG_PROJECT_KEY: 'test-api-key',
+  },
+}));
+
+// Mock logger
+vi.mock('./logger.service', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+  },
+}));
+
+describe('PostHogService', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    
+    // Default successful response
+    (fetch as unknown as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should capture events with the correct payload structure', async () => {
+    const userId = 'test-user-id';
+    const event = 'test-event';
+    const properties = { test: 'property' };
+    
+    await posthogService.capture(event, userId, properties);
+    
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith('https://eu.posthog.com/capture/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer test-api-key',
+      },
+      body: expect.stringContaining(event),
+    });
+    
+    const callPayload = JSON.parse((fetch as unknown as jest.Mock).mock.calls[0][1].body);
+    expect(callPayload.api_key).toBe('test-api-key');
+    expect(callPayload.batch).toHaveLength(1);
+    expect(callPayload.batch[0].event).toBe(event);
+    expect(callPayload.batch[0].distinctId).toBe(userId);
+    expect(callPayload.batch[0].properties).toMatchObject({
+      ...properties,
+      $lib: 'server',
+      $lib_version: '1.0.0',
+    });
+  });
+
+  it('should track search events with appropriate properties', async () => {
+    const userId = 'test-user-id';
+    const query = 'test search query';
+    const options = { limit: 10 };
+    const resultCounts = { result_count_total: 5 };
+    
+    await posthogService.trackSearch(userId, query, options, resultCounts);
+    
+    expect(fetch).toHaveBeenCalledTimes(1);
+    
+    const callPayload = JSON.parse((fetch as unknown as jest.Mock).mock.calls[0][1].body);
+    expect(callPayload.batch[0].event).toBe('search');
+    expect(callPayload.batch[0].distinctId).toBe(userId);
+    expect(callPayload.batch[0].properties).toMatchObject({
+      query,
+      query_length: query.length,
+      limit: 10,
+      result_count_total: 5,
+    });
+  });
+
+  it('should track ingestion events with appropriate properties', async () => {
+    const userId = 'test-user-id';
+    const episodeLength = 1000;
+    const metadata = { source: 'test-source' };
+    const success = true;
+    
+    await posthogService.trackIngestion(userId, episodeLength, metadata, success);
+    
+    expect(fetch).toHaveBeenCalledTimes(1);
+    
+    const callPayload = JSON.parse((fetch as unknown as jest.Mock).mock.calls[0][1].body);
+    expect(callPayload.batch[0].event).toBe('ingestion');
+    expect(callPayload.batch[0].distinctId).toBe(userId);
+    expect(callPayload.batch[0].properties).toMatchObject({
+      episode_length: 1000,
+      source: 'test-source',
+      success: true,
+    });
+  });
+
+  it('should handle fetch errors gracefully', async () => {
+    (fetch as unknown as jest.Mock).mockRejectedValue(new Error('Network error'));
+    
+    const result = await posthogService.capture('test-event', 'test-user-id');
+    
+    expect(result).toBe(false);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    (fetch as unknown as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+    
+    const result = await posthogService.capture('test-event', 'test-user-id');
+    
+    expect(result).toBe(false);
+  });
+
+  it('should not send events if no API key is provided', async () => {
+    // Override env mock for this test
+    vi.mock('~/env.server', () => ({
+      env: {
+        POSTHOG_PROJECT_KEY: '',
+      },
+    }), { virtual: true });
+    
+    // Need to recreate the service to pick up the new env mock
+    const mockService = new (posthogService.constructor as any)();
+    
+    const result = await mockService.capture('test-event', 'test-user-id');
+    
+    expect(result).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/services/posthog.server.ts
+++ b/apps/webapp/app/services/posthog.server.ts
@@ -1,0 +1,136 @@
+import { env } from "~/env.server";
+import { logger } from "./logger.service";
+import fetch from "node-fetch";
+
+interface PostHogEvent {
+  event: string;
+  distinctId: string;
+  properties?: Record<string, any>;
+  timestamp?: string;
+}
+
+/**
+ * Server-side PostHog client for analytics tracking
+ * Provides methods to track events on the server without requiring the client-side JS
+ */
+export class PostHogService {
+  private readonly apiKey: string;
+  private readonly host: string;
+  private readonly enabled: boolean;
+
+  constructor() {
+    this.apiKey = env.POSTHOG_PROJECT_KEY;
+    this.host = "https://eu.posthog.com";
+    this.enabled = !!this.apiKey && this.apiKey.length > 0;
+    
+    if (!this.enabled) {
+      logger.warn("PostHog tracking is disabled. Set POSTHOG_PROJECT_KEY to enable.");
+    }
+  }
+
+  /**
+   * Capture an event in PostHog
+   * @param event Event name
+   * @param distinctId User ID for identification
+   * @param properties Additional properties to track
+   * @returns Promise resolving to true if successful
+   */
+  public async capture(
+    event: string,
+    distinctId: string,
+    properties: Record<string, any> = {}
+  ): Promise<boolean> {
+    if (!this.enabled) return false;
+    if (!distinctId) {
+      logger.warn("PostHog event capture failed: No distinctId provided");
+      return false;
+    }
+
+    try {
+      const eventData: PostHogEvent = {
+        event,
+        distinctId,
+        properties: {
+          ...properties,
+          $lib: "server",
+          $lib_version: "1.0.0",
+        },
+        timestamp: new Date().toISOString(),
+      };
+
+      const response = await fetch(`${this.host}/capture/`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({
+          api_key: this.apiKey,
+          batch: [eventData],
+        }),
+      });
+
+      if (!response.ok) {
+        logger.error(`PostHog capture failed: ${response.status} ${response.statusText}`);
+        return false;
+      }
+
+      logger.debug(`PostHog event captured: ${event}`, { 
+        distinctId, 
+        eventName: event
+      });
+      return true;
+    } catch (error) {
+      logger.error("Error sending event to PostHog", { error });
+      return false;
+    }
+  }
+
+  /**
+   * Track search event in PostHog
+   * @param userId User ID
+   * @param query Search query
+   * @param options Search options
+   * @param resultCounts Result counts
+   * @returns Promise resolving to true if successful
+   */
+  public async trackSearch(
+    userId: string,
+    query: string,
+    options: Record<string, any> = {},
+    resultCounts: Record<string, number> = {}
+  ): Promise<boolean> {
+    return this.capture("search", userId, {
+      query,
+      query_length: query.length,
+      ...options,
+      ...resultCounts,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Track ingestion event in PostHog
+   * @param userId User ID
+   * @param episodeLength Length of ingested content
+   * @param metadata Additional metadata
+   * @param success Whether ingestion succeeded
+   * @returns Promise resolving to true if successful
+   */
+  public async trackIngestion(
+    userId: string,
+    episodeLength: number,
+    metadata: Record<string, any> = {},
+    success: boolean = true
+  ): Promise<boolean> {
+    return this.capture("ingestion", userId, {
+      episode_length: episodeLength,
+      success,
+      ...metadata,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+
+// Singleton instance for use across the application
+export const posthogService = new PostHogService();


### PR DESCRIPTION
…ions

- Add server-side PostHog service for backend analytics
- Track search operations with query details and result metrics
- Track ingest operations at queue, start, and completion stages
- Add unit tests for PostHog service
- Include detailed metadata for better analytics insights