### PR TITLE
fix: exploratory search returns empty when no labels match

### DIFF
--- a/apps/webapp/app/services/search-v2/handlers.ts
+++ b/apps/webapp/app/services/search-v2/handlers.ts
@@ -396,10 +396,8 @@ export async function handleExploratory(
     `[Handler:exploratory] Labels: [${labelIds.join(", ")}], MaxEpisodes: ${maxEpisodes}`
   );
 
-  // If no labels matched, return empty (exploratory requires label context)
   if (labelIds.length === 0) {
-    logger.info("[Handler:exploratory] No labels matched, returning empty");
-    return [];
+    logger.info("[Handler:exploratory] No labels matched, falling back to recent episodes");
   }
 
   // Get episodes filtered by labels using graph provider method

--- a/packages/providers/src/graph/neo4j/domains/searchV2.ts
+++ b/packages/providers/src/graph/neo4j/domains/searchV2.ts
@@ -225,9 +225,9 @@ export function createSearchV2Methods(core: Neo4jCore) {
 
       const query = `
                 MATCH (e:Episode {userId: $userId${wsFilter}})
-                WHERE ANY(lid IN e.labelIds WHERE lid IN $labelIds)
-                AND e.content IS NOT NULL
+                WHERE e.content IS NOT NULL
                 AND e.content <> ""
+                ${params.labelIds.length > 0 ? "AND ANY(lid IN e.labelIds WHERE lid IN $labelIds)" : ""}
 
                 WITH e
                 ORDER BY e.validAt DESC


### PR DESCRIPTION
## Summary
- **Remove early-return guard** in `handleExploratory()` that returned `[]` when `labelIds` was empty — now logs and continues
- **Make label filter conditional** in `getEpisodesForExploratory()` Cypher query, matching the existing pattern in `getEpisodesForTemporal()` (line 137)

## Problem
Search V2 exploratory queries (the most common type) return zero results when the label router fails to match the search intent to any existing labels. The data exists in the graph but is unreachable because:
1. `handleExploratory()` bails out early with `return []`
2. `getEpisodesForExploratory()` has a hard `WHERE ANY(lid IN e.labelIds WHERE lid IN $labelIds)` that matches nothing when `$labelIds` is empty

## Fix
Follow the same pattern already used by the temporal handler:
- Make the `WHERE` clause filter on `e.content IS NOT NULL` and `e.content <> ""` unconditionally
- Conditionally append `AND ANY(lid IN e.labelIds WHERE lid IN $labelIds)` only when labels are present
- Let the downstream `applyEpisodeReranking()` (threshold 0.05) handle semantic relevance filtering

## Files changed (2 files, ~5 lines)
- `packages/providers/src/graph/neo4j/domains/searchV2.ts` — conditional label filter in Cypher
- `apps/webapp/app/services/search-v2/handlers.ts` — remove early-return, log fallback

## Test plan
- [ ] Verify exploratory search returns episodes when no labels match (previously returned `[]`)
- [ ] Verify label-filtered exploratory search still works when labels do match
- [ ] Verify temporal handler (which already uses this pattern) is unaffected
- [ ] Check logs for `[Handler:exploratory] No labels matched, falling back to recent episodes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)