### PR TITLE
docs: migrate documentation from Spaces to Labels

### DIFF
--- a/docs/concepts/labels.mdx
+++ b/docs/concepts/labels.mdx
@@ -1,0 +1,157 @@
+---
+title: "Labels"
+description: "Organize your memory with workspace-scoped labels"
+---
+
+## Overview
+
+Labels are CORE's flexible tagging system for organizing episodes, sessions, and documents within your workspace. Think of them as project tags or categories that help you filter and find related memories quickly.
+
+Unlike traditional hierarchical folders, labels use a flat, Linear-style organization that lets you apply multiple tags to any piece of content, making it easy to organize information across different contexts and projects.
+
+## What Are Labels?
+
+Labels are workspace-unique tags that you can assign to:
+- **Episodes**: Individual conversations and interactions
+- **Sessions**: Related groups of conversations
+- **Documents**: Files and content you've ingested
+
+Each label has:
+- **Name**: A unique identifier within your workspace (max 100 characters)
+- **Description**: Optional details about what the label represents
+- **Color**: Visual identifier for quick recognition
+- **Workspace Scope**: Labels are unique per workspace, not global
+
+## Key Characteristics
+
+### Workspace-Scoped
+Labels are scoped to your workspace, meaning:
+- Each workspace has its own set of labels
+- Label names must be unique within a workspace
+- Different workspaces can have labels with the same name
+- You can't share labels across workspaces
+
+### Multiple Labels per Item
+You can assign multiple labels to any episode:
+- Episodes have a `labelIds` array field
+- No limit on the number of labels per episode
+- Filter searches by one or multiple labels
+- Labels don't nest or form hierarchies
+
+## How Episodes Use Labels
+
+When you ingest content or have conversations, episodes can be tagged with labels:
+
+```typescript
+{
+  id: "episode-uuid",
+  content: "Conversation about authentication...",
+  labelIds: ["label-uuid-1", "label-uuid-2"],
+  isFavorite: false,
+  folders: [] // User.folders for personal organization
+}
+```
+
+## Creating and Managing Labels
+
+### Via Web Interface
+1. Navigate to **Settings → Labels**
+2. Click **"Create Label"**
+3. Enter name, optional description, and choose a color
+4. Labels appear in your workspace immediately
+
+### Via API
+List all labels in your workspace:
+
+```bash
+GET /api/v1/labels
+```
+
+See the [API Reference](/api-reference) for details.
+
+
+## Using Labels in Search
+
+Labels provide powerful filtering capabilities across all search methods:
+
+### Basic Search with Labels
+```typescript
+memory_search({
+  query: "API design decisions",
+  labelIds: ["project-taskmaster-uuid"]
+})
+```
+
+### Multiple Label Filtering
+Search across multiple labels to find related content:
+```typescript
+memory_search({
+  query: "security vulnerabilities",
+  labelIds: ["label-auth-uuid", "label-api-uuid"]
+})
+```
+
+### Recent Work by Label
+Combine labels with time filters:
+```typescript
+memory_search({
+  query: "recent progress",
+  labelIds: ["label-project-uuid"],
+  startTime: "2025-01-01T00:00:00Z",
+  sortBy: "recency"
+})
+```
+
+## Label-Based Search Architecture
+
+When you filter by labels, CORE's search system:
+
+1. **BM25 Search**: Filters episodes by `labelIds` before scoring
+2. **Vector Search**: Applies label filter to episode embeddings
+3. **Episode Graph Search**: Constrains graph traversal to labeled episodes
+4. **BFS Search**: Limits entity exploration to episodes with matching labels
+
+This ensures that label filtering is efficient and works consistently across all search methods.
+
+## API Endpoints for Label Management
+
+| **Endpoint**                | **Method** | **Description**                    |
+| --------------------------- | ---------- | ---------------------------------- |
+| `/api/v1/labels`            | GET        | List all labels in workspace       |
+
+Additional label management operations (create, update, delete) are available through the web interface.
+
+## MCP Integration with Labels
+
+CORE's MCP server exposes memory tools that support label filtering:
+
+### Available Tools
+- `memory_search`: Search with optional `labelIds` array
+- `memory_ingest`: Store conversations with `labelIds`
+- `memory_get_labels`: List all workspace labels
+- `memory_get_document`: Retrieve specific documents
+
+## Best Practices
+
+### Label Naming
+- Use clear, descriptive names (e.g., "TaskMaster Project", "Authentication")
+- Keep names concise but meaningful
+- Use consistent naming conventions across your workspace
+
+### Label Organization
+- Create labels for projects, topics, or contexts
+- Don't over-label - use 2-4 labels per episode typically
+- Use favorites for truly important items rather than creating "Important" labels
+
+## Examples
+
+### Organizing a Multi-Project Workspace
+```
+Labels:
+- "Project: TaskMaster" (color: blue)
+- "Project: CORE Features" (color: green)
+- "Client: Acme Corp" (color: purple)
+- "Topic: Authentication" (color: red)
+- "Topic: Performance" (color: orange)
+```
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,7 +26,7 @@
               "concepts/memory_graph",
               "concepts/entity_types",
               "concepts/chat",
