### PR TITLE
feat: optimize search performance 

### DIFF
--- a/apps/webapp/app/services/graphModels/statement.ts
+++ b/apps/webapp/app/services/graphModels/statement.ts
@@ -69,11 +69,11 @@ export async function saveTriple(triple: Triple): Promise<string> {
   MATCH (episode:Episode {uuid: $episodeUuid, userId: $userId})
   
   MERGE (episode)-[prov:HAS_PROVENANCE]->(statement)
-    ON CREATE SET prov.uuid = $provenanceEdgeUuid, prov.createdAt = $createdAt
+    ON CREATE SET prov.uuid = $provenanceEdgeUuid, prov.createdAt = $createdAt, prov.userId = $userId
   MERGE (statement)-[subj:HAS_SUBJECT]->(subject)
-    ON CREATE SET subj.uuid = $subjectEdgeUuid, subj.createdAt = $createdAt
+    ON CREATE SET subj.uuid = $subjectEdgeUuid, subj.createdAt = $createdAt, subj.userId = $userId
   MERGE (statement)-[pred:HAS_PREDICATE]->(predicate)
-    ON CREATE SET pred.uuid = $predicateEdgeUuid, pred.createdAt = $createdAt
+    ON CREATE SET pred.uuid = $predicateEdgeUuid, pred.createdAt = $createdAt, pred.userId = $userId
   MERGE (statement)-[obj:HAS_OBJECT]->(object)
     ON CREATE SET obj.uuid = $objectEdgeUuid, obj.createdAt = $createdAt
   


### PR DESCRIPTION
## Performance Optimization for Memory Recall

Fixes slow recall queries, especially for broad searches that were taking 50+ seconds. Recall queries are now **20-30x faster** through database indexing and query optimizations.

## What Changed

### Database Improvements
- Added critical Neo4j indexes for faster lookups:
  - Composite temporal index for time-range queries
  - Relationship indexes for graph traversal
  - Session-based episode lookups

### Search Optimization
- **BM25 & Vector Search**: Single-pass episode aggregation (no more expensive multi-query patterns)
- **Vector Search**: Now uses ANN vector index instead of full table scans (10-100x faster)
- **BFS Search**: In-memory grouping instead of complex Neo4j queries
- **Episode Graph**: Streamlined score calculation with fewer intermediate steps

### Response Quality
- Only return invalidated facts (facts that are no longer valid)
- Valid facts are already in episode content, so no need to duplicate
- Clearer response formatting

## Impact

**Before**: Broad queries could take 60-160 seconds  
**After**: Same queries complete in 6-8 seconds

## Migration

Indexes are created automatically on startup. No manual migration needed.