### PR TITLE
feat: add Google Search Console integration

### DIFF
--- a/apps/webapp/app/components/icon-utils.tsx
+++ b/apps/webapp/app/components/icon-utils.tsx
@@ -18,6 +18,7 @@ import { Gmail } from "./icons/gmail";
 import { GoogleCalendar } from "./icons/google-calendar";
 import { GoogleSheets } from "./icons/google-sheets";
 import { GoogleDocs } from "./icons/google-docs";
+import { GoogleSearchConsole } from "./icons/google-search-console";
 import { CalCom } from "./icons/cal_com";
 import { Notion } from "./icons/notion";
 import { Zoho } from "./icons/zoho";
@@ -50,6 +51,7 @@ export const ICON_MAPPING = {
   "google-calendar": GoogleCalendar,
   "google-sheets": GoogleSheets,
   "google-docs": GoogleDocs,
+  "google-search-console": GoogleSearchConsole,
   linear: LinearIcon,
   cursor: Cursor,
   claude: Claude,

--- a/apps/webapp/app/components/icons/google-search-console.tsx
+++ b/apps/webapp/app/components/icons/google-search-console.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from './types';
+
+export function GoogleSearchConsole({ size = 18, className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 48 48"
+      width={size}
+      height={size}
+      className={className}
+    >
+      <path fill="#4caf50" d="M24 4C13 4 4 13 4 24s9 20 20 20 20-9 20-20S35 4 24 4z" />
+      <path
+        fill="#fff"
+        d="M24 10c-7.7 0-14 6.3-14 14s6.3 14 14 14 14-6.3 14-14-6.3-14-14-14zm0 25c-6.1 0-11-4.9-11-11s4.9-11 11-11 11 4.9 11 11-4.9 11-11 11z"
+      />
+      <circle cx="24" cy="24" r="5" fill="#fff" />
+      <path
+        fill="#fff"
+        d="M33.2 14.8l-6.4 6.4c.8.9 1.2 2 1.2 3.2 0 .4 0 .8-.1 1.2l6.9 2.3c.2-.9.2-1.7.2-2.6 0-3.8-1.4-7.3-3.8-9.8-.1 0 0-.3 0-.7z"
+      />
+    </svg>
+  );
+}

--- a/integrations/google-search-console/.prettierrc
+++ b/integrations/google-search-console/.prettierrc
@@ -1,0 +1,19 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "rangeStart": 0,
+  "rangeEnd": null,
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "lf"
+}

--- a/integrations/google-search-console/eslint.config.js
+++ b/integrations/google-search-console/eslint.config.js
@@ -1,0 +1,65 @@
+import js from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import importPlugin from 'eslint-plugin-import';
+import eslintPluginPrettier from 'eslint-plugin-prettier';
+import unusedImports from 'eslint-plugin-unused-imports';
+import typescriptEslint from 'typescript-eslint';
+
+export default [
+  js.configs.recommended,
+  ...typescriptEslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        global: 'readonly',
+      },
+    },
+    plugins: {
+      import: importPlugin,
+      prettier: eslintPluginPrettier,
+      'unused-imports': unusedImports,
+    },
+    rules: {
+      'prettier/prettier': 'error',
+      'no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': [
+        'warn',
+        {
+          vars: 'all',
+          varsIgnorePattern: '^_',
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+        },
+      ],
+      'import/order': [
+        'error',
+        {
+          groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+          'newlines-between': 'always',
+        },
+      ],
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+    },
+    settings: {
+      'import/resolver': {
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+      },
+    },
+  },
+];

