### PR TITLE
Fix: show retry button when document ingestion fails

### DIFF
--- a/apps/webapp/app/components/sidebar/ingestion-status.tsx
+++ b/apps/webapp/app/components/sidebar/ingestion-status.tsx
@@ -1,29 +1,85 @@
-import { LoaderCircle } from "lucide-react";
+import { LoaderCircle, RotateCw, AlertCircle } from "lucide-react";
 import { Card, CardContent } from "~/components/ui/card";
-import { useIngestionStatus } from "~/hooks/use-ingestion-status";
+import { Button } from "~/components/ui/button";
+import { useIngestionStatus, type FailedIngestionQueueItem } from "~/hooks/use-ingestion-status";
+import { useFetcher } from "@remix-run/react";
+import { useEffect } from "react";
+import { toast } from "~/hooks/use-toast";
+
+function FailedItem({ item }: { item: FailedIngestionQueueItem }) {
+  const retryFetcher = useFetcher<{ success: boolean }>();
+  const title = (item.data as any)?.title ?? "Untitled";
+
+  useEffect(() => {
+    if (retryFetcher.state === "idle" && retryFetcher.data?.success) {
+      toast({ title: "Retry initiated", description: "Ingestion re-queued" });
+    }
+  }, [retryFetcher.state, retryFetcher.data]);
+
+  return (
+    <div className="flex items-center gap-2 w-full">
+      <span className="flex-1 truncate text-xs text-muted-foreground" title={title}>
+        {title}
+      </span>
+      {item.documentId && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 shrink-0 p-0"
+          disabled={retryFetcher.state !== "idle"}
+          onClick={() =>
+            retryFetcher.submit(
+              {},
+              { method: "POST", action: `/api/v1/documents/${item.documentId}/retry` },
+            )
+          }
+        >
+          <RotateCw
+            size={13}
+            className={retryFetcher.state !== "idle" ? "animate-spin" : ""}
+          />
+        </Button>
+      )}
+    </div>
+  );
+}
 
 export function IngestionStatus() {
   const { data } = useIngestionStatus();
 
-  if (!data || data.count === 0) {
+  const activeCount =
+    data?.queue.filter(
+      (item) => item.status === "PROCESSING" || item.status === "PENDING",
+    ).length ?? 0;
+  const failedItems = data?.failedQueue ?? [];
+
+  if (activeCount === 0 && failedItems.length === 0) {
     return null;
   }
 
-  const processingCount = data.queue.filter(
-    (item) => item.status === "PROCESSING",
-  ).length;
-  const pendingCount = data.queue.filter(
-    (item) => item.status === "PENDING",
-  ).length;
-
   return (
-    <div>
-      <Card>
-        <CardContent className="flex items-center gap-2 p-2">
-          <LoaderCircle className="text-primary h-4 w-4 animate-spin" />
-          <span>{processingCount + pendingCount} ingesting</span>
-        </CardContent>
-      </Card>
+    <div className="flex flex-col gap-1">
+      {activeCount > 0 && (
+        <Card>
+          <CardContent className="flex items-center gap-2 p-2">
+            <LoaderCircle className="text-primary h-4 w-4 animate-spin" />
+            <span>{activeCount} ingesting</span>
+          </CardContent>
+        </Card>
+      )}
+      {failedItems.length > 0 && (
+        <Card>
+          <CardContent className="flex flex-col gap-1 p-2">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="text-destructive h-4 w-4 shrink-0" />
+              <span className="text-sm">{failedItems.length} failed</span>
+            </div>
+            {failedItems.map((item) => (
+              <FailedItem key={item.id} item={item} />
+            ))}
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/webapp/app/hooks/use-ingestion-status.tsx
+++ b/apps/webapp/app/hooks/use-ingestion-status.tsx
@@ -9,9 +9,16 @@ export interface IngestionQueueItem {
   data: any;
 }
 
+export interface FailedIngestionQueueItem extends IngestionQueueItem {
+  sessionId: string | null;
+  documentId: string | null;
+}
+
 export interface IngestionStatusResponse {
   queue: IngestionQueueItem[];
   count: number;
+  failedQueue: FailedIngestionQueueItem[];
+  failedCount: number;
 }
 
 export function useIngestionStatus() {

--- a/apps/webapp/app/routes/api.v1.ingestion-queue.status.tsx
+++ b/apps/webapp/app/routes/api.v1.ingestion-queue.status.tsx
@@ -101,9 +101,66 @@ export async function loader({ request }: LoaderFunctionArgs) {
     },
   });
 
+  // Fetch recent FAILED items (last 24 hours)
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const failedQueue = await prisma.ingestionQueue.findMany({
+    where: {
+      workspaceId,
+      status: "FAILED",
+      updatedAt: {
+        gte: oneDayAgo,
+      },
+    },
+    select: {
+      id: true,
+      status: true,
+      createdAt: true,
+      error: true,
+      data: true,
+      sessionId: true,
+    },
+    orderBy: {
+      updatedAt: "desc",
+    },
+    take: 20,
+  });
+
+  // For each failed item, look up the corresponding documentId via sessionId
+  const sessionIds = failedQueue
+    .map((item) => item.sessionId)
+    .filter(Boolean) as string[];
+
+  const documents =
+    sessionIds.length > 0
+      ? await prisma.document.findMany({
+          where: {
+            sessionId: { in: sessionIds },
+            workspaceId,
+            deleted: null,
+          },
+          select: {
+            id: true,
+            sessionId: true,
+          },
+        })
+      : [];
+
+  const sessionToDocumentId = Object.fromEntries(
+    documents.map((d) => [d.sessionId, d.id]),
+  );
+
+  const failedQueueWithDocumentId = failedQueue.map((item) => ({
+    ...item,
+    documentId: item.sessionId
+      ? sessionToDocumentId[item.sessionId] ?? null
+      : null,
+  }));
+
   return json({
     queue: updatedQueue,
     count: updatedQueue.length,
+    failedQueue: failedQueueWithDocumentId,
+    failedCount: failedQueueWithDocumentId.length,
     markedAsStale: {
       processing: staleProcessingItems.length,
       pending: stalePendingItems.length,


### PR DESCRIPTION
Fixes #618

## Summary

- **API** (`api.v1.ingestion-queue.status.tsx`): also queries `FAILED` items from the last 24 hours, joins with the `Document` table via `sessionId` to expose `documentId`; returns `failedQueue` + `failedCount` in the response.
- **Hook** (`use-ingestion-status.tsx`): added `FailedIngestionQueueItem` type (extends base with `sessionId` + `documentId`) and updated `IngestionStatusResponse` to include `failedQueue`/`failedCount`.
- **Component** (`ingestion-status.tsx`): renders a "N failed" card below the existing "N ingesting" card when failed items exist; each item shows the document title and a `RotateCw` retry button that calls `POST /api/v1/documents/${documentId}/retry`. Items that failed before document creation (no `documentId`) display without a retry button.

## Testing

- [ ] Ingest a document and simulate a failure (e.g. bad URL or network drop).
- [ ] Confirm the sidebar shows a "failed" card with the document title.
- [ ] Click the retry button — verify a new ingestion job is queued and the card clears on success.
- [ ] Verify items without a `documentId` render without a retry button (no crash).
- [ ] Verify the "ingesting" card still functions normally alongside the failed card.