### PR TITLE
feat(ui): Add specific ingestion rule examples for all integrations

### DIFF
--- a/apps/webapp/app/components/integrations/ingestion-rule-section.tsx
+++ b/apps/webapp/app/components/integrations/ingestion-rule-section.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { useFetcher } from "@remix-run/react";
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
@@ -9,11 +9,13 @@ interface IngestionRuleSectionProps {
     text: string;
   } | null;
   activeAccount: any;
+  slug?: string;
 }
 
 export function IngestionRuleSection({
   ingestionRule,
   activeAccount,
+  slug,
 }: IngestionRuleSectionProps) {
   const [ingestionRuleText, setIngestionRuleText] = useState(
     ingestionRule?.text || "",
@@ -37,6 +39,58 @@ export function IngestionRuleSection({
     }
   }, [ingestionRuleFetcher.state, ingestionRuleFetcher.data]);
 
+  const placeholder = useMemo(() => {
+    switch (slug) {
+      // Productivity & Tasks
+      case "linear":
+        return `Example for Linear: "Ingest issues assigned to me or with 'Urgent' priority. Track comments on tickets I am subscribed to."`;
+      case "todoist":
+        return `Example for Todoist: "Ingest active tasks with 'High' priority (P1). Ignore sub-tasks or routine daily chores."`;
+      case "google-tasks":
+        return `Example for Google Tasks: "Ingest incomplete tasks due this week. Ignore tasks in the 'Groceries' list."`;
+      case "notion":
+        return `Example for Notion: "Ingest pages in the 'Engineering' workspace that I have edited or commented on."`;
+
+      // Communication
+      case "slack":
+        return `Example for Slack: "Ingest messages from DMs and the #team-core channel. Capture threads where I am mentioned."`;
+      case "discord":
+        return `Example for Discord: "Ingest messages from #announcements and #dev-chat. Ignore bot messages."`;
+      case "gmail":
+        return `Example for Gmail: "Ingest emails from 'important' contacts or with the label 'Work'. Ignore newsletters and promotions."`;
+      case "zoho-mail":
+        return `Example for Zoho Mail: "Ingest unread emails from my 'Inbox' received in the last 48 hours."`;
+
+      // Code & Development
+      case "codeberg":
+        return `Example for Codeberg: "Ingest issues assigned to me and pull requests where I am a reviewer. Monitor activity in the 'RedPlanetHQ' organization. Ignore commits from dependabot."`;
+      case "github":
+        return `Example for GitHub: "Ingest PRs where I am a reviewer and issues assigned to me. Track commits to the 'main' branch."`;
+      case "github-analytics":
+        return `Example for GitHub Analytics: "Ingest daily view and clone traffic for my top 5 public repositories."`;
+
+      // Calendar & Docs
+      case "google-calendar":
+        return `Example for Google Calendar: "Ingest upcoming events where I am an attendee. Ignore 'Out of Office' blocks."`;
+      case "cal-com":
+        return `Example for Cal.com: "Ingest confirmed bookings where I am the host. Ignore cancelled events."`;
+      case "google-docs":
+        return `Example for Google Docs: "Ingest documents I have modified in the last 7 days."`;
+      case "google-sheets":
+        return `Example for Google Sheets: "Ingest spreadsheets located in the 'Financials' folder."`;
+
+      // Social & CRM
+      case "linkedin":
+        return `Example for LinkedIn: "Ingest my posts and professional updates. Capture comments on my posts that mention 'collaboration' or 'partnership'. Ignore generic engagement like 'Congrats!' or 'Good job!'."`;
+      case "hubspot":
+        return `Example for HubSpot: "Ingest new contacts assigned to me and deals currently in the 'Negotiation' stage."`;
+
+      // Default
+      default:
+        return `Example: "Only ingest items from the last 24 hours that match specific keywords. Skip automated notifications."`;
+    }
+  }, [slug]);
+
   if (!activeAccount) {
     return null;
   }
@@ -51,7 +105,7 @@ export function IngestionRuleSection({
           </label>
           <Textarea
             id="ingestionRule"
-            placeholder={`Example for Gmail: "Only ingest emails from the last 24 hours that contain the word 'urgent' or 'important' in the subject line or body. Skip promotional emails and newsletters. Focus on emails from known contacts or business domains."`}
+            placeholder={placeholder}
             value={ingestionRuleText}
             onChange={(e) => setIngestionRuleText(e.target.value)}
             className="min-h-[100px]"


### PR DESCRIPTION
This PR updates the `IngestionRuleSection` component to provide specific, context-aware ingestion rule examples for all supported integrations. 

Instead of a generic Gmail placeholder for every integration, users will now see relevant examples for tools like Linear, Slack, GitHub, Todoist, HubSpot, etc., helping them write better rules faster.

### Examples Added:
- **Linear**: Filter by assignment and priority.
- **Slack/Discord**: Filter by channel and mentions.
- **GitHub**: Filter by PR reviews and assigned issues.
- **Calendar/Tasks**: Filter by attendance and due dates.
- **CRM**: Filter by contact ownership and deal stage.