### PR TITLE
Add --scope user to Claude CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ No context loss, no re-explaining projects, no forgotten decisions.
 1. Run this command in your terminal to connect CORE with Claude Code:
 
 ```sh
-claude mcp add --transport http core-memory https://core.heysol.ai/api/v1/mcp?source=Claude-Code
+claude mcp add --transport http --scope user core-memory https://core.heysol.ai/api/v1/mcp?source=Claude-Code
 ```
 
 2. Type `/mcp` and open core-memory MCP for authentication

--- a/apps/webapp/app/components/onboarding/provider-config.tsx
+++ b/apps/webapp/app/components/onboarding/provider-config.tsx
@@ -60,7 +60,7 @@ export const PROVIDER_CONFIGS: Record<Provider, ProviderConfig> = {
             <div className="space-y-2">
               <div>Run in terminal:</div>
               <code className="text-sm">
-                claude mcp add --transport http core-memory
+                claude mcp add --transport http --scope user core-memory
                 https://core.heysol.ai/api/v1/mcp?source=Claude-Code
               </code>
             </div>

--- a/docs/providers/claude-code.mdx
+++ b/docs/providers/claude-code.mdx
@@ -13,7 +13,7 @@ description: "Connect your Claude Code CLI to CORE's memory system"
 Run this command in your terminal to connect CORE with Claude Code:
 
 ```bash
-claude mcp add --transport http core-memory https://core.heysol.ai/api/v1/mcp?source=Claude-Code
+claude mcp add --transport http --scope user core-memory https://core.heysol.ai/api/v1/mcp?source=Claude-Code
 ```
 
 What this does: This command registers CORE's MCP server with Claude Code, establishing the connection endpoint for memory operations.


### PR DESCRIPTION
### Summary
By default, `claude mcp add` uses `local` scope, which only works in the current project. Adding `--scope user` makes CORE memory available across all projects on your machine.

### Reference
https://code.claude.com/docs/en/mcp