--- a/integrations/google-search-console/package.json
+++ b/integrations/google-search-console/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@core/google-search-console",
+  "version": "0.1.0",
+  "description": "Google Search Console integration for CORE",
+  "main": "./bin/index.cjs",
+  "type": "module",
+  "files": [
+    "google-search-console",
+    "bin"
+  ],
+  "bin": {
+    "google-search-console": "./bin/index.cjs"
+  },
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint --ext js,ts,tsx src/ --fix",
+    "prettier": "prettier --config .prettierrc --write ."
+  },
+  "devDependencies": {
+    "@babel/preset-typescript": "^7.26.0",
+    "@types/node": "^18.0.20",
+    "eslint": "^9.24.0",
+    "eslint-config-prettier": "^10.1.2",
+    "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jest": "^27.9.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-unused-imports": "^2.0.0",
+    "google-auth-library": "10.5.0",
+    "googleapis": "166.0.0",
+    "prettier": "^3.4.2",
+    "rimraf": "^3.0.2",
+    "tslib": "^2.8.1",
+    "tsup": "^8.0.1",
+    "typescript": "^4.7.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@redplanethq/sdk": "0.1.14",
+    "axios": "^1.7.9",
+    "commander": "^12.0.0",
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.4"
+  }
+}

--- a/integrations/google-search-console/scripts/register.ts
+++ b/integrations/google-search-console/scripts/register.ts
@@ -1,0 +1,80 @@
+import pg from 'pg';
+
+const { Client } = pg;
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString });
+
+  const spec = {
+    name: 'Google Search Console',
+    key: 'google-search-console',
+    description:
+      'Connect your workspace to Google Search Console. Manage sites, sitemaps, search analytics, and URL inspection directly from CORE.',
+    icon: 'google-search-console',
+    mcp: {
+      type: 'cli',
+    },
+    auth: {
+      OAuth2: {
+        token_url: 'https://oauth2.googleapis.com/token',
+        authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth',
+        scopes: [
+          'https://www.googleapis.com/auth/webmasters',
+          'https://www.googleapis.com/auth/webmasters.readonly',
+          'https://www.googleapis.com/auth/userinfo.profile',
+          'https://www.googleapis.com/auth/userinfo.email',
+        ],
+        scope_identifier: 'scope',
+        scope_separator: ' ',
+        token_params: {
+          access_type: 'offline',
+          prompt: 'consent',
+        },
+        authorization_params: {
+          access_type: 'offline',
+          prompt: 'consent',
+        },
+      },
+    },
+  };
+
+  try {
+    await client.connect();
+
+    await client.query(
+      `
+      INSERT INTO core."IntegrationDefinitionV2" ("id", "name", "slug", "description", "icon", "spec", "config", "version", "url", "updatedAt", "createdAt")
+      VALUES (gen_random_uuid(), 'Google Search Console', 'google-search-console', 'Connect your workspace to Google Search Console. Manage sites, sitemaps, search analytics, and URL inspection directly from CORE.', 'google-search-console', $1, $2, '0.1.0', $3, NOW(), NOW())
+      ON CONFLICT (name) DO UPDATE SET
+        "slug" = EXCLUDED."slug",
+        "description" = EXCLUDED."description",
+        "icon" = EXCLUDED."icon",
+        "spec" = EXCLUDED."spec",
+        "config" = EXCLUDED."config",
+        "version" = EXCLUDED."version",
+        "url" = EXCLUDED."url",
+        "updatedAt" = NOW()
+      RETURNING *;
+    `,
+      [
+        JSON.stringify(spec),
+        JSON.stringify({}),
+        '../../integrations/google-search-console/bin/index.cjs',
+      ]
+    );
+
+    console.log('Google Search Console integration registered successfully in the database.');
+  } catch (error) {
+    console.error('Error registering Google Search Console integration:', error);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch(console.error);

--- a/integrations/google-search-console/src/account-create.ts
+++ b/integrations/google-search-console/src/account-create.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+
+export async function integrationCreate(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any
+) {
+  const { oauthResponse, oauthParams } = data;
+
+  let userEmail: string | null = null;
+  let userId: string | null = null;
+
+  try {
+    const userInfoResponse = await axios.get('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: {
+        Authorization: `Bearer ${oauthResponse.access_token}`,
+      },
+    });
+
+    userEmail = userInfoResponse.data.email;
+    userId = userInfoResponse.data.id;
+  } catch (error) {
+    console.error('Error fetching user info:', error);
+  }
+
+  const integrationConfiguration = {
+    access_token: oauthResponse.access_token,
+    refresh_token: oauthResponse.refresh_token,
+    client_id: oauthResponse.client_id,
+    client_secret: oauthResponse.client_secret,
+    token_type: oauthResponse.token_type,
+    expires_in: oauthResponse.expires_in,
+    expires_at: oauthResponse.expires_at,
+    scope: oauthResponse.scope,
+    userEmail,
+    userId,
+    redirect_uri: oauthParams?.redirect_uri || null,
+  };
+
+  const payload = {
+    settings: {},
+    accountId: integrationConfiguration.userEmail || integrationConfiguration.userId,
+    config: integrationConfiguration,
+  };
+
+  return [
+    {
+      type: 'account',
+      data: payload,
+    },
+  ];
+}

--- a/integrations/google-search-console/src/index.ts
+++ b/integrations/google-search-console/src/index.ts
@@ -1,0 +1,105 @@
+import { fileURLToPath } from 'url';
+
+import {
+  IntegrationCLI,
+  IntegrationEventPayload,
+  IntegrationEventType,
+  Spec,
+} from '@redplanethq/sdk';
+
+import { integrationCreate } from './account-create';
+import { getTools, callTool } from './mcp';
+
+export async function run(eventPayload: IntegrationEventPayload) {
+  switch (eventPayload.event) {
+    case IntegrationEventType.SETUP:
+      return await integrationCreate(eventPayload.eventBody);
+
+    case IntegrationEventType.GET_TOOLS: {
+      const tools = await getTools();
+
+      return tools;
+    }
+
+    case IntegrationEventType.CALL_TOOL: {
+      const integrationDefinition = eventPayload.integrationDefinition;
+
+      if (!integrationDefinition) {
+        return null;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const config = eventPayload.config as any;
+      const { name, arguments: args } = eventPayload.eventBody;
+
+      const result = await callTool(
+        name,
+        args,
+        integrationDefinition.config.clientId,
+        integrationDefinition.config.clientSecret,
+        config?.redirect_uri,
+        config
+      );
+
+      return result;
+    }
+
+    default:
+      return { message: `The event payload type is ${eventPayload.event}` };
+  }
+}
+
+class GoogleSearchConsoleCLI extends IntegrationCLI {
+  constructor() {
+    super('google-search-console', '1.0.0');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected async handleEvent(eventPayload: IntegrationEventPayload): Promise<any> {
+    return await run(eventPayload);
+  }
+
+  protected async getSpec(): Promise<Spec> {
+    return {
+      name: 'Google Search Console',
+      key: 'google-search-console',
+      description:
+        'Connect your workspace to Google Search Console. Manage sites, sitemaps, search analytics, and URL inspection directly from CORE.',
+      icon: 'google-search-console',
+      mcp: {
+        type: 'cli',
+      },
+      auth: {
+        OAuth2: {
+          token_url: 'https://oauth2.googleapis.com/token',
+          authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth',
+          scopes: [
+            'https://www.googleapis.com/auth/webmasters',
+            'https://www.googleapis.com/auth/webmasters.readonly',
+            'https://www.googleapis.com/auth/userinfo.profile',
+            'https://www.googleapis.com/auth/userinfo.email',
+          ],
+          scope_identifier: 'scope',
+          scope_separator: ' ',
+          token_params: {
+            access_type: 'offline',
+            prompt: 'consent',
+          },
+          authorization_params: {
+            access_type: 'offline',
+            prompt: 'consent',
+          },
+        },
+      },
+    };
+  }
+}
+
+function main() {
+  const cli = new GoogleSearchConsoleCLI();
+  cli.parse();
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/integrations/google-search-console/src/mcp/index.ts
+++ b/integrations/google-search-console/src/mcp/index.ts
@@ -1,0 +1,367 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { getSearchConsoleClient, withBackoff } from '../utils';
+
+// ─── Schemas ────────────────────────────────────────────────────────────────
+
+const SiteUrlSchema = z.object({
+  siteUrl: z
+    .string()
+    .describe(
+      'The URL of the site as returned by list_sites. Use the exact string including protocol, subdomain, sc-domain: prefix, and trailing slash.'
+    ),
+});
+
+const AddSiteSchema = z.object({
+  siteUrl: z
+    .string()
+    .describe(
+      'The URL of the site to add. For URL-prefix properties use https://example.com/ (with trailing slash). For domain properties use sc-domain:example.com.'
+    ),
+});
+
+const SitemapSchema = z.object({
+  siteUrl: z.string().describe('The site URL (exactly as returned by list_sites).'),
+  feedpath: z.string().describe('The URL of the sitemap to operate on.'),
+});
+
+const ListSitemapsSchema = z.object({
+  siteUrl: z.string().describe('The site URL (exactly as returned by list_sites).'),
+  sitemapIndex: z.string().optional().describe('Optional sitemap index URL to filter results.'),
+});
+
+const SearchAnalyticsSchema = z.object({
+  siteUrl: z.string().describe('The site URL (exactly as returned by list_sites).'),
+  startDate: z.string().describe('Start date in YYYY-MM-DD format.'),
+  endDate: z.string().describe('End date in YYYY-MM-DD format.'),
+  dimensions: z
+    .array(z.enum(['country', 'device', 'page', 'query', 'searchAppearance', 'date']))
+    .optional()
+    .describe('Dimensions to group results by.'),
+  rowLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(25000)
+    .optional()
+    .default(1000)
+    .describe('Maximum number of rows to return (1–25000, default 1000).'),
+  startRow: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .default(0)
+    .describe('Zero-based index of the first row to return.'),
+  searchType: z
+    .enum(['web', 'image', 'video', 'news', 'googleNews', 'discover'])
+    .optional()
+    .default('web')
+    .describe('The search type to filter on.'),
+  dimensionFilterGroups: z.array(z.any()).optional().describe('Optional dimension filter groups.'),
+});
+
+const InspectUrlSchema = z.object({
+  siteUrl: z
+    .string()
+    .describe(
+      'The site property URL (exactly as returned by list_sites). Must own or have verified this property.'
+    ),
+  inspectionUrl: z.string().describe('The fully qualified URL to inspect.'),
+  languageCode: z
+    .string()
+    .optional()
+    .default('en-US')
+    .describe('BCP-47 language code for inspection results (default: en-US).'),
+});
+
+// ─── Tools list ──────────────────────────────────────────────────────────────
+
+export async function getTools() {
+  return [
+    {
+      name: 'list_sites',
+      description:
+        "List all sites (properties) verified in the user's Google Search Console account.",
+      inputSchema: zodToJsonSchema(z.object({})),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    {
+      name: 'get_site',
+      description: 'Get permission level and details for a specific site property.',
+      inputSchema: zodToJsonSchema(SiteUrlSchema),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    {
+      name: 'add_site',
+      description:
+        'Add a new site property to Google Search Console. Ownership verification is required separately in GSC.',
+      inputSchema: zodToJsonSchema(AddSiteSchema),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    },
+    {
+      name: 'delete_site',
+      description:
+        'Permanently remove a site property from Google Search Console. This action cannot be undone.',
+      inputSchema: zodToJsonSchema(SiteUrlSchema),
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+    },
+    {
+      name: 'list_sitemaps',
+      description: 'List all sitemaps submitted for a site property.',
+      inputSchema: zodToJsonSchema(ListSitemapsSchema),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    {
+      name: 'get_sitemap',
+      description: 'Get metadata for a specific sitemap. Numeric fields may lag several days.',
+      inputSchema: zodToJsonSchema(SitemapSchema),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    {
+      name: 'submit_sitemap',
+      description:
+        'Submit a sitemap for a site property. Requires owner or full-user permissions on the property.',
+      inputSchema: zodToJsonSchema(SitemapSchema),
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    },
+    {
+      name: 'search_analytics_query',
+      description:
+        'Query search analytics data (clicks, impressions, CTR, position). Only rows with at least 1 impression are returned.',
+      inputSchema: zodToJsonSchema(SearchAnalyticsSchema),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+    {
+      name: 'inspect_url',
+      description:
+        'Inspect a URL using the URL Inspection API. Results reflect cached/indexed state and may lag several days. Applies exponential backoff on quota errors.',
+      inputSchema: zodToJsonSchema(InspectUrlSchema),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    },
+  ];
+}
+
+// ─── Tool handler ─────────────────────────────────────────────────────────────
+
+export async function callTool(
+  name: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any,
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any
+) {
+  const gsc = getSearchConsoleClient(clientId, clientSecret, redirectUri || '', config);
+
+  try {
+    switch (name) {
+      case 'list_sites': {
+        const res = await gsc.sites.list();
+        const sites = res.data.siteEntry ?? [];
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(sites, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_site': {
+        const { siteUrl } = SiteUrlSchema.parse(args);
+        const res = await gsc.sites.get({ siteUrl });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(res.data, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'add_site': {
+        const { siteUrl } = AddSiteSchema.parse(args);
+        await gsc.sites.add({ siteUrl });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Site ${siteUrl} added successfully. Note: ownership verification is required in Google Search Console.`,
+            },
+          ],
+        };
+      }
+
+      case 'delete_site': {
+        const { siteUrl } = SiteUrlSchema.parse(args);
+        await gsc.sites.delete({ siteUrl });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Site ${siteUrl} deleted successfully.`,
+            },
+          ],
+        };
+      }
+
+      case 'list_sitemaps': {
+        const { siteUrl, sitemapIndex } = ListSitemapsSchema.parse(args);
+        const params: Record<string, string> = { siteUrl };
+        if (sitemapIndex) {
+          params['sitemapIndex'] = sitemapIndex;
+        }
+        const res = await gsc.sitemaps.list(params);
+        const sitemaps = (res.data.sitemap ?? []).map(s => ({
+          ...s,
+          errors: s.errors !== undefined ? parseInt(String(s.errors), 10) : undefined,
+          warnings: s.warnings !== undefined ? parseInt(String(s.warnings), 10) : undefined,
+          isPending: s.isPending,
+          isSitemapsIndex: s.isSitemapsIndex,
+          lastSubmitted: s.lastSubmitted,
+          lastDownloaded: s.lastDownloaded,
+          path: s.path,
+          type: s.type,
+          contents: s.contents?.map(c => ({
+            ...c,
+            submitted: c.submitted !== undefined ? parseInt(String(c.submitted), 10) : undefined,
+            indexed: c.indexed !== undefined ? parseInt(String(c.indexed), 10) : undefined,
+          })),
+        }));
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(sitemaps, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_sitemap': {
+        const { siteUrl, feedpath } = SitemapSchema.parse(args);
+        const res = await gsc.sitemaps.get({ siteUrl, feedpath });
+        const sitemap = res.data;
+        const normalized = {
+          ...sitemap,
+          errors: sitemap.errors !== undefined ? parseInt(String(sitemap.errors), 10) : undefined,
+          warnings:
+            sitemap.warnings !== undefined ? parseInt(String(sitemap.warnings), 10) : undefined,
+          contents: sitemap.contents?.map(c => ({
+            ...c,
+            submitted: c.submitted !== undefined ? parseInt(String(c.submitted), 10) : undefined,
+            indexed: c.indexed !== undefined ? parseInt(String(c.indexed), 10) : undefined,
+          })),
+        };
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(normalized, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'submit_sitemap': {
+        const { siteUrl, feedpath } = SitemapSchema.parse(args);
+        await gsc.sitemaps.submit({ siteUrl, feedpath });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Sitemap ${feedpath} submitted successfully for ${siteUrl}.`,
+            },
+          ],
+        };
+      }
+
+      case 'search_analytics_query': {
+        const validated = SearchAnalyticsSchema.parse(args);
+        const res = await gsc.searchanalytics.query({
+          siteUrl: validated.siteUrl,
+          requestBody: {
+            startDate: validated.startDate,
+            endDate: validated.endDate,
+            dimensions: validated.dimensions,
+            rowLimit: validated.rowLimit,
+            startRow: validated.startRow,
+            searchType: validated.searchType,
+            dimensionFilterGroups: validated.dimensionFilterGroups,
+          },
+        });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(res.data, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'inspect_url': {
+        const validated = InspectUrlSchema.parse(args);
+        const res = await withBackoff(() =>
+          gsc.urlInspection.index.inspect({
+            requestBody: {
+              siteUrl: validated.siteUrl,
+              inspectionUrl: validated.inspectionUrl,
+              languageCode: validated.languageCode,
+            },
+          })
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(res.data, null, 2),
+            },
+          ],
+        };
+      }
+
+      default:
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Unknown tool: ${name}`,
+            },
+          ],
+          isError: true,
+        };
+    }
+  } catch (error: unknown) {
+    const err = error as {
+      response?: { status?: number; data?: unknown };
+      message?: string;
+    };
+    if (err?.response?.status === 429) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Quota exceeded (HTTP 429). The Search Console API limit has been reached. Please wait before retrying.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error: ${err?.message ?? String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/integrations/google-search-console/src/utils.ts
+++ b/integrations/google-search-console/src/utils.ts
@@ -1,0 +1,69 @@
+import { OAuth2Client } from 'google-auth-library';
+import { google, searchconsole_v1 } from 'googleapis';
+
+export interface GSCConfig {
+  access_token: string;
+  refresh_token: string;
+  client_id: string;
+  client_secret: string;
+  token_type?: string;
+  expires_in?: string;
+  expires_at?: string;
+  scope?: string;
+  redirect_uri?: string;
+}
+
+export function getOAuth2Client(
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string,
+  config: GSCConfig
+): OAuth2Client {
+  const oauth2Client = new OAuth2Client(clientId, clientSecret, redirectUri);
+  oauth2Client.setCredentials({
+    access_token: config.access_token,
+    refresh_token: config.refresh_token,
+    expiry_date:
+      typeof config.expires_at === 'string' ? parseInt(config.expires_at) : config.expires_at,
+    token_type: config.token_type,
+    scope: config.scope,
+  });
+  return oauth2Client;
+}
+
+export function getSearchConsoleClient(
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string,
+  config: GSCConfig
+): searchconsole_v1.Searchconsole {
+  const auth = getOAuth2Client(clientId, clientSecret, redirectUri, config);
+  return google.searchconsole({ version: 'v1', auth });
+}
+
+/**
+ * Exponential backoff for API calls that may return 429.
+ */
+export async function withBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries = 5,
+  baseDelayMs = 1000
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (err: unknown) {
+      const error = err as { response?: { status?: number }; message?: string };
+      const status = error?.response?.status;
+      if (status === 429 && attempt < maxRetries) {
+        const delay = baseDelayMs * Math.pow(2, attempt);
+        console.warn(`Rate limited (429). Retrying in ${delay}ms... (attempt ${attempt + 1})`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+        attempt++;
+      } else {
+        throw err;
+      }
+    }
+  }
+}

--- a/integrations/google-search-console/tsconfig.json
+++ b/integrations/google-search-console/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strictNullChecks": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "dist", "bin"]
+}

--- a/integrations/google-search-console/tsup.config.ts
+++ b/integrations/google-search-console/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+import { dependencies } from './package.json';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs'],
+  bundle: true,
+  target: 'node16',
+  outDir: 'bin',
+  splitting: false,
+  shims: true,
+  clean: true,
+  name: 'google-search-console',
+  platform: 'node',
+  legacyOutput: false,
+  noExternal: Object.keys(dependencies || {}),
+  treeshake: {
+    preset: 'recommended',
+  },
+});


### PR DESCRIPTION
Implements OAuth2 integration for Google Search Console with 9 MCP tools: 
- list_sites 
- get_site
- add_site
- delete_site
- list_sitemaps
- get_sitemap
- submit_sitemap
- search_analytics_query
- inspect_url (with exponential backoff on HTTP 429). 


Follows IntegrationDefinitionV2 pattern.

Closes #696