### PR TITLE
fix: prevent TypeError when documents is undefined in label page

### DIFF
--- a/apps/webapp/app/routes/home.labels.$labelId.tsx
+++ b/apps/webapp/app/routes/home.labels.$labelId.tsx
@@ -60,7 +60,7 @@ export default function LogsAll() {
         setOnboarding(true);
       }
     }
-  }, [documents.length, isLoading]);
+  }, [documents?.length, isLoading]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Added optional chaining to `documents.length` in useEffect dependency array
- Prevents 'Cannot read properties of undefined' error when clicking labels

## Problem
When clicking a label in the sidebar, a TypeError occurs because `documents` can be `undefined` before the `useDocuments` hook finishes loading.

## Solution
Changed `documents.length` to `documents?.length` in the useEffect dependency array (line 63).

## Testing
- Verified the fix prevents the TypeError on label click

Fixes #240