### PR TITLE
feat(kubernetes): add kubernetes deployment manifests

### DIFF
--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -1,0 +1,237 @@
+# CORE Kubernetes Deployment
+
+This directory contains Kubernetes manifests for deploying the RedPlanetHQ CORE system on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes cluster (v1.20+)
+- kubectl configured to connect to your cluster
+- Sufficient storage for persistent volumes
+- Ingress controller (nginx recommended)
+
+## Configuration
+
+### 1. Update Secrets
+
+Edit `secrets.yaml` and replace the placeholder values with your actual credentials:
+
+```bash
+# Base64 encode your values
+echo -n "your-openai-api-key" | base64
+echo -n "your-google-client-id" | base64
+echo -n "your-google-client-secret" | base64
+echo -n "your-anthropic-api-key" | base64
+```
+
+Update the following keys in `secrets.yaml`:
+- `OPENAI_API_KEY` (if using OpenAI)
+- `AUTH_GOOGLE_CLIENT_ID` (if using Google OAuth)
+- `AUTH_GOOGLE_CLIENT_SECRET` (if using Google OAuth)
+- `ANTHROPIC_API_KEY` (if using Claude/Anthropic)
+- `RESEND_API_KEY` (if using Resend for emails)
+- `COHERE_API_KEY` (if using Cohere)
+- `AWS_ACCESS_KEY_ID` (if using AWS Bedrock)
+- `AWS_SECRET_ACCESS_KEY` (if using AWS Bedrock)
+- Email configuration values
+
+### 2. Update Ingress
+
+Edit `ingress.yaml` and replace the example hosts with your actual domain names:
+- `core.example.com` → your CORE domain
+- `trigger.example.com` → your Trigger.dev domain
+
+### 3. Configure AI Provider
+
+To use Claude/Anthropic instead of OpenAI, update the `MODEL` value in `configmap.yaml`:
+
+```yaml
+MODEL: "claude-3-5-haiku-20241022"  # or another Claude model
+```
+
+### 4. Storage Configuration
+
+The manifests use the default storage class. If you need to specify a different storage class, uncomment and update the `storageClassName` fields in the StatefulSet manifests.
+
+## Deployment Steps
+
+### Option 1: Using Kustomize (Recommended)
+
+The easiest way to deploy all components is using Kustomize:
+
+```bash
+# 1. Update your secrets first
+# Edit secrets.yaml with your actual API keys and credentials
+
+# 2. Deploy everything
+kubectl apply -k .
+
+# 3. Check deployment status
+kubectl get pods -n RedPlanetHQcore
+```
+
+### Option 2: Manual Deployment
+
+If you prefer to deploy manually, follow these steps in order:
+
+```bash
+# 1. Create namespace (optional)
+kubectl create namespace RedPlanetHQcore
+
+# 2. Deploy configuration and secrets
+kubectl apply -f configmap.yaml
+kubectl apply -f secrets.yaml
+kubectl apply -f clickhouse-configmap.yaml
+
+# 3. Deploy persistent volumes
+kubectl apply -f persistent-volume-claims.yaml
+
+# 4. Deploy databases (StatefulSets)
+kubectl apply -f postgres-statefulset.yaml
+kubectl apply -f neo4j-statefulset.yaml
+kubectl apply -f clickhouse-statefulset.yaml
+
+# 5. Deploy supporting services
+kubectl apply -f redis-deployment.yaml
+
+# 6. Deploy services
+kubectl apply -f services.yaml
+
+# 7. Deploy init job
+kubectl apply -f trigger-init-deployment.yaml
+
+# 8. Deploy applications
+kubectl apply -f trigger-electric-deployment.yaml
+kubectl apply -f trigger-webapp-deployment.yaml
+kubectl apply -f trigger-supervisor-deployment.yaml
+kubectl apply -f core-deployment.yaml
+
+# 9. Deploy ingress (last)
+kubectl apply -f ingress.yaml
+```
+
+### 3. Verify Deployment
+
+Check that all pods are running:
+
+```bash
+kubectl get pods -n RedPlanetHQcore
+```
+
+Check services:
+
+```bash
+kubectl get services -n RedPlanetHQcore
+```
+
+Check ingress:
+
+```bash
+kubectl get ingress -n RedPlanetHQcore
+```
+
+## Accessing the Applications
+
+- CORE application: http://core.example.com (or your configured domain)
+- Trigger.dev: http://trigger.example.com (or your configured domain)
+
+## Monitoring and Logs
+
+View logs for a specific component:
+
+```bash
+# CORE application
+kubectl logs -n RedPlanetHQcore deployment/core-app -f
+
+# PostgreSQL
+kubectl logs -n RedPlanetHQcore statefulset/postgres -f
+
+# Neo4j
+kubectl logs -n RedPlanetHQcore statefulset/neo4j -f
+```
+
+## Scaling
+
+### Horizontal Scaling
+
+Scale the CORE application:
+
+```bash
+kubectl scale deployment core-app --replicas=3 -n RedPlanetHQcore
+```
+
+### Resource Limits
+
+Adjust resource limits in the deployment manifests based on your cluster capacity and usage patterns.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Pods stuck in Pending state**
+   - Check if there's enough storage available
+   - Verify the storage class is available in your cluster
+
+2. **Database connection errors**
+   - Ensure databases are fully started before applications
+   - Check service names and ports in the configuration
+
+3. **Ingress not working**
+   - Verify the ingress controller is installed and running
+   - Check the ingress controller logs for errors
+
+### Resetting the Deployment
+
+To completely remove the deployment:
+
+```bash
+kubectl delete -f . -n RedPlanetHQcore
+```
+
+## Backup and Recovery
+
+### Database Backups
+
+For PostgreSQL:
+```bash
+kubectl exec -n RedPlanetHQcore postgres-0 -- pg_dump -U docker core > backup.sql
+```
+
+For Neo4j:
+```bash
+kubectl exec -n RedPlanetHQcore neo4j-0 -- neo4j-admin dump --database=neo4j --to=/backup/neo4j.dump
+```
+
+### Recovery
+
+Restore PostgreSQL:
+```bash
+kubectl exec -i -n RedPlanetHQcore postgres-0 -- psql -U docker core < backup.sql
+```
+
+## Security Considerations
+
+1. **Network Policies**: Consider adding network policies to restrict traffic between components
+2. **RBAC**: Implement proper role-based access control
+3. **Secrets Management**: Use a proper secrets management solution in production
+4. **TLS**: Enable TLS for all external communications
+
+## Customization
+
+### Environment Variables
+
+Add or modify environment variables in the respective deployment manifests or in the `configmap.yaml`.
+
+### Storage
+
+Adjust the storage sizes in the `persistent-volume-claims.yaml` based on your needs.
+
+### AI Provider Configuration
+
+To use different AI providers or models, update the relevant environment variables in `configmap.yaml` and add the required API keys to `secrets.yaml`.
+
+## Support
+
+For issues related to:
+- CORE application: Check the [CORE documentation](https://docs.heysol.ai)
+- Kubernetes: Refer to the [Kubernetes documentation](https://kubernetes.io/docs/)
+- Specific components: Check their respective documentation

--- a/hosting/kubernetes/clickhouse-configmap.yaml
+++ b/hosting/kubernetes/clickhouse-configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-config
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: clickhouse
+data:
+  override.xml: |
+    <?xml version="1.0"?>
+    <yandex>
+        <!-- ClickHouse configuration override -->
+        <logger>
+            <level>information</level>
+            <console>true</console>
+        </logger>
+        
+        <!-- Memory settings -->
+        <memory>
+            <max_server_memory_usage_percentage>85</max_server_memory_usage_percentage>
+        </memory>
+        
+        <!-- Performance settings -->
+        <max_threads>8</max_threads>
+        <max_concurrent_queries>100</max_concurrent_queries>
+        
+        <!-- Network settings -->
+        <listen_host>::</listen_host>
+        <http_port>8123</http_port>
+        <tcp_port>9000</tcp_port>
+        
+        <!-- Replication settings (if needed in future) -->
+        <replication>
+            <use_replicated_merge_tree>1</use_replicated_merge_tree>
+        </replication>
+        
+        <!-- Zookeeper settings (if using replication in future) -->
+        <!-- 
+        <zookeeper>
+            <node>
+                <host>zookeeper</host>
+                <port>2181</port>
+            </node>
+        </zookeeper>
+        -->
+    </yandex>

--- a/hosting/kubernetes/clickhouse-statefulset.yaml
+++ b/hosting/kubernetes/clickhouse-statefulset.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: clickhouse
+spec:
+  serviceName: clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: clickhouse
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: clickhouse
+    spec:
+      containers:
+      - name: clickhouse
+        image: bitnami/clickhouse:latest
+        ports:
+        - containerPort: 8123
+          name: http
+        - containerPort: 9000
+          name: native
+        env:
+        - name: CLICKHOUSE_ADMIN_USER
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: CLICKHOUSE_USER
+        - name: CLICKHOUSE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: CLICKHOUSE_PASSWORD
+        volumeMounts:
+        - name: clickhouse-storage
+          mountPath: /bitnami/clickhouse
+        - name: clickhouse-config
+          mountPath: /bitnami/clickhouse/etc/config.d/override.xml
+          subPath: override.xml
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "1000m"
+        livenessProbe:
+          exec:
+            command:
+            - clickhouse-client
+            - --host
+            - localhost
+            - --port
+            - "9000"
+            - --user
+            - default
+            - --password
+            - password
+            - --query
+            - "SELECT 1"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - clickhouse-client
+            - --host
+            - localhost
+            - --port
+            - "9000"
+            - --user
+            - default
+            - --password
+            - password
+            - --query
+            - "SELECT 1"
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: clickhouse-config
+        configMap:
+          name: clickhouse-config
+  volumeClaimTemplates:
+  - metadata:
+      name: clickhouse-storage
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      # storageClassName: standard # Uncomment if you need to specify a storage class
+      resources:
+        requests:
+          storage: 50Gi

--- a/hosting/kubernetes/configmap.yaml
+++ b/hosting/kubernetes/configmap.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: core-config
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: config
+data:
+  VERSION: "0.1.24"
+  DB_HOST: "postgres"
+  DB_PORT: "5432"
+  POSTGRES_USER: "docker"
+  POSTGRES_PASSWORD: "docker"
+  POSTGRES_DB: "core"
+  DATABASE_URL: "postgresql://docker:docker@postgres:5432/core?schema=core"
+  DIRECT_URL: "postgresql://docker:docker@postgres:5432/core?schema=core"
+  REMIX_APP_PORT: "3033"
+  APP_ENV: "production"
+  NODE_ENV: "production"
+  CORE_APP_ORIGIN: "http://localhost:3033"
+  API_BASE_URL: "http://localhost:3033"
+  CORE_LOGIN_ORIGIN: "http://localhost:3033"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  REDIS_TLS_DISABLED: "true"
+  ENABLE_EMAIL_LOGIN: "true"
+  NEO4J_URI: "bolt://neo4j:7687"
+  NEO4J_USERNAME: "neo4j"
+  EMBEDDING_MODEL: "text-embedding-3-small"
+  MODEL: "gpt-4.1-2025-04-14"
+  OLLAMA_URL: ""
+  TRIGGER_PROJECT_ID: "proj_mqwudvjcukvybqxyjkjv"
+  TRIGGER_IMAGE_TAG: "v4-beta"
+  TRIGGER_DB: "trigger"
+  TRIGGER_DATABASE_URL: "postgresql://docker:docker@postgres:5432/trigger?schema=public&sslmode=disable"
+  TRIGGER_DIRECT_URL: "postgresql://docker:docker@postgres:5432/trigger?schema=public&sslmode=disable"
+  ELECTRIC_DATABASE_URL: "postgresql://docker:docker@postgres/trigger"
+  TRIGGER_TASKS_IMAGE: "redplanethq/proj_core:latest"
+  APP_ORIGIN: "http://localhost:8030"
+  LOGIN_ORIGIN: "http://localhost:8030"
+  API_ORIGIN: "http://trigger-webapp:3000"
+  DEV_OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:8030/otel"
+  CLICKHOUSE_USER: "default"
+  DOCKER_REGISTRY_URL: "docker.io"
+  LOGGING_DRIVER: "local"
+  LOGGING_MAX_SIZE: "20m"
+  LOGGING_MAX_FILES: "5"
+  LOGGING_COMPRESS: "true"
+  RESTART_POLICY: "unless-stopped"

--- a/hosting/kubernetes/core-deployment.yaml
+++ b/hosting/kubernetes/core-deployment.yaml
@@ -1,0 +1,221 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: core-app
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: app
+    spec:
+      containers:
+      - name: core-app
+        image: redplanethq/core:0.1.24
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: NODE_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: NODE_ENV
+        - name: DATABASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: DATABASE_URL
+        - name: DIRECT_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: DIRECT_URL
+        - name: SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: SESSION_SECRET
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: ENCRYPTION_KEY
+        - name: MAGIC_LINK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: MAGIC_LINK_SECRET
+        - name: CORE_LOGIN_ORIGIN
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: CORE_LOGIN_ORIGIN
+        - name: CORE_APP_ORIGIN
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: CORE_APP_ORIGIN
+        - name: REDIS_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: REDIS_HOST
+        - name: REDIS_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: REDIS_PORT
+        - name: REDIS_TLS_DISABLED
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: REDIS_TLS_DISABLED
+        - name: NEO4J_URI
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: NEO4J_URI
+        - name: NEO4J_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: NEO4J_USERNAME
+        - name: NEO4J_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: NEO4J_PASSWORD
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: OPENAI_API_KEY
+          optional: true
+        - name: AUTH_GOOGLE_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: AUTH_GOOGLE_CLIENT_ID
+          optional: true
+        - name: AUTH_GOOGLE_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: AUTH_GOOGLE_CLIENT_SECRET
+          optional: true
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: ANTHROPIC_API_KEY
+          optional: true
+        - name: ENABLE_EMAIL_LOGIN
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: ENABLE_EMAIL_LOGIN
+        - name: EMBEDDING_MODEL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: EMBEDDING_MODEL
+        - name: MODEL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: MODEL
+        - name: TRIGGER_PROJECT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: TRIGGER_PROJECT_ID
+        - name: TRIGGER_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: TRIGGER_SECRET_KEY
+        - name: TRIGGER_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: API_ORIGIN
+        - name: EMAIL_TRANSPORT
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: EMAIL_TRANSPORT
+          optional: true
+        - name: REPLY_TO_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: REPLY_TO_EMAIL
+          optional: true
+        - name: FROM_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: FROM_EMAIL
+          optional: true
+        - name: RESEND_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: RESEND_API_KEY
+          optional: true
+        - name: COHERE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: COHERE_API_KEY
+          optional: true
+        - name: OLLAMA_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: OLLAMA_URL
+          optional: true
+        - name: TRIGGER_TASKS_IMAGE
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: TRIGGER_TASKS_IMAGE
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "1000m"
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      initContainers:
+      - name: wait-for-postgres
+        image: postgres:15
+        command: ['sh', '-c', 'until pg_isready -h postgres -p 5432; do echo waiting for postgres; sleep 2; done;']
+      - name: wait-for-redis
+        image: redis:7
+        command: ['sh', '-c', 'until redis-cli -h redis -p 6379 ping; do echo waiting for redis; sleep 2; done;']
+      - name: wait-for-neo4j
+        image: neo4j:5
+        command: ['sh', '-c', 'until cypher-shell -a bolt://neo4j:7687 -u neo4j -p 27192e6432564f4788d55c15131bd5ac "RETURN 1"; do echo waiting for neo4j; sleep 2; done;']

--- a/hosting/kubernetes/ingress.yaml
+++ b/hosting/kubernetes/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: core-ingress
+  namespace: RedPlanetHQcore
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    cert-manager.io/cluster-issuer: "letsencrypt-prod" # Uncomment if using cert-manager
+spec:
+  tls:
+  - hosts:
+    - core.example.com
+    - trigger.example.com
+    secretName: core-tls # Uncomment if using TLS
+  rules:
+  - host: core.example.com
+    http:
+      paths:
+      - path: /?(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: core-app
+            port:
+              number: 3033
+  - host: trigger.example.com
+    http:
+      paths:
+      - path: /?(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: trigger-webapp
+            port:
+              number: 8030

--- a/hosting/kubernetes/kustomization.yaml
+++ b/hosting/kubernetes/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: RedPlanetHQcore
+
+resources:
+# Configuration
+- configmap.yaml
+- secrets.yaml
+- clickhouse-configmap.yaml
+
+# Storage
+- persistent-volume-claims.yaml
+
+# Databases (StatefulSets)
+- postgres-statefulset.yaml
+- neo4j-statefulset.yaml
+- clickhouse-statefulset.yaml
+
+# Supporting services
+- redis-deployment.yaml
+
+# Services
+- services.yaml
+
+# Trigger.dev components
+- trigger-init-deployment.yaml
+- trigger-electric-deployment.yaml
+- trigger-webapp-deployment.yaml
+- trigger-supervisor-deployment.yaml
+
+# CORE application
+- core-deployment.yaml
+
+# Ingress
+- ingress.yaml
+
+commonLabels:
+  app.kubernetes.io/name: core
+  app.kubernetes.io/version: "0.1.24"
+
+patchesStrategicMerge:
+# Add any patches here if needed
+
+# Example for customizing values without modifying the original files:
+# patches:
+# - patch: |-
+#     - op: replace
+#       path: /spec/replicas
+#       value: 3
+#   target:
+#     kind: Deployment
+#     name: core-app

--- a/hosting/kubernetes/neo4j-statefulset.yaml
+++ b/hosting/kubernetes/neo4j-statefulset.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: neo4j
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: neo4j
+spec:
+  serviceName: neo4j
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: neo4j
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: neo4j
+    spec:
+      containers:
+      - name: neo4j
+        image: neo4j:5
+        ports:
+        - containerPort: 7474
+          name: http
+        - containerPort: 7687
+          name: bolt
+        env:
+        - name: NEO4J_AUTH
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: NEO4J_AUTH
+        - name: NEO4J_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: NEO4J_USERNAME
+        - name: NEO4J_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: NEO4J_PASSWORD
+        - name: NEO4J_dbms_security_procedures_unrestricted
+          value: "gds.*,apoc.*"
+        - name: NEO4J_dbms_security_procedures_allowlist
+          value: "gds.*,apoc.*"
+        - name: NEO4J_apoc_export_file_enabled
+          value: "true"
+        - name: NEO4J_apoc_import_file_enabled
+          value: "true"
+        - name: NEO4J_apoc_import_file_use_neo4j_config
+          value: "true"
+        - name: NEO4J_server_memory_heap_initial__size
+          value: "2G"
+        - name: NEO4J_server_memory_heap_max__size
+          value: "4G"
+        volumeMounts:
+        - name: neo4j-storage
+          mountPath: /data
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "500m"
+          limits:
+            memory: "4Gi"
+            cpu: "1000m"
+        livenessProbe:
+          exec:
+            command:
+            - cypher-shell
+            - -u
+            - $(NEO4J_USERNAME)
+            - -p
+            - $(NEO4J_PASSWORD)
+            - "RETURN 1"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cypher-shell
+            - -u
+            - $(NEO4J_USERNAME)
+            - -p
+            - $(NEO4J_PASSWORD)
+            - "RETURN 1"
+          initialDelaySeconds: 10
+          periodSeconds: 5
+  volumeClaimTemplates:
+  - metadata:
+      name: neo4j-storage
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      # storageClassName: standard # Uncomment if you need to specify a storage class
+      resources:
+        requests:
+          storage: 30Gi

--- a/hosting/kubernetes/persistent-volume-claims.yaml
+++ b/hosting/kubernetes/persistent-volume-claims.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: standard # Adjust based on your cluster
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: neo4j-pvc
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: neo4j
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
+  storageClassName: standard # Adjust based on your cluster
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clickhouse-pvc
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: clickhouse
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: standard # Adjust based on your cluster

--- a/hosting/kubernetes/postgres-statefulset.yaml
+++ b/hosting/kubernetes/postgres-statefulset.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: tegonhq/tegon-postgres:0.1.0-alpha
+        ports:
+        - containerPort: 5432
+          name: postgres
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: POSTGRES_PASSWORD
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: POSTGRES_DB
+        volumeMounts:
+        - name: postgres-storage
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+          initialDelaySeconds: 5
+          periodSeconds: 5
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-storage
+    spec:
+    accessModes: ["ReadWriteOnce"]
+    # storageClassName: standard # Uncomment if you need to specify a storage class
+    resources:
+      requests:
+        storage: 20Gi

--- a/hosting/kubernetes/redis-deployment.yaml
+++ b/hosting/kubernetes/redis-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7
+        ports:
+        - containerPort: 6379
+          name: redis
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "250m"
+        livenessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/hosting/kubernetes/secrets.yaml
+++ b/hosting/kubernetes/secrets.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: core-secrets
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: secrets
+type: Opaque
+data:
+  # Base64 encoded values
+  SESSION_SECRET: MjgxODE0MzY0NjUxNmY2ZmZmZDcwN2IzNmYzMzRiYmI= # 2818143646516f6fffd707b36f334bbb
+  ENCRYPTION_KEY: ZjY4NjE0N2FiOTY3OTQzZWJiZTllZDNkNDk2ZTQ2NWE= # f686147ab967943ebbe9ed3b496e465a
+  MAGIC_LINK_SECRET: MjcxOTJlNjQzMjU2NGY0Nzg4ZDU1YzE1MTMxYmQ1YWM= # 27192e6432564f4788d55c15131bd5ac
+  NEO4J_PASSWORD: MjcxOTJlNjQzMjU2NGY0Nzg4ZDU1YzE1MTMxYmQ1YWM= # 27192e6432564f4788d55c15131bd5ac
+  NEO4J_AUTH: bmVvNGovMjcxOTJlNjQzMjU2NGY0Nzg4ZDU1YzE1MTMxYmQ1YWM= # neo4j/27192e6432564f4788d55c15131bd5ac
+  CLICKHOUSE_PASSWORD: cGFzc3dvcmQ= # password
+  CLICKHOUSE_URL: aHR0cDovL2RlZmF1bHQ6cGFzc3dvcmRAY2xpY2tob3VzZTo4MTIzP3NlY3VyZT1mYWxzZQ== # http://default:password@clickhouse:8123?secure=false
+  RUN_REPLICATION_CLICKHOUSE_URL: aHR0cDovL2RlZmF1bHQ6cGFzc3dvcmRAY2xpY2tob3VzZTo4MTIz # http://default:password@clickhouse:8123
+  MANAGED_WORKER_SECRET: NDQ3YzI5Njc4ZjllYWYyODllOWM0YjcwMDMzZDhkYTdm # 447c29678f9eaf289e9c4b70d3dd8a7f
+  TRIGGER_SECRET_KEY: dHJfcHJvZF83Mml6aUNZMnlXQTVTR2d4UkZpaTA0OUNsd0c3YXF3Zzc3Vk1Qd3U3SVY= # tr_prod_72iziCY2yWA5SdGxRFii
+  TRIGGER_WORKER_TOKEN: dHJfd2d0X2p0UnVqa1VuZjNRM21OdFVldjA0OUNsd0c3YXF3Zzc3Vk1Qd3U3SVY= # tr_wgt_jtRujkUnfK3RmNtUev049Clw7gaqwg77VMPGu7Iv
+  
+  # API Keys - replace with your actual keys (base64 encoded)
+  # OPENAI_API_KEY: <base64-encoded-openai-key>
+  # AUTH_GOOGLE_CLIENT_ID: <base64-encoded-google-client-id>
+  # AUTH_GOOGLE_CLIENT_SECRET: <base64-encoded-google-client-secret>
+  # ANTHROPIC_API_KEY: <base64-encoded-anthropic-key>
+  # RESEND_API_KEY: <base64-encoded-resend-key>
+  # COHERE_API_KEY: <base64-encoded-cohere-key>
+  # AWS_ACCESS_KEY_ID: <base64-encoded-aws-access-key>
+  # AWS_SECRET_ACCESS_KEY: <base64-encoded-aws-secret-key>
+  
+  # Email configuration
+  EMAIL_TRANSPORT: <base64-encoded-email-transport> # e.g., "resend"
+  REPLY_TO_EMAIL: <base64-encoded-reply-email>
+  FROM_EMAIL: <base64-encoded-from-email>
+  
+  # Docker registry (if using private registry)
+  DOCKER_REGISTRY_USERNAME: <base64-encoded-registry-username>
+  DOCKER_REGISTRY_PASSWORD: <base64-encoded-registry-password>
+  
+  # Object storage (if using MinIO or S3)
+  OBJECT_STORE_ACCESS_KEY_ID: <base64-encoded-access-key>
+  OBJECT_STORE_SECRET_ACCESS_KEY: <base64-encoded-secret-key>

--- a/hosting/kubernetes/services.yaml
+++ b/hosting/kubernetes/services.yaml
@@ -1,0 +1,162 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: postgres
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+    name: postgres
+  clusterIP: None
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: redis
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: redis
+  ports:
+  - port: 6379
+    targetPort: 6379
+    name: redis
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: neo4j
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: neo4j
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: neo4j
+  ports:
+  - port: 7474
+    targetPort: 7474
+    name: http
+  - port: 7687
+    targetPort: 7687
+    name: bolt
+  clusterIP: None
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: clickhouse
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: clickhouse
+  ports:
+  - port: 8123
+    targetPort: 8123
+    name: http
+  - port: 9000
+    targetPort: 9000
+    name: native
+  clusterIP: None
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-app
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: app
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: app
+  ports:
+  - port: 3033
+    targetPort: 3000
+    name: http
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: trigger-webapp
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-webapp
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-webapp
+  ports:
+  - port: 8030
+    targetPort: 3000
+    name: http
+  type: ClusterIP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: trigger-electric
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-electric
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-electric
+  ports:
+  - port: 3000
+    targetPort: 3000
+    name: http
+  clusterIP: None
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: trigger-supervisor
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-supervisor
+spec:
+  selector:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-supervisor
+  ports:
+  - port: 8020
+    targetPort: 8020
+    name: http
+  clusterIP: None

--- a/hosting/kubernetes/trigger-electric-deployment.yaml
+++ b/hosting/kubernetes/trigger-electric-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trigger-electric
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-electric
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: trigger-electric
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: trigger-electric
+    spec:
+      containers:
+      - name: trigger-electric
+        image: electricsql/electric:1.0.10
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: ELECTRIC_DATABASE_URL
+        - name: ELECTRIC_INSECURE
+          value: "true"
+        - name: ELECTRIC_USAGE_REPORTING
+          value: "false"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "250m"
+        livenessProbe:
+          httpGet:
+            path: /v1/health
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /v1/health
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 5

--- a/hosting/kubernetes/trigger-init-deployment.yaml
+++ b/hosting/kubernetes/trigger-init-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: trigger-init
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-init
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: trigger-init
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: trigger-init
+        image: redplanethq/init:0.1.24
+        env:
+        - name: VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: VERSION
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: DB_HOST
+        - name: DB_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: DB_PORT
+        - name: TRIGGER_DB
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: TRIGGER_DB
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: POSTGRES_PASSWORD
+        - name: TRIGGER_TASKS_IMAGE
+          value: "redplanethq/proj_core:latest"
+        - name: NODE_ENV
+          value: "production"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "250m"

--- a/hosting/kubernetes/trigger-supervisor-deployment.yaml
+++ b/hosting/kubernetes/trigger-supervisor-deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trigger-supervisor
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-supervisor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: trigger-supervisor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: trigger-supervisor
+    spec:
+      containers:
+      - name: trigger-supervisor
+        image: ghcr.io/triggerdotdev/supervisor:v4-beta
+        env:
+        - name: TRIGGER_WORKER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: TRIGGER_WORKER_TOKEN
+        - name: MANAGED_WORKER_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: MANAGED_WORKER_SECRET
+        - name: TRIGGER_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: API_ORIGIN
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://trigger-webapp:3000/otel"
+        - name: TRIGGER_WORKLOAD_API_DOMAIN
+          value: "supervisor"
+        - name: TRIGGER_WORKLOAD_API_PORT_EXTERNAL
+          value: "8020"
+        - name: DEBUG
+          value: "1"
+        - name: ENFORCE_MACHINE_PRESETS
+          value: "1"
+        - name: TRIGGER_DEQUEUE_INTERVAL_MS
+          value: "1000"
+        - name: DOCKER_REGISTRY_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: DOCKER_REGISTRY_URL
+        - name: DOCKER_REGISTRY_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: DOCKER_REGISTRY_USERNAME
+          optional: true
+        - name: DOCKER_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: DOCKER_REGISTRY_PASSWORD
+          optional: true
+        - name: DOCKER_AUTOREMOVE_EXITED_CONTAINERS
+          value: "0"
+        command: ["/bin/sh", "-c", "chown -R node:node /home/node/shared && exec /usr/bin/dumb-init -- pnpm run --filter supervisor start"]
+        securityContext:
+          runAsUser: 0 # Run as root for bootstrap
+        volumeMounts:
+        - name: shared-storage
+          mountPath: /home/node/shared
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8020
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8020
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: shared-storage
+        emptyDir: {}

--- a/hosting/kubernetes/trigger-webapp-deployment.yaml
+++ b/hosting/kubernetes/trigger-webapp-deployment.yaml
@@ -1,0 +1,179 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trigger-webapp
+  namespace: RedPlanetHQcore
+  labels:
+    app.kubernetes.io/name: core
+    app.kubernetes.io/component: trigger-webapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: core
+      app.kubernetes.io/component: trigger-webapp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: core
+        app.kubernetes.io/component: trigger-webapp
+    spec:
+      containers:
+      - name: trigger-webapp
+        image: ghcr.io/triggerdotdev/trigger.dev@sha256:a19c438f348ac05c939f39ed455ed27b4f189f720b4c9810aef8e71fdc731211
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: APP_ORIGIN
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: APP_ORIGIN
+        - name: LOGIN_ORIGIN
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: LOGIN_ORIGIN
+        - name: API_ORIGIN
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: API_ORIGIN
+        - name: ELECTRIC_ORIGIN
+          value: "http://electric:3000"
+        - name: DATABASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: TRIGGER_DATABASE_URL
+        - name: DIRECT_URL
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: TRIGGER_DIRECT_URL
+        - name: SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: SESSION_SECRET
+        - name: MAGIC_LINK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: MAGIC_LINK_SECRET
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: ENCRYPTION_KEY
+        - name: MANAGED_WORKER_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: MANAGED_WORKER_SECRET
+        - name: REDIS_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: REDIS_HOST
+        - name: REDIS_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: REDIS_PORT
+        - name: REDIS_TLS_DISABLED
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: REDIS_TLS_DISABLED
+        - name: APP_LOG_LEVEL
+          value: "info"
+        - name: DEV_OTEL_EXPORTER_OTLP_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: DEV_OTEL_EXPORTER_OTLP_ENDPOINT
+        - name: DEPLOY_REGISTRY_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: core-config
+              key: DOCKER_REGISTRY_URL
+        - name: DEPLOY_REGISTRY_NAMESPACE
+          value: "trigger"
+        - name: OBJECT_STORE_BASE_URL
+          value: "http://minio:9000"
+        - name: OBJECT_STORE_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: OBJECT_STORE_ACCESS_KEY_ID
+          optional: true
+        - name: OBJECT_STORE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: OBJECT_STORE_SECRET_ACCESS_KEY
+          optional: true
+        - name: GRACEFUL_SHUTDOWN_TIMEOUT
+          value: "1000"
+        - name: TRIGGER_BOOTSTRAP_ENABLED
+          value: "1"
+        - name: TRIGGER_BOOTSTRAP_WORKER_GROUP_NAME
+          value: "bootstrap"
+        - name: TRIGGER_BOOTSTRAP_WORKER_TOKEN_PATH
+          value: "/home/node/shared/worker_token"
+        - name: CLICKHOUSE_URL
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: CLICKHOUSE_URL
+        - name: CLICKHOUSE_LOG_LEVEL
+          value: "info"
+        - name: RUN_REPLICATION_ENABLED
+          value: "1"
+        - name: RUN_REPLICATION_CLICKHOUSE_URL
+          valueFrom:
+            secretKeyRef:
+              name: core-secrets
+              key: RUN_REPLICATION_CLICKHOUSE_URL
+        - name: RUN_REPLICATION_LOG_LEVEL
+          value: "info"
+        - name: INTERNAL_OTEL_TRACE_LOGGING_ENABLED
+          value: "0"
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        volumeMounts:
+        - name: shared-storage
+          mountPath: /home/node/shared
+        # Only needed for bootstrap
+        command: ["/bin/sh", "-c", "chown -R node:node /home/node/shared && sleep 5 && exec ./scripts/entrypoint.sh"]
+        securityContext:
+          runAsUser: 0 # Run as root for bootstrap
+      initContainers:
+      - name: wait-for-postgres
+        image: postgres:15
+        command: ['sh', '-c', 'until pg_isready -h postgres -p 5432; do echo waiting for postgres; sleep 2; done;']
+      - name: wait-for-clickhouse
+        image: bitnami/clickhouse:latest
+        command: ['sh', '-c', 'until clickhouse-client --host clickhouse --port 9000 --user default --password password --query "SELECT 1"; do echo waiting for clickhouse; sleep 2; done;']
+      volumes:
+      - name: shared-storage
+        emptyDir: {}


### PR DESCRIPTION
Add comprehensive Kubernetes deployment support for RedPlanetHQ CORE system including:
- Complete infrastructure setup with PostgreSQL, Neo4j, ClickHouse, and Redis
- Application deployments for CORE app and Trigger.dev components
- Configuration management with ConfigMaps and Secrets
- Ingress configuration for external access
- Persistent volume claims for data storage
- Kustomize configuration for easy deployment
- Comprehensive documentation with setup instructions and troubleshooting guide