### PR TITLE
fix(search-v2): deduplicate invalidated facts at Cypher query level

### DIFF
--- a/packages/providers/src/graph/interface.ts
+++ b/packages/providers/src/graph/interface.ts
@@ -394,7 +394,7 @@ export interface IGraphProvider {
     userId: string,
     workspaceId?: string
   ): Promise<
-    { episodeUuid: string; statementUuid: string; fact: string; validAt: Date; invalidAt: Date }[]
+    { statementUuid: string; fact: string; validAt: Date; invalidAt: Date }[]
   >;
 
   // ===== STATEMENTS =====

--- a/packages/providers/src/graph/neo4j/domains/episode.ts
+++ b/packages/providers/src/graph/neo4j/domains/episode.ts
@@ -957,7 +957,8 @@ export function createEpisodeMethods(core: Neo4jCore) {
         WHERE e.uuid IN $episodeUuids
         MATCH (e)-[:HAS_PROVENANCE]->(s:Statement {userId: $userId${wsFilter}})
         WHERE s.invalidAt IS NOT NULL
-        RETURN e.uuid as episodeUuid, s.uuid as statementUuid, s.fact as fact, s.validAt as validAt, s.invalidAt as invalidAt
+        WITH DISTINCT s
+        RETURN s.uuid as statementUuid, s.fact as fact, s.validAt as validAt, s.invalidAt as invalidAt
       `;
       const records = await core.runQuery(cypher, {
         episodeUuids,
@@ -965,7 +966,6 @@ export function createEpisodeMethods(core: Neo4jCore) {
         ...(workspaceId && { workspaceId }),
       });
       return records.map((record) => ({
-        episodeUuid: record.get("episodeUuid"),
         statementUuid: record.get("statementUuid"),
         fact: record.get("fact"),
         validAt: record.get("validAt"),


### PR DESCRIPTION
Use DISTINCT on statement node in the Neo4j query to eliminate duplicate rows caused by multiple HAS_PROVENANCE edges per statement. Remove episodeUuid from return type since it's no longer needed after deduplication.