-              "concepts/spaces"
+              "concepts/labels"
             ]
           },
           {
@@ -156,14 +156,9 @@
             ]
           },
           {
-            "group": "Spaces",
+            "group": "Labels",
             "pages": [
-              "GET /api/v1/spaces",
-              "POST /api/v1/spaces",
-              "PUT /api/v1/spaces",
-              "GET /api/v1/spaces/{spaceId}",
-              "PUT /api/v1/spaces/{spaceId}",
-              "DELETE /api/v1/spaces/{spaceId}"
+              "GET /api/v1/labels"
             ]
           },
           {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "CORE API",
     "version": "1.0.0",
-    "description": "CORE is a memory sharing platform for LLMs with graph-based storage, temporal facts, and comprehensive search capabilities.\n\n## Authentication\n\nCORE supports multiple authentication methods:\n- **Bearer Token**: Personal API tokens or OAuth2 access tokens\n- **OAuth2**: Full OAuth2 authorization code flow with PKCE support\n- **Session Cookies**: For web interface access\n\nMost API endpoints support Bearer token authentication via the Authorization header:\n```\nAuthorization: Bearer YOUR_TOKEN_HERE\n```\n\n## Features\n\n- **Temporal Knowledge Graph**: Store and query facts with temporal validity\n- **Spaces**: Organize knowledge into logical spaces/projects\n- **Search**: Advanced semantic search with graph traversal\n- **Ingestion**: Process and extract facts from various data sources  \n- **Integrations**: Connect with external platforms via OAuth2\n- **MCP Support**: Model Context Protocol for AI assistant integration\n- **Webhooks**: Real-time notifications for data changes\n",
+    "description": "CORE is a memory sharing platform for LLMs with graph-based storage, temporal facts, and comprehensive search capabilities.\n\n## Authentication\n\nCORE supports multiple authentication methods:\n- **Bearer Token**: Personal API tokens or OAuth2 access tokens\n- **OAuth2**: Full OAuth2 authorization code flow with PKCE support\n- **Session Cookies**: For web interface access\n\nMost API endpoints support Bearer token authentication via the Authorization header:\n```\nAuthorization: Bearer YOUR_TOKEN_HERE\n```\n\n## Features\n\n- **Temporal Knowledge Graph**: Store and query facts with temporal validity\n- **Labels**: Organize knowledge with workspace-scoped tags\n- **Search**: Advanced semantic search with graph traversal\n- **Ingestion**: Process and extract facts from various data sources  \n- **Integrations**: Connect with external platforms via OAuth2\n- **MCP Support**: Model Context Protocol for AI assistant integration\n- **Webhooks**: Real-time notifications for data changes\n",
     "contact": {
       "name": "Core",
       "url": "https://github.com/redplanethq/core"
@@ -179,13 +179,13 @@
             "format": "date-time",
             "description": "Filter facts before this timestamp"
           },
-          "spaceIds": {
+          "labelIds": {
             "type": "array",
             "items": {
               "type": "string"
             },
             "default": [ ],
-            "description": "Filter results to specific spaces"
+            "description": "Filter results to specific labels"
           },
           "limit": {
             "type": "integer",
@@ -325,9 +325,12 @@
             "type": "string",
             "description": "Source identifier"
           },
-          "spaceId": {
-            "type": "string",
-            "description": "Space to assign the content to"
+          "labelIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Labels to assign the content to"
           },
           "sessionId": {
             "type": "string",
@@ -365,93 +368,38 @@
           }
         }
       },
