### PR TITLE
feat: integration tools visibility, channel connected status, and connect CTA fixes

### DIFF
--- a/apps/webapp/app/components/conversation/conversation-list.tsx
+++ b/apps/webapp/app/components/conversation/conversation-list.tsx
@@ -86,7 +86,7 @@ export const ConversationList = ({
   useEffect(() => {
     if (fetcher.data && fetcher.state === "idle") {
       setIsLoading(false);
-      const newConversations = fetcher.data.conversations.filter(
+      const newConversations = (fetcher.data.conversations ?? []).filter(
         (c) => !loadedConversationIds.current.has(c.id),
       );
       newConversations.forEach((c) => loadedConversationIds.current.add(c.id));

--- a/apps/webapp/app/routes/home.agent.connect.tsx
+++ b/apps/webapp/app/routes/home.agent.connect.tsx
@@ -4,7 +4,7 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "@remix-run/node";
-import { useFetcher, useLoaderData } from "@remix-run/react";
+import { Link, useFetcher, useLoaderData } from "@remix-run/react";
 import { Mail, Clock, Check, Star, MessageCircle } from "lucide-react";
 import { PageHeader } from "~/components/common/page-header";
 import {
@@ -66,6 +66,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
     hasSlack = !!slackAccount;
   }
 
+  // Fetch active MCP sources to detect connected AI providers
+  const activeMcpSources = workspaceId
+    ? await prisma.mCPSession.findMany({
+        where: { deleted: null, workspaceId },
+        select: { source: true },
+        distinct: ["source"],
+      })
+    : [];
+  const connectedProviders = activeMcpSources
+    .map((s) => s.source?.toLowerCase() ?? "")
+    .filter(Boolean);
+
   return json({
     whatsappOptin,
     imessageOptin,
@@ -75,6 +87,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       slack: hasSlack,
       email: hasEmail,
     },
+    connectedProviders,
   });
 }
 
@@ -139,6 +152,34 @@ export async function action({ request }: ActionFunctionArgs) {
 
   return json({ error: "Invalid intent" }, { status: 400 });
 }
+
+const PROVIDER_SOURCE_MAP: Record<string, string> = {
+  claude_code: "claude-code",
+  claude: "claude",
+  cursor: "cursor",
+  codex: "codex",
+  vscode: "vscode",
+  windsurf: "windsurf",
+  zed: "zed",
+  kilo_code: "kilo-code",
+  vscode_insiders: "vscode-insiders",
+  amp: "amp",
+  augment_code: "augment-code",
+  roo_code: "roo-code",
+  opencode: "opencode",
+  qwen_coder: "qwen",
+  copilot_cli: "copilot-cli",
+  copilot_coding_agent: "copilot-agent",
+  warp: "warp",
+  rovo_dev: "rovo-dev",
+  cline: "cline",
+  kiro: "kiro",
+  trae: "trae",
+  perplexity: "perplexity",
+  qodo_gen: "qodo-gen",
+  crush: "crush",
+  factory: "factory",
+};
 
 // Direct communication channels
 const DIRECT_CHANNELS = [
@@ -214,6 +255,12 @@ function DirectChannelCard({
                 Default
               </Badge>
             )}
+            {isConnected && (
+              <Badge className="rounded bg-green-100 text-xs text-green-800">
+                <Check size={10} className="mr-1" />
+                Connected
+              </Badge>
+            )}
             {isWaitlist && !isConnected && isOptedIn && (
               <Badge className="rounded bg-green-100 text-xs text-green-800">
                 <Check size={10} />
@@ -226,7 +273,7 @@ function DirectChannelCard({
                 Waitlist
               </Badge>
             )}
-            {channel.status === "available" && !isDefault && (
+            {channel.status === "available" && !isConnected && !isDefault && (
               <Badge className="rounded bg-green-100 text-xs text-green-800">
                 Available
               </Badge>
@@ -265,19 +312,15 @@ function DirectChannelCard({
             </Button>
           )}
           {channel.id === "slack" && (
-            <Button
-              variant="secondary"
-              className="w-full rounded"
-              onClick={(e) => {
-                e.stopPropagation();
-                window.open(
-                  "https://docs.getcore.me/access-core/channels/slack",
-                  "_blank",
-                );
-              }}
+            <Link
+              to="/home/integration/slack"
+              className="w-full"
+              onClick={(e) => e.stopPropagation()}
             >
-              View Docs
-            </Button>
+              <Button variant="secondary" className="w-full rounded">
+                Connect
+              </Button>
+            </Link>
           )}
           {isConnected && !isDefault && onSetDefault && (
             <Button
@@ -348,8 +391,13 @@ function EmailModal({
 }
 
 export default function Connect() {
-  const { whatsappOptin, imessageOptin, defaultChannel, connectedChannels } =
-    useLoaderData<typeof loader>();
+  const {
+    whatsappOptin,
+    imessageOptin,
+    defaultChannel,
+    connectedChannels,
+    connectedProviders,
+  } = useLoaderData<typeof loader>();
   const [isEmailModalOpen, setIsEmailModalOpen] = useState(false);
   const fetcher = useFetcher<{ success: boolean }>();
   const imessageFetcher = useFetcher<{ success: boolean }>();
@@ -461,7 +509,9 @@ export default function Connect() {
               <ProviderCard
                 key={provider.id}
                 provider={provider}
-                isConnected={false}
+                isConnected={connectedProviders.includes(
+                  PROVIDER_SOURCE_MAP[provider.id]?.toLowerCase() ?? "",
+                )}
               />
             ))}
           </div>

--- a/apps/webapp/app/routes/home.integration.$slug.tsx
+++ b/apps/webapp/app/routes/home.integration.$slug.tsx
@@ -20,6 +20,7 @@ import { PageHeader } from "~/components/common/page-header";
 import { prisma } from "~/db.server";
 import { scheduler, unschedule } from "~/services/oauth/scheduler";
 import { Plus } from "lucide-react";
+import { IntegrationRunner } from "~/services/integrations/integration-runner";
 import { isBillingEnabled, isPaidPlan } from "~/config/billing.server";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -56,12 +57,28 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     isPaidPlan(subscription?.planType || "FREE") ||
     user.admin;
 
+  let tools: Array<{ name: string; description: string }> = [];
+  try {
+    const rawTools = await IntegrationRunner.getTools({
+      integrationDefinition: integration as any,
+    });
+    tools = rawTools
+      .filter((t: any) => t.name)
+      .map((t: any) => ({
+        name: t.name,
+        description: t.description ?? "",
+      }));
+  } catch {
+    tools = [];
+  }
+
   return json({
     integration,
     integrationAccounts,
     activeAccounts,
     userId: user.id,
     isAutoReadAvailable,
+    tools,
   });
 }
 
@@ -111,6 +128,7 @@ interface IntegrationDetailProps {
   integrationAccounts: any;
   activeAccounts: any[];
   isAutoReadAvailable: boolean;
+  tools: Array<{ name: string; description: string }>;
 }
 
 export function IntegrationDetail({
@@ -118,6 +136,7 @@ export function IntegrationDetail({
   integrationAccounts,
   activeAccounts,
   isAutoReadAvailable,
+  tools,
 }: IntegrationDetailProps) {
   const hasActiveAccounts = activeAccounts && activeAccounts.length > 0;
 
@@ -244,6 +263,30 @@ export function IntegrationDetail({
                 supportsAutoActivity={hasAutoActivity}
               />
 
+              {/* Tools Section */}
+              {tools && tools.length > 0 && (
+                <div className="mt-6 space-y-3">
+                  <h3 className="text-lg font-medium">
+                    Tools ({tools.length})
+                  </h3>
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {tools.map((tool) => (
+                      <div
+                        key={tool.name}
+                        className="bg-background-3 rounded-lg p-3"
+                      >
+                        <p className="text-sm font-medium">{tool.name}</p>
+                        {tool.description && (
+                          <p className="text-muted-foreground mt-0.5 text-xs">
+                            {tool.description}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {/* MCP Authentication Section */}
               <MCPAuthSection
                 integration={integration}
@@ -264,6 +307,7 @@ export default function IntegrationDetailWrapper() {
     integrationAccounts,
     activeAccounts,
     isAutoReadAvailable,
+    tools,
   } = useLoaderData<typeof loader>();
 
   return (
@@ -272,6 +316,7 @@ export default function IntegrationDetailWrapper() {
       integrationAccounts={integrationAccounts}
       activeAccounts={activeAccounts}
       isAutoReadAvailable={isAutoReadAvailable}
+      tools={tools}
     />
   );
 }


### PR DESCRIPTION
## Summary

Addresses issues #567 and #581 — improving integration discoverability and connection status visibility across the UI.

### What was done and why

**1. MCP Tools grid on integration detail pages (#567)**

Users opening an integration page (e.g. `/home/integration/slack`) had no visibility into what the integration could actually do. Added a "Tools (N)" grid below the Connected Accounts section that lists every available MCP tool with its name and description.

Key decision: tools are loaded via `IntegrationRunner.getTools()` which only needs the integration definition (not a connected account), so the grid shows for **all** integrations whether connected or not — giving users a reason to connect in the first place.

**2. Connected status badges on Connect page (#581, part 1)**

The Connect page (`/home/agent/connect`) showed channels and AI providers with no indication of which ones were already set up. Added green "Connected" badges:
- **Messaging channels** (Slack, Email, WhatsApp): derived from existing `connectedChannels` loader data
- **AI providers** (Claude Code, Cursor, Windsurf, etc.): derived from active `MCPSession` records — the `source` field matches the `?source=` param each tool uses when connecting

Also suppressed the "Available" badge when a channel is already connected to avoid redundant status labels.

**3. Slack "View Docs" → "Connect" CTA (#581, part 2)**

The Slack card on the Connect page showed a "View Docs" button that opened external docs in a new tab. Users had no direct path to actually connect Slack from this page. Changed it to a "Connect" button that navigates to `/home/integration/slack` — the actual integration setup page.

**4. Conversation list crash guard (bug fix)**

Fixed a crash in `ConversationList` where `fetcher.data.conversations` could be `undefined` when the conversations API returns a 500, causing the entire page to error out. Added a `?? []` guard so the app degrades gracefully.

## Files changed

- `apps/webapp/app/routes/home.integration.$slug.tsx` — loader fetches tools via `IntegrationRunner.getTools`; component renders Tools grid
- `apps/webapp/app/routes/home.agent.connect.tsx` — Connected badges for channels and providers; Slack CTA fix; active MCP session lookup in loader
- `apps/webapp/app/components/conversation/conversation-list.tsx` — null guard on conversations array

## Test plan

- [ ] Open any integration page — Tools grid appears below connected accounts (works even when not connected)
- [ ] On Connect page, Slack card shows "Connect" button → clicks through to `/home/integration/slack`
- [ ] On Connect page, connected Slack/Email channels show green "Connected" badge
- [ ] On Connect page, AI providers with active MCP sessions show "Connected" badge
- [ ] App loads without crash even when conversations API returns 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)