-      "Space": {
+      "Label": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique label identifier"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Label name (unique within workspace)"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Optional label description"
+          },
+          "color": {
+            "type": "string",
+            "description": "Label color (hex format)"
+          },
+          "workspaceId": {
+            "type": "string",
+            "description": "Workspace this label belongs to"
           },
           "createdAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Label creation timestamp"
           },
           "updatedAt": {
             "type": "string",
-            "format": "date-time"
-          },
-          "userId": {
-            "type": "string"
-          }
-        }
-      },
-      "CreateSpaceRequest": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Space name"
-          },
-          "description": {
-            "type": "string",
-            "description": "Space description"
-          }
-        }
-      },
-      "UpdateSpaceRequest": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Updated space name"
-          },
-          "description": {
-            "type": "string",
-            "description": "Updated space description"
-          }
-        }
-      },
-      "BulkSpaceOperation": {
-        "type": "object",
-        "required": [
-          "intent"
-        ],
-        "properties": {
-          "intent": {
-            "type": "string",
-            "enum": [
-              "assign_statements",
-              "remove_statements",
-              "bulk_assign",
-              "initialize_space_ids"
-            ],
-            "description": "Type of bulk operation"
-          },
-          "spaceId": {
-            "type": "string",
-            "description": "Target space ID (required for some operations)"
-          },
-          "statementIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Statement IDs to operate on"
-          },
-          "spaceIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Space IDs for bulk operations"
+            "format": "date-time",
+            "description": "Label last update timestamp"
           }
         }
       },
@@ -1218,175 +1166,28 @@
         }
       }
     },
-    "/api/v1/spaces": {
+    "/api/v1/labels": {
       "get": {
-        "summary": "List/Search Spaces",
-        "description": "Get list of spaces with optional search filtering",
+        "summary": "List Labels",
+        "description": "Get list of all labels in the authenticated user's workspace",
         "security": [
           {
             "bearerAuth": [ ]
           }
         ],
-        "parameters": [
-          {
-            "name": "q",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "description": "Search query for space names"
-          }
-        ],
         "responses": {
           "200": {
-            "description": "List of spaces",
+            "description": "List of workspace labels",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Space"
+                    "$ref": "#/components/schemas/Label"
                   }
                 }
               }
             }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create New Space",
-        "description": "Create a new space for organizing knowledge",
-        "security": [
-          {
-            "bearerAuth": [ ]
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateSpaceRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Space created successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Space"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Bulk Space Operations",
-        "description": "Perform bulk operations on spaces including:\n- assign_statements: Assign statements to a space\n- remove_statements: Remove statements from a space  \n- bulk_assign: Bulk assign multiple statements\n- initialize_space_ids: Initialize space IDs for statements\n",
-        "security": [
-          {
-            "bearerAuth": [ ]
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkSpaceOperation"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Bulk operation completed"
-          }
-        }
-      }
-    },
-    "/api/v1/spaces/{spaceId}": {
-      "parameters": [
-        {
-          "name": "spaceId",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "type": "string"
-          },
-          "description": "Space identifier"
-        }
-      ],
-      "get": {
-        "summary": "Get Space Details",
-        "description": "Retrieve detailed information about a specific space",
-        "security": [
-          {
-            "bearerAuth": [ ]
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Space details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Space"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Space not found"
-          }
-        }
-      },
-      "put": {
-        "summary": "Update Space",
-        "description": "Update space name and/or description",
-        "security": [
-          {
-            "bearerAuth": [ ]
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateSpaceRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Space updated successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Space"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Space",
-        "description": "Delete a space and optionally reassign its content",
-        "security": [
-          {
-            "bearerAuth": [ ]
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Space deleted successfully"
           }
         }
       }

--- a/docs/opensource/changelog.mdx
+++ b/docs/opensource/changelog.mdx
@@ -47,11 +47,14 @@ description: "Product updates and announcements"
 
 ## 🔧 Improvements
 
-- **Spaces**:
+- **Labels** (Migration from Spaces):
 
-  - Option to remove episodes from spaces for better organization
-  - Removed restrictive space description requirements
-  - Queue-based space assignment for improved reliability
+  - Complete migration from Spaces to Labels organizational model
+  - Workspace-scoped labels with Linear-style tagging
+  - Labels stored in PostgreSQL, scoped by workspace
+  - Episodes now use `labelIds` array instead of `spaceIds`
+  - Multiple labels can be assigned to any episode
+  - Simplified label management via web interface and API
 
 - **MCP Tooling**:
   - Clear error messages when credits run low
@@ -67,7 +70,7 @@ description: "Product updates and announcements"
 - Fixed graph visualization issues in Chrome 140
 - Corrected ingestion queue handling for deleted episodes
 - Fixed MCP tool call failures for (`get_user_profile`)
-- Resolved space description validation blocking space creation
+- Resolved label description validation blocking label creation
 
 ## 🔒 Security & Privacy
 
@@ -76,7 +79,7 @@ description: "Product updates and announcements"
 - **Complete Account Wipe**: Account deletion now removes all traces from both relational and graph databases
 - **Cascade Delete Logic**: Simplified deletion flows with proper relationship cleanup for users and workspaces
 - **Neo4j Graph Cleanup**: Automated cleanup of knowledge graph nodes when deleting accounts
-- **Proper Resource Cleanup**: Removes all associated API keys, spaces, and episodes
+- **Proper Resource Cleanup**: Removes all associated API keys, labels, and episodes
 
 </Update>
 
@@ -86,11 +89,11 @@ description: "Product updates and announcements"
 
 **Capabilities users can now access**
 
-**Spaces**
+**Organization** (Note: This feature evolved into Labels in later releases)
 
 - Organize your memory into project-specific contexts (Health, Personal, Work, Client Projects)
-- Share memory spaces with team members for collaborative AI assistance
-- Default user profile space with seamless node linking across contexts
+- Share memory contexts with team members for collaborative AI assistance
+- Default user profile context with seamless node linking across projects
 
 **Enhanced Logging & Monitoring**
 
@@ -119,7 +122,7 @@ description: "Product updates and announcements"
 **Enhanced existing functionality**
 
 - **Enhanced MCP OAuth Scopes**: Better integration support for Windsurf and other coding tools
-- **Refined Facts Page UI**: Improved space-specific fact browsing and search
+- **Refined Facts Page UI**: Improved label-specific fact browsing and search
 - **Optimized Memory Tools**: Better source tracking and metadata preservation
 - **Unified MCP Server**: Single server instance handling all integrations for improved performance
 
@@ -130,7 +133,7 @@ description: "Product updates and announcements"
 - Fixed MCP server stream failures that interrupted AI client connections
 - Resolved OAuth scope issues affecting Windsurf integration
 - Corrected source attribution problems in memory tools
-- Fixed facts page access issues for space-specific content
+- Fixed facts page access issues for label-specific content
 - Resolved database dependency conflicts in trigger service deployment
 
 ## 🔒 Security & Privacy

--- a/docs/providers/browser-extension.mdx
+++ b/docs/providers/browser-extension.mdx
@@ -39,8 +39,8 @@ The CORE extension currently works with **ChatGPT** and **Gemini** (more integra
 1. **Auto Sync**
    Toggle this on and CORE automatically saves your conversations to memory. Every brainstorming session, solution, or insight gets captured for future recall across all your tools.
 
-2. **Add Space Context**
-   Inject pre-built project summaries directly into your prompt. Create spaces in CORE for different projects or topics (e.g., "CORE Features," "Marketing Strategy"), then instantly add that full context to any conversation without retyping.
+2. **Add Label Context**
+   Inject pre-built project summaries directly into your prompt. Organize memories with labels in CORE for different projects or topics (e.g., "CORE Features," "Marketing Strategy"), then instantly add that full context to any conversation without retyping.
 
 3. **Improve Prompt**
    Powered by CORE's Deep Search, this analyzes your prompt, searches your entire memory, and automatically enriches it with relevant context—making AI responses smarter and more personalized.

--- a/docs/providers/cline.mdx
+++ b/docs/providers/cline.mdx
@@ -155,7 +155,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -205,7 +205,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```

--- a/docs/providers/codex.mdx
+++ b/docs/providers/codex.mdx
@@ -174,7 +174,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -224,7 +224,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```

--- a/docs/providers/cursor.mdx
+++ b/docs/providers/cursor.mdx
@@ -129,7 +129,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -174,7 +174,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```

--- a/docs/providers/kilo-code.mdx
+++ b/docs/providers/kilo-code.mdx
@@ -141,7 +141,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -191,7 +191,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```

--- a/docs/providers/roo-code.mdx
+++ b/docs/providers/roo-code.mdx
@@ -145,7 +145,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -195,7 +195,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```

--- a/docs/providers/vscode.mdx
+++ b/docs/providers/vscode.mdx
@@ -136,7 +136,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -186,7 +186,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```

--- a/docs/providers/windsurf.mdx
+++ b/docs/providers/windsurf.mdx
@@ -175,7 +175,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -225,7 +225,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```

--- a/docs/providers/zed.mdx
+++ b/docs/providers/zed.mdx
@@ -145,7 +145,7 @@ EXECUTE THIS TOOL FIRST:
 
 EXECUTE THIS TOOL LAST:
 `memory_ingest`
-Include the spaceId parameter using the ID from your initial memory_get_space call.
+Optionally include labelIds array to organize the conversation with workspace labels.
 
 ⚠️ **THIS IS NON-NEGOTIABLE** - You must ALWAYS store conversation context as your final action.
 
@@ -195,7 +195,7 @@ From Assistant:
 
 1. **FIRST ACTION**: Execute `memory_search` with semantic query about the user's request
 2. **RESPOND**: Help the user with their request
-3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and spaceId
+3. **FINAL ACTION**: Execute `memory_ingest` with conversation summary and optional labelIds
 
 **If you skip any of these steps, you are not following the project requirements.**
 ```


### PR DESCRIPTION
Complete documentation update reflecting the migration from Spaces to Labels organizational model:

- Created comprehensive Labels documentation (docs/concepts/labels.mdx)
  - Explains workspace-scoped labeling system
  - Documents data model and architecture changes
  - Includes API endpoints and MCP integration details
  - Provides best practices and examples

- Updated navigation (docs.json)
  - Changed Memory section: concepts/spaces → concepts/labels
  - Updated API Reference: Spaces → Labels group

- Updated OpenAPI specification (openapi.json)
  - Changed spaceIds → labelIds throughout
  - Replaced Space schema with Label schema
  - Updated all endpoints to reflect label-based API

- Updated all provider documentation
  - Changed spaceId references to labelIds in 9 provider files
  - Updated MCP tool usage instructions

- Updated browser extension docs
  - Changed "Add Space Context" to "Add Label Context"

- Updated changelog
  - Added migration notes in October 2025 release
  - Updated historical references for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)