### PR TITLE
docs: fix MDX parsing errors across skill files

### DIFF
--- a/docs/skills/ab_test_setup.mdx
+++ b/docs/skills/ab_test_setup.mdx
@@ -451,7 +451,7 @@ Looking at results before reaching sample size and stopping early leads to false
 
 ### Statistical Significance
 - 95% confidence = p-value < 0.05
-- Means <5% chance result is random
+- Means \<5% chance result is random
 - Not a guarantee—just a threshold
 
 ### Analysis Checklist

--- a/docs/skills/ai_seo.mdx
+++ b/docs/skills/ai_seo.mdx
@@ -1,12 +1,9 @@
 ---
-title: "Ai Seo"
-description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup."
+title: "AI SEO"
+description: "Optimize content to be cited by AI search engines and LLMs. Use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'AI Overviews,' 'optimize for ChatGPT/Perplexity/Claude,' 'AI citations,' or 'how do I show up in AI answers.' For traditional SEO audits, see seo-audit. For structured data, see schema-markup."
 category: Marketing
 integrations: []
 ---
-
-
-# AI SEO
 
 You are an expert in AI search optimization — the practice of making content discoverable, extractable, and citable by AI systems including Google AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and Copilot. Your goal is to help users get their content cited as a source in AI-generated answers.
 
@@ -18,22 +15,26 @@ If `.agents/product-marketing-context.md` exists (or `.claude/product-marketing-
 Gather this context (ask if not provided):
 
 ### 1. Current AI Visibility
+
 - Do you know if your brand appears in AI-generated answers today?
 - Have you checked ChatGPT, Perplexity, or Google AI Overviews for your key queries?
 - What queries matter most to your business?
 
 ### 2. Content & Domain
+
 - What type of content do you produce? (Blog, docs, comparisons, product pages)
 - What's your domain authority / traditional SEO strength?
 - Do you have existing structured data (schema markup)?
 
 ### 3. Goals
+
 - Get cited as a source in AI answers?
 - Appear in Google AI Overviews for specific queries?
 - Compete with specific brands already getting cited?
 - Optimize existing content or create new AI-optimized content?
 
 ### 4. Competitive Landscape
+
 - Who are your top competitors in AI search results?
 - Are they being cited where you're not?
 
@@ -43,14 +44,14 @@ Gather this context (ask if not provided):
 
 ### The AI Search Landscape
 
-| Platform | How It Works | Source Selection |
-|----------|-------------|----------------|
-| **Google AI Overviews** | Summarizes top-ranking pages | Strong correlation with traditional rankings |
-| **ChatGPT (with search)** | Searches web, cites sources | Draws from wider range, not just top-ranked |
-| **Perplexity** | Always cites sources with links | Favors authoritative, recent, well-structured content |
-| **Gemini** | Google's AI assistant | Pulls from Google index + Knowledge Graph |
-| **Copilot** | Bing-powered AI search | Bing index + authoritative sources |
-| **Claude** | Brave Search (when enabled) | Training data + Brave search results |
+| Platform                  | How It Works                    | Source Selection                                      |
+| ------------------------- | ------------------------------- | ----------------------------------------------------- |
+| **Google AI Overviews**   | Summarizes top-ranking pages    | Strong correlation with traditional rankings          |
+| **ChatGPT (with search)** | Searches web, cites sources     | Draws from wider range, not just top-ranked           |
+| **Perplexity**            | Always cites sources with links | Favors authoritative, recent, well-structured content |
+| **Gemini**                | Google's AI assistant           | Pulls from Google index + Knowledge Graph             |
+| **Copilot**               | Bing-powered AI search          | Bing index + authoritative sources                    |
+| **Claude**                | Brave Search (when enabled)     | Training data + Brave search results                  |
 
 For a deep dive on how each platform selects sources and what to optimize per platform, see [references/platform-ranking-factors.md](references/platform-ranking-factors.md).
 
@@ -61,6 +62,7 @@ Traditional SEO gets you ranked. AI SEO gets you **cited**.
 In traditional search, you need to rank on page 1. In AI search, a well-structured page can get cited even if it ranks on page 2 or 3 — AI systems select sources based on content quality, structure, and relevance, not just rank position.
 
 **Critical stats:**
+
 - AI Overviews appear in ~45% of Google searches
 - AI Overviews reduce clicks to websites by up to 58%
 - Brands are 6.5x more likely to be cited via third-party sources than their own domains
@@ -77,12 +79,13 @@ Before optimizing, assess your current AI search presence.
 
 Test 10-20 of your most important queries across platforms:
 
-| Query | Google AI Overview | ChatGPT | Perplexity | You Cited? | Competitors Cited? |
-|-------|:-----------------:|:-------:|:----------:|:----------:|:-----------------:|
-| [query 1] | Yes/No | Yes/No | Yes/No | Yes/No | [who] |
-| [query 2] | Yes/No | Yes/No | Yes/No | Yes/No | [who] |
+| Query     | Google AI Overview | ChatGPT | Perplexity | You Cited? | Competitors Cited? |
+| --------- | :----------------: | :-----: | :--------: | :--------: | :----------------: |
+| [query 1] |       Yes/No       | Yes/No  |   Yes/No   |   Yes/No   |       [who]        |
+| [query 2] |       Yes/No       | Yes/No  |   Yes/No   |   Yes/No   |       [who]        |
 
 **Query types to test:**
+
 - "What is [your product category]?"
 - "Best [product category] for [use case]"
 - "[Your brand] vs [competitor]"
@@ -92,6 +95,7 @@ Test 10-20 of your most important queries across platforms:
 ### Step 2: Analyze Citation Patterns
 
 When your competitors get cited and you don't, examine:
+
 - **Content structure** — Is their content more extractable?
 - **Authority signals** — Do they have more citations, stats, expert quotes?
 - **Freshness** — Is their content more recently updated?
@@ -102,18 +106,18 @@ When your competitors get cited and you don't, examine:
 
 For each priority page, verify:
 
-| Check | Pass/Fail |
-|-------|-----------|
-| Clear definition in first paragraph? | |
-| Self-contained answer blocks (work without surrounding context)? | |
-| Statistics with sources cited? | |
-| Comparison tables for "[X] vs [Y]" queries? | |
-| FAQ section with natural-language questions? | |
-| Schema markup (FAQ, HowTo, Article, Product)? | |
-| Expert attribution (author name, credentials)? | |
-| Recently updated (within 6 months)? | |
-| Heading structure matches query patterns? | |
-| AI bots allowed in robots.txt? | |
+| Check                                                            | Pass/Fail |
+| ---------------------------------------------------------------- | --------- |
+| Clear definition in first paragraph?                             |           |
+| Self-contained answer blocks (work without surrounding context)? |           |
+| Statistics with sources cited?                                   |           |
+| Comparison tables for "[X] vs [Y]" queries?                      |           |
+| FAQ section with natural-language questions?                     |           |
+| Schema markup (FAQ, HowTo, Article, Product)?                    |           |
+| Expert attribution (author name, credentials)?                   |           |
+| Recently updated (within 6 months)?                              |           |
+| Heading structure matches query patterns?                        |           |
+| AI bots allowed in robots.txt?                                   |           |
 
 ### Step 4: AI Bot Access Check
 
@@ -146,6 +150,7 @@ See [references/platform-ranking-factors.md](references/platform-ranking-factors
 AI systems extract passages, not pages. Every key claim should work as a standalone statement.
 
 **Content block patterns:**
+
 - **Definition blocks** for "What is X?" queries
 - **Step-by-step blocks** for "How to X" queries
 - **Comparison tables** for "X vs Y" queries
@@ -156,6 +161,7 @@ AI systems extract passages, not pages. Every key claim should work as a standal
 For detailed templates for each block type, see [references/content-patterns.md](references/content-patterns.md).
 
 **Structural rules:**
+
 - Lead every section with a direct answer (don't bury it)
 - Keep key answer passages to 40-60 words (optimal for snippet extraction)
 - Use H2/H3 headings that match how people phrase queries
@@ -169,39 +175,43 @@ AI systems prefer sources they can trust. Build citation-worthiness.
 
 **The Princeton GEO research** (KDD 2024, studied across Perplexity.ai) ranked 9 optimization methods:
 
-| Method | Visibility Boost | How to Apply |
-|--------|:---------------:|--------------|
-| **Cite sources** | +40% | Add authoritative references with links |
-| **Add statistics** | +37% | Include specific numbers with sources |
-| **Add quotations** | +30% | Expert quotes with name and title |
-| **Authoritative tone** | +25% | Write with demonstrated expertise |
-| **Improve clarity** | +20% | Simplify complex concepts |
-| **Technical terms** | +18% | Use domain-specific terminology |
-| **Unique vocabulary** | +15% | Increase word diversity |
-| **Fluency optimization** | +15-30% | Improve readability and flow |
-| ~~Keyword stuffing~~ | **-10%** | **Actively hurts AI visibility** |
+| Method                   | Visibility Boost | How to Apply                            |
+| ------------------------ | :--------------: | --------------------------------------- |
+| **Cite sources**         |       +40%       | Add authoritative references with links |
+| **Add statistics**       |       +37%       | Include specific numbers with sources   |
+| **Add quotations**       |       +30%       | Expert quotes with name and title       |
+| **Authoritative tone**   |       +25%       | Write with demonstrated expertise       |
+| **Improve clarity**      |       +20%       | Simplify complex concepts               |
+| **Technical terms**      |       +18%       | Use domain-specific terminology         |
+| **Unique vocabulary**    |       +15%       | Increase word diversity                 |
+| **Fluency optimization** |     +15-30%      | Improve readability and flow            |
+| ~~Keyword stuffing~~     |     **-10%**     | **Actively hurts AI visibility**        |
 
 **Best combination:** Fluency + Statistics = maximum boost. Low-ranking sites benefit even more — up to 115% visibility increase with citations.
 
 **Statistics and data** (+37-40% citation boost)
+
 - Include specific numbers with sources
 - Cite original research, not summaries of research
 - Add dates to all statistics
 - Original data beats aggregated data
 
 **Expert attribution** (+25-30% citation boost)
+
 - Named authors with credentials
 - Expert quotes with titles and organizations
 - "According to [Source]" framing for claims
 - Author bios with relevant expertise
 
 **Freshness signals**
+
 - "Last updated: [date]" prominently displayed
 - Regular content refreshes (quarterly minimum for competitive topics)
 - Current year references and recent statistics
 - Remove or update outdated information
 
 **E-E-A-T alignment**
+
 - First-hand experience demonstrated
 - Specific, detailed information (not generic)
 - Transparent sourcing and methodology
@@ -212,6 +222,7 @@ AI systems prefer sources they can trust. Build citation-worthiness.
 AI systems don't just cite your website — they cite where you appear.
 
 **Third-party sources matter more than your own site:**
+
 - Wikipedia mentions (7.8% of all ChatGPT citations)
 - Reddit discussions (1.8% of ChatGPT citations)
 - Industry publications and guest posts
@@ -220,6 +231,7 @@ AI systems don't just cite your website — they cite where you appear.
 - Quora answers
 
 **Actions:**
+
 - Ensure your Wikipedia page is accurate and current
 - Participate authentically in Reddit communities
 - Get featured in industry roundups and comparison articles
@@ -231,15 +243,15 @@ AI systems don't just cite your website — they cite where you appear.
 
 Structured data helps AI systems understand your content. Key schemas:
 
-| Content Type | Schema | Why It Helps |
-|-------------|--------|-------------|
-| Articles/Blog posts | `Article`, `BlogPosting` | Author, date, topic identification |
-| How-to content | `HowTo` | Step extraction for process queries |
-| FAQs | `FAQPage` | Direct Q&A extraction |
-| Products | `Product` | Pricing, features, reviews |
-| Comparisons | `ItemList` | Structured comparison data |
-| Reviews | `Review`, `AggregateRating` | Trust signals |
-| Organization | `Organization` | Entity recognition |
+| Content Type        | Schema                      | Why It Helps                        |
+| ------------------- | --------------------------- | ----------------------------------- |
+| Articles/Blog posts | `Article`, `BlogPosting`    | Author, date, topic identification  |
+| How-to content      | `HowTo`                     | Step extraction for process queries |
+| FAQs                | `FAQPage`                   | Direct Q&A extraction               |
+| Products            | `Product`                   | Pricing, features, reviews          |
+| Comparisons         | `ItemList`                  | Structured comparison data          |
+| Reviews             | `Review`, `AggregateRating` | Trust signals                       |
+| Organization        | `Organization`              | Entity recognition                  |
 
 Content with proper schema shows 30-40% higher AI visibility. For implementation, use the **schema-markup** skill.
 
@@ -249,17 +261,18 @@ Content with proper schema shows 30-40% higher AI visibility. For implementation
 
 Not all content is equally citable. Prioritize these formats:
 
-| Content Type | Citation Share | Why AI Cites It |
-|-------------|:------------:|----------------|
-| **Comparison articles** | ~33% | Structured, balanced, high-intent |
-| **Definitive guides** | ~15% | Comprehensive, authoritative |
-| **Original research/data** | ~12% | Unique, citable statistics |
-| **Best-of/listicles** | ~10% | Clear structure, entity-rich |
-| **Product pages** | ~10% | Specific details AI can extract |
-| **How-to guides** | ~8% | Step-by-step structure |
-| **Opinion/analysis** | ~10% | Expert perspective, quotable |
+| Content Type               | Citation Share | Why AI Cites It                   |
+| -------------------------- | :------------: | --------------------------------- |
+| **Comparison articles**    |      ~33%      | Structured, balanced, high-intent |
+| **Definitive guides**      |      ~15%      | Comprehensive, authoritative      |
+| **Original research/data** |      ~12%      | Unique, citable statistics        |
+| **Best-of/listicles**      |      ~10%      | Clear structure, entity-rich      |
+| **Product pages**          |      ~10%      | Specific details AI can extract   |
+| **How-to guides**          |      ~8%       | Step-by-step structure            |
+| **Opinion/analysis**       |      ~10%      | Expert perspective, quotable      |
 
 **Underperformers for AI citation:**
+
 - Generic blog posts without structure
 - Thin product pages with marketing fluff
 - Gated content (AI can't access it)
@@ -272,26 +285,27 @@ Not all content is equally citable. Prioritize these formats:
 
 ### What to Track
 
-| Metric | What It Measures | How to Check |
-|--------|-----------------|-------------|
-| AI Overview presence | Do AI Overviews appear for your queries? | Manual check or Semrush/Ahrefs |
-| Brand citation rate | How often you're cited in AI answers | AI visibility tools (see below) |
-| Share of AI voice | Your citations vs. competitors | Peec AI, Otterly, ZipTie |
-| Citation sentiment | How AI describes your brand | Manual review + monitoring tools |
-| Source attribution | Which of your pages get cited | Track referral traffic from AI sources |
+| Metric               | What It Measures                         | How to Check                           |
+| -------------------- | ---------------------------------------- | -------------------------------------- |
+| AI Overview presence | Do AI Overviews appear for your queries? | Manual check or Semrush/Ahrefs         |
+| Brand citation rate  | How often you're cited in AI answers     | AI visibility tools (see below)        |
+| Share of AI voice    | Your citations vs. competitors           | Peec AI, Otterly, ZipTie               |
+| Citation sentiment   | How AI describes your brand              | Manual review + monitoring tools       |
+| Source attribution   | Which of your pages get cited            | Track referral traffic from AI sources |
 
 ### AI Visibility Monitoring Tools
 
-| Tool | Coverage | Best For |
-|------|----------|----------|
-| **Otterly AI** | ChatGPT, Perplexity, Google AI Overviews | Share of AI voice tracking |
-| **Peec AI** | ChatGPT, Gemini, Perplexity, Claude, Copilot+ | Multi-platform monitoring at scale |
-| **ZipTie** | Google AI Overviews, ChatGPT, Perplexity | Brand mention + sentiment tracking |
-| **LLMrefs** | ChatGPT, Perplexity, AI Overviews, Gemini | SEO keyword → AI visibility mapping |
+| Tool           | Coverage                                      | Best For                            |
+| -------------- | --------------------------------------------- | ----------------------------------- |
+| **Otterly AI** | ChatGPT, Perplexity, Google AI Overviews      | Share of AI voice tracking          |
+| **Peec AI**    | ChatGPT, Gemini, Perplexity, Claude, Copilot+ | Multi-platform monitoring at scale  |
+| **ZipTie**     | Google AI Overviews, ChatGPT, Perplexity      | Brand mention + sentiment tracking  |
+| **LLMrefs**    | ChatGPT, Perplexity, AI Overviews, Gemini     | SEO keyword → AI visibility mapping |
 
 ### DIY Monitoring (No Tools)
 
 Monthly manual check:
+
 1. Pick your top 20 queries
 2. Run each through ChatGPT, Perplexity, and Google
 3. Record: Are you cited? Who is? What page?
@@ -306,6 +320,7 @@ Monthly manual check:
 **Goal:** Get cited in "What is [category]?" and "Best [category]" queries.
 
 **Optimize:**
+
 - Clear product description in first paragraph (what it does, who it's for)
 - Feature comparison tables (you vs. category, not just competitors)
 - Specific metrics ("processes 10,000 transactions/sec" not "blazing fast")
@@ -318,6 +333,7 @@ Monthly manual check:
 **Goal:** Get cited as an authoritative source on topics in your space.
 
 **Optimize:**
+
 - One clear target query per post (match heading to query)
 - Definition in first paragraph for "What is" queries
 - Original data, research, or expert quotes
@@ -330,6 +346,7 @@ Monthly manual check:
 **Goal:** Get cited in "[X] vs [Y]" and "Best [X] alternatives" queries.
 
 **Optimize:**
+
 - Structured comparison tables (not just prose)
 - Fair and balanced (AI penalizes obviously biased comparisons)
 - Specific criteria with ratings or scores
@@ -341,6 +358,7 @@ Monthly manual check:
 **Goal:** Get cited in "How to [X] with [your product]" queries.
 
 **Optimize:**
+
 - Step-by-step format with numbered lists
 - Code examples where relevant
 - HowTo schema markup
@@ -369,12 +387,12 @@ Monthly manual check:
 
 For implementation, see the [tools registry](../../tools/REGISTRY.md).
 
-| Tool | Use For |
-|------|---------|
+| Tool      | Use For                                                      |
+| --------- | ------------------------------------------------------------ |
 | `semrush` | AI Overview tracking, keyword research, content gap analysis |
-| `ahrefs` | Backlink analysis, content explorer, AI Overview data |
-| `gsc` | Search Console performance data, query tracking |
-| `ga4` | Referral traffic from AI sources |
+| `ahrefs`  | Backlink analysis, content explorer, AI Overview data        |
+| `gsc`     | Search Console performance data, query tracking              |
+| `ga4`     | Referral traffic from AI sources                             |
 
 ---
 

--- a/docs/skills/beachhead_segment.mdx
+++ b/docs/skills/beachhead_segment.mdx
@@ -133,7 +133,7 @@ Define:
 - **Sales motion:** How will you sell? (Self-serve, free trial, direct sales, partnerships)
 - **Channels:** Top 2–3 ways to reach customers in this segment
 - **Customer acquisition goals:** How many customers do you want in the beachhead in [months]?
-- **Success metrics:** What proves the beachhead is working? (E.g., 20 paying customers, $5k MRR, <$500 CAC)
+- **Success metrics:** What proves the beachhead is working? (E.g., 20 paying customers, $5k MRR, \<$500 CAC)
 - **Expansion triggers:** When and how will you expand to the next segment?
 
 Keep the plan focused: avoid distractions. Say "no" to requests from other segments until beachhead goals are met.
@@ -198,7 +198,7 @@ Output: Beachhead-focused GTM roadmap.
 ## Edge Cases
 
 - **No clear winner:** If two segments score similarly, recommend starting with the one where you have an insider or first customer (proof of concept trumps analysis).
-- **Very small beachhead:** If the beachhead segment is small (e.g., <100 companies), validate that expansion paths exist before committing. A tiny beachhead can be a dead-end.
+- **Very small beachhead:** If the beachhead segment is small (e.g., \<100 companies), validate that expansion paths exist before committing. A tiny beachhead can be a dead-end.
 - **Requires partnership to access:** If the easiest beachhead requires a partnership to reach (e.g., reseller, channel), factor partnership time-to-activation into the plan. May take 3–6 months before revenue flows.
 - **Conflicting feedback from customers:** If customers in the beachhead want different things, use frequency of requests to prioritize. If the top 3 customers want different features, ask which is blocking their purchase → prioritize that.
 - **Market shift during execution:** If a different segment suddenly becomes hot (regulatory change, competitor entry, new technology), reassess quarterly. Beachhead is not forever; be willing to pivot if data changes.

--- a/docs/skills/churn_prevention.mdx
+++ b/docs/skills/churn_prevention.mdx
@@ -120,7 +120,7 @@ Establish baseline and target metrics:
 
 | Metric | Target |
 |--------|--------|
-| Monthly churn rate | <5% B2C / <2% B2B |
+| Monthly churn rate | \<5% B2C / \<2% B2B |
 | Revenue churn | Negative (net expansion) |
 | Cancel flow save rate | 25-35% |
 | Offer acceptance rate | 15-25% |

--- a/docs/skills/cohort_analysis.mdx
+++ b/docs/skills/cohort_analysis.mdx
@@ -65,7 +65,7 @@ For each cohort, measure how many users remain active at Day 7, Day 30, Day 60, 
 - If a user has no activity on a given day, they are counted as churned
 - Round percentages to whole numbers
 
-Flag cohorts with <50% 7-day retention as high-churn.
+Flag cohorts with \<50% 7-day retention as high-churn.
 
 ## Step 5: Identify Trends and Patterns
 
@@ -106,7 +106,7 @@ Structure the analysis into a cohort table and trend summary.
 - 📊 Activation rates: [Improving / Declining / Stable]
 - 📊 7-day retention: [Average X%, range Y–Z%]
 - 📊 30-day retention: [Average X%, range Y–Z%]
-- 🚨 High-churn cohorts: [List cohorts <50% 7-day retention, or "None"]
+- 🚨 High-churn cohorts: [List cohorts \<50% 7-day retention, or "None"]
 
 **Key Insights**
 1. [Most recent cohort health]
@@ -117,7 +117,7 @@ Structure the analysis into a cohort table and trend summary.
 
 ## Edge Cases
 
-- **Insufficient data:** If fewer than 3 cohorts or <100 total users exist, note "Cohort sample too small for reliable trends" and show available data only.
+- **Insufficient data:** If fewer than 3 cohorts or \<100 total users exist, note "Cohort sample too small for reliable trends" and show available data only.
 - **No retention data:** If users have no activity after signup (all churn on Day 0), show 0% retention and flag data quality.
 - **Future signups:** Exclude any users with signup dates in the future; silently filter.
 - **Custom time zones:** If user has specified a time zone in memory, adjust cohort boundaries accordingly (e.g., "week starts Monday at midnight PST").

--- a/docs/skills/cold_email.mdx
+++ b/docs/skills/cold_email.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Cold Email"
-description: "Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails, prospecting emails, cold email campaigns, sales development emails, or SDR emails. Also use when the user mentions "cold outreach," "prospecting email," "outbound email," "email to leads," "reach out to prospects," "sales email," "follow-up email sequence," "nobody's replying to my emails," or "how do I write a cold email." Covers subject lines, opening lines, body copy, CTAs, personalization, and multi-touch follow-up sequences. For warm/lifecycle email sequences, see email-sequence. For sales collateral beyond emails, see sales-enablement."
+description: "Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails, prospecting emails, cold email campaigns, sales development emails, or SDR emails. Also use when the user mentions 'cold outreach,' 'prospecting email,' 'outbound email,' 'email to leads,' 'reach out to prospects,' 'sales email,' 'follow-up email sequence,' 'nobody's replying to my emails,' or 'how do I write a cold email.' Covers subject lines, opening lines, body copy, CTAs, personalization, and multi-touch follow-up sequences. For warm/lifecycle email sequences, see email-sequence. For sales collateral beyond emails, see sales-enablement."
 category: Marketing
 integrations: []
 ---
-
 
 # Cold Email Writing
 

--- a/docs/skills/content_strategy.mdx
+++ b/docs/skills/content_strategy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Content Strategy"
-description: "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions "content strategy," "what should I write about," "content ideas," "blog strategy," "topic clusters," "content planning," "editorial calendar," "content marketing," "content roadmap," "what content should I create," "blog topics," "content pillars," or "I don't know what to write." Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content."
+description: "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions 'content strategy,' 'what should I write about,' 'content ideas,' 'blog strategy,' 'topic clusters,' 'content planning,' 'editorial calendar,' 'content marketing,' 'content roadmap,' 'what content should I create,' 'blog topics,' 'content pillars,' or 'I don't know what to write.' Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content."
 category: Marketing
 integrations: []
 ---

--- a/docs/skills/copywriting.mdx
+++ b/docs/skills/copywriting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Copywriting"
-description: "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says "write copy for," "improve this copy," "rewrite this page," "marketing copy," "headline help," "CTA copy," "value proposition," "tagline," "subheadline," "hero section copy," "above the fold," "this copy is weak," "make this more compelling," or "help me describe my product." Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing."
+description: "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says 'write copy for,' 'improve this copy,' 'rewrite this page,' 'marketing copy,' 'headline help,' 'CTA copy,' 'value proposition,' 'tagline,' 'subheadline,' 'hero section copy,' 'above the fold,' 'this copy is weak,' 'make this more compelling,' or 'help me describe my product.' Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing."
 category: Marketing
 integrations: []
 ---
@@ -114,10 +114,10 @@ Puns and wit make copy memorable—but only if it fits the brand and doesn't und
 - Specific > generic
 
 **Example formulas:**
-- "{Achieve outcome} without {pain point}"
-- "The {category} for {audience}"
-- "Never {unpleasant event} again"
-- "{Question highlighting main pain point}"
+- `{Achieve outcome} without {pain point}`
+- `The {category} for {audience}`
+- `Never {unpleasant event} again`
+- `{Question highlighting main pain point}`
 
 **For comprehensive headline formulas**: See [references/copy-frameworks.md](references/copy-frameworks.md)
 

--- a/docs/skills/design_growth_loops.mdx
+++ b/docs/skills/design_growth_loops.mdx
@@ -42,7 +42,7 @@ Calculate the multiplier effect:
 
 For each stage, ask:
 - **Is the trigger compelling?** Easy to understand why they should act?
-- **Is the action frictionless?** Can they do it in <30 seconds?
+- **Is the action frictionless?** Can they do it in \<30 seconds?
 - **Is the reward immediate?** Do they feel value right away?
 - **Is the invite natural?** Does inviting others feel organic, not transactional?
 

--- a/docs/skills/email_sequence.mdx
+++ b/docs/skills/email_sequence.mdx
@@ -165,7 +165,7 @@ Provide complete sequence documentation.
 | Open rate | [expected %] | Benchmark by type |
 | Click rate | [expected %] | Engagement signal |
 | Conversion | [#] | Primary success metric |
-| Unsubscribe rate | <0.5% | Monitor for relevance |
+| Unsubscribe rate | \<0.5% | Monitor for relevance |
 
 ---
 

--- a/docs/skills/free_tool_strategy.mdx
+++ b/docs/skills/free_tool_strategy.mdx
@@ -79,7 +79,7 @@ Rate each factor 1-5:
 | Link-building potential | ___ |
 | Share-worthiness | ___ |
 
-Scores: 25+ = Strong candidate | 15-24 = Promising | <15 = Reconsider
+Scores: 25+ = Strong candidate | 15-24 = Promising | \<15 = Reconsider
 
 ## Step 4: Design Lead Capture Strategy
 

--- a/docs/skills/market_sizing.mdx
+++ b/docs/skills/market_sizing.mdx
@@ -169,8 +169,8 @@ Create ranges (conservative, base case, optimistic) instead of point estimates.
 
 ## Edge Cases
 
-- **TAM is too big (>$100B):** Ask: "Are you really addressable to all of that?" Define SAM more tightly. Most early-stage companies should target SAM <$1B.
-- **TAM is too small (<$100M):** Ask: "Is this the right problem? Should we expand to adjacent problems?" A venture-scale business needs >$100M opportunity minimum.
+- **TAM is too big (>$100B):** Ask: "Are you really addressable to all of that?" Define SAM more tightly. Most early-stage companies should target SAM \<$1B.
+- **TAM is too small (\<$100M):** Ask: "Is this the right problem? Should we expand to adjacent problems?" A venture-scale business needs >$100M opportunity minimum.
 - **Approaches diverge significantly:** Something's wrong. Ask: "Which assumption is most questionable?" Dig into the gap.
 - **Market is shrinking or flat:** Ask: "Is this the right market, or should we pivot?" A declining TAM is a strategic red flag.
 - **You can't find data:** Use triangulation. Combine customer surveys, competitor financial data, industry reports, and analogous markets. Document confidence level clearly.

--- a/docs/skills/paid_ads.mdx
+++ b/docs/skills/paid_ads.mdx
@@ -217,7 +217,7 @@ LI_LeadGen_CMOs-SaaS_Whitepaper_Mar24
 ### Exclusions to Set Up
 - Existing customers (unless upsell)
 - Recent converters (7-14 day window)
-- Bounced visitors (<10 sec)
+- Bounced visitors (\<10 sec)
 - Irrelevant pages (careers, support)
 
 ---
@@ -248,7 +248,7 @@ Before launching campaigns, ensure proper tracking and account setup.
 
 ### Universal Pre-Launch Checklist
 - [ ] Conversion tracking tested with real conversion
-- [ ] Landing page loads fast (<3 sec)
+- [ ] Landing page loads fast (\<3 sec)
 - [ ] Landing page mobile-friendly
 - [ ] UTM parameters working
 - [ ] Budget set correctly

--- a/docs/skills/pricing_strategy.mdx
+++ b/docs/skills/pricing_strategy.mdx
@@ -152,7 +152,7 @@ Identifies which features customers value most:
 
 **Business signals:**
 - Very high conversion rates (>40%)
-- Very low churn (<3% monthly)
+- Very low churn (\<3% monthly)
 - Strong unit economics
 
 **Product signals:**

--- a/docs/skills/sales_pipeline_review.mdx
+++ b/docs/skills/sales_pipeline_review.mdx
@@ -198,8 +198,8 @@ Coverage assessment:
 |----------|-----------|
 | 3x+ | Healthy |
 | 2–3x | Adequate |
-| <2x | At risk |
-| <1x | Critical |
+| \<2x | At risk |
+| \<1x | Critical |
 
 ## Step 3: Generate Report
 
@@ -245,13 +245,13 @@ Each recommendation must cite the specific data point that drives it. Apply this
 
 | Pattern | Recommendation |
 |---------|---------------|
-| Qualification rate <40% | Tighten ICP targeting — top DQ reason is [X] |
+| Qualification rate \<40% | Tighten ICP targeting — top DQ reason is [X] |
 | No-show rate >20% | Implement confirmation reminders 24h and 1h before meetings |
 | One source >60% of pipeline | Diversify — if this channel underperforms, pipeline collapses |
 | High-quality source with low volume | Scale it — [source] has [X]% qual rate but only [Y]% of volume |
 | Deals stuck in a specific stage | Unblock [stage] — [N] deals averaging [Y] days (2× normal) |
 | Win rate declining | Win rate dropped from [X]% to [Y]% — top loss reason is now [Z] |
-| Pipeline coverage <2x | Need [Z] more qualified deals — requires [W] meetings at current rates |
+| Pipeline coverage \<2x | Need [Z] more qualified deals — requires [W] meetings at current rates |
 | Cycle lengthening | Bottleneck at [stage] — deals [X] days slower vs prior period |
 
 Present the executive summary first, then offer the detailed diagnostic:

--- a/docs/skills/schema_markup.mdx
+++ b/docs/skills/schema_markup.mdx
@@ -160,7 +160,7 @@ After deployment:
 
 **Implementation Plan**
 - Static / Dynamic: [How content is delivered]
-- Placement: [<head> or end of <body>]
+- Placement: [`<head>` or end of `<body>`]
 - Testing: [Rich Results Test pass?]
 
 **Rich Results Expected**

--- a/docs/skills/weekly_learning_summary.mdx
+++ b/docs/skills/weekly_learning_summary.mdx
@@ -2,34 +2,66 @@
 title: "Weekly Learning Summary"
 description: "Generate a narrative summary of what CORE learned about you over the past week. Covers topics discussed, people mentioned, new facts learned, and key conversation threads. Trigger with 'what did you learn about me', 'weekly summary', 'weekly digest', 'summarize last week', or 'what's new in my memory'."
 category: Planning
-integrations: '[]'
+integrations: []
 ---
 
-**Goal:** Produce a concise, personal recap of everything CORE learned about the user over a given time period — written like an intelligent personal assistant, not a data dump.
+**Goal:** Produce a concise, personal recap of everything CORE learned about the user over a given time period — written like a thoughtful debrief from an assistant who's been paying attention, not a data dump or dashboard readout.
 
-**Tools Required:** `gather_context` (memory). No external integrations needed.
+## Tools Required
+
+This skill uses `memory_explorer` (temporal_facets). No external integrations needed.
 
 **Trigger:** On-demand ("what did you learn this week") or via a weekly reminder. Deliver output in the channel this skill is triggered from.
 
-Channel constraint: If the channel has a message length limit (e.g. WhatsApp), split the summary into shorter messages. Send the overview first, then one message per major section.
+**Channel constraint:** If the channel has a message length limit (e.g. WhatsApp), split the summary into shorter messages. Send the overview first, then one message per major section.
 
 ---
 
-### Step 1 — Fetch the Data
+## Step 1: Fetch the Data
 
-Call `gather_context` with a query describing the time range. Examples:
-- Default (7 days): `"Give me an overview of the last 7 days — topics, people, and what was learned"`
-- If user says "this month": `"Give me an overview of the last 30 days — topics, people, and what was learned"`
-- If user says "last 3 days": `"Give me an overview of the last 3 days — topics, people, and what was learned"`
+Break the time range into smaller windows and run multiple `memory_explorer` calls to ensure complete coverage. Each call should explicitly request all aspect types.
 
-The response will contain these sections:
-- **Topics** — what subjects were discussed with episode counts
+**Window breakdown by range:**
+
+| Range | Calls | Window size |
+|-------|-------|-------------|
+| 7 days (default) | 3 calls | Days 1–2, 3–4, 5–7 |
+| 3 days | 2 calls | Days 1–2, Day 3 |
+| 14 days | 5 calls | 4 × 3 days, 1 × 2 days |
+| 30 days | 10 calls | 10 × 3 days |
+
+**Query format for each call:**
+
+In the `memory_explorer` tool call, use the `temporal_facets` tool only. Use this exact query structure (adjust dates per window):
+
+```
+Give me an overview of [DATE_START] to [DATE_END]. Include all aspect types: Identity, Event,
+Task, Knowledge, Relationship, Decision, Problem. Limit to 30 fact statements per aspect type.
+Include topics with episode counts, people and entities with mention counts, and conversation
+highlights for top topics. USE temporal_facets tool call in memory explorer. Only return
+facets, we don't need episodes.
+```
+
+**What each response contains:**
+
+- **Topics** — subjects discussed with episode counts
 - **People & Entities** — who was mentioned with mention counts
-- **By Aspect** — new facts grouped by type (Preference, Goal, Decision, etc.) with individual fact statements
+- **By Aspect** — new facts grouped by these 7 types (up to 30 each):
+  - **Identity** — who the user is, preferences, habits, personal attributes
+  - **Event** — things that happened, meetings, milestones, occurrences
+  - **Task** — action items, to-dos, assignments, pending work
+  - **Knowledge** — things learned, technical details, system information
+  - **Relationship** — connections between people, organizations, dynamics
+  - **Decision** — choices made, directions taken, options evaluated
+  - **Problem** — issues encountered, bugs, blockers, unresolved friction
 - **Conversation Highlights** — latest conversation content per top topic (up to 10 topics, truncated to 2000 chars each)
-- **Stats line** — `N conversations · N new facts · N topics`
+- **Stats line** — N conversations · N new facts · N topics
 
-If the response contains no topics AND no facts, respond:
+If the response doesn't match this structure, retry with a different query.
+
+**After all calls complete:** Merge the results mentally. Combine topic counts, deduplicate people/entities, and union the fact statements across all windows before proceeding to Step 2.
+
+If the merged response contains no topics AND no facts, respond:
 
 > "Quiet week — I didn't pick up anything new. Want me to check a longer time range?"
 
@@ -37,53 +69,145 @@ Do not generate a summary from empty data.
 
 ---
 
-### Step 2 — Write the Summary
+## Step 2: Process Before Writing
 
-Use the data from `gather_context` to write a narrative recap. Follow these rules:
+Before writing anything, run these filters on the merged data:
 
-**Tone:** Write like a thoughtful personal assistant giving a debrief — warm but concise, not robotic. First person ("I learned", "I noticed", "You discussed").
+### Sensitivity filter (hard rule — never violate)
 
-**Structure the output in this order:**
+Do not surface any of the following in the summary:
+- **Financial account details:** transaction amounts, policy numbers, account numbers, IBAN/SWIFT codes
+- **Security information:** sign-in locations, recovery emails, 2FA codes, authorization alerts
+- **Tax filing specifics:** GST numbers, ARN numbers, PAN numbers, filing reference IDs
+- **Insurance details:** policy numbers, claim IDs, service request numbers
 
-1. **Opening line** — One sentence capturing the feel of the period. Reference the stats naturally.
-   - Example: "This was a busy week — I tracked 47 conversations across 11 topics."
-   - Example: "Lighter week. 12 conversations, mostly around two themes."
+If these topics came up, reference the category only: "You dealt with some tax filings" or "There were a few banking-related threads" — never the specifics.
 
-2. **What you were focused on** — Walk through the top 3-5 topics by episode count. For each, use the compact session summary to add 1-2 sentences of context about what was discussed. Don't just list topic names — explain what happened.
-   - Example: "You spent the most time on **Gmail / Email Management** (12 conversations) — mostly triaging inbox, setting up filters, and handling a few urgent threads from vendors."
+### Deduplication rule
 
-3. **People in the picture** — Mention the top entities naturally, weaving them into the topic context where possible rather than listing separately.
-   - Example: "Matt Starfield came up 3 times, mostly around the account cancellation follow-up."
+When the same fact appears across multiple episodes or windows, surface it exactly once. Only mention the repetition count if the pattern itself is the insight (e.g., "MCP disconnection came up across 3 separate users this week — that's a recurring theme worth noting").
 
-4. **Things I now know about you** — List new facts grouped by aspect type. Present these as observations, not database entries.
-   - Example: "I picked up a few new things about your preferences: you prefer Slack over email for quick updates, you block Monday mornings for deep work, and you want calendar invites to always include a video link."
+### Noise filter
 
-5. **By the numbers** — End with a compact stats line.
-   - Format: `[totalEpisodes] conversations · [newFacts] new facts · [activeTopics] topics`
-
-**Writing rules:**
-- Lead with insight, not data structure. Never say "here are your topics" or "the entities are."
-- If a topic has a compact session, use it to ground your description. Don't invent details.
-- Keep the total output under 500 words for the default 7-day summary. Shorter periods should be proportionally shorter.
-- If a section has nothing meaningful (e.g. no entities), skip it entirely. Don't write "No people mentioned."
-- Group related topics if they overlap (e.g. "CORE Product" and "CORE Development" can be one thread).
+Exclude entirely: automated reminder triggers (drink water, polling logs), system health checks, and repetitive automation pings. These inflate episode counts without adding insight. Adjust topic counts mentally before writing.
 
 ---
 
-### Step 3 — Present
+## Step 3: Write the Summary
+
+Use the processed data to write a narrative recap. Follow this structure in order:
+
+### 1. Your week in one line
+
+One sentence capturing what the period was about — the theme, not the stats.
+
+**Good:** "You spent most of this week shaping how the world sees CORE — the website, the positioning, the narrative — while keeping the product engine running underneath."
+
+**Good:** "Lighter week. Mostly heads-down on integrations with a couple of customer calls mixed in."
+
+**Bad:** "This was a busy week — I tracked 47 conversations across 11 topics." *(Stats-forward, says nothing about the user.)*
+
+### 2. Where your attention went
+
+Walk through the top 3–5 themes by episode count. For each, use conversation highlights to add 1–2 sentences of what actually happened — not just the topic name. Weave people into this section naturally rather than listing them separately.
+
+**Good:** "Integrations took the most time (24 conversations) — you shipped the Granola scaffold, iterated on Meta Ads, and debugged the Composio tool-not-found error. Muskan came up mostly in the context of dashboard design improvements."
+
+**Bad:** "Your top topics were: Integrations (24), Email Triage (15), Health (8). Top people: Muskan (5 mentions), Matt (6 mentions)."
+
+The goal is to reflect back where time actually went versus where the user might think it went. If there's a surprising distribution, name it.
+
+### 3. Decisions & how your thinking evolved
+
+This is the most important section. Pull from the **Decision** aspect type. Don't list isolated decisions — connect them into arcs that show how thinking changed over the period.
+
+**Good:** "You moved email triage from Todoist to CORE Tasks, then switched from scheduled to manual invocation. Two changes in the same direction: you're pulling triage closer to CORE's own system rather than relying on external tools."
+
+**Good:** "You rejected your own homepage taglines mid-week, called them generic, and by Thursday landed on 'AI gave you a copilot. You needed a butler.' That's a positioning shift from tool to category."
+
+**Bad:** "Decision: replaced Todoist with CORE Tasks. Decision: chose hero direction B."
+
+If no meaningful decision arcs exist this week, skip this section entirely.
+
+### 4. Something new about you
+
+1–2 observations max. Pull from the **Identity** aspect type. These are personal identity or preference signals that CORE picked up for the first time or that meaningfully changed — health preferences, communication style shifts, workflow changes, new tools adopted.
+
+**Good:** "First time I have a clear picture of your health direction: heart-healthy, high-fiber, form over load in the gym, 30–45 min strength plus zone 2 cardio."
+
+**Bad:** "New facts: you use Inkle, Apollo.io, Claude, Metabase, PostHog, Cal.com, Google Calendar, Brex, and HSBC via manik@poozle.dev."
+
+If nothing genuinely new was learned about the user as a person, skip this section.
+
+### 5. Relationship signals
+
+Pull from the **Relationship** aspect type. Surface changes in relationships — not mention counts. Who's new, who churned, who gave meaningful feedback, who you're waiting on.
+
+**Good:** "Matt Starfield churned — MCP disconnections were the breaking point. You closed the loop with a graceful follow-up. On the growth side, Divyaansh brought a YC F25 intro and you onboarded four new users."
+
+**Bad:** "Matt Starfield was mentioned 6 times. Muskan was mentioned 5 times."
+
+If no meaningful relationship changes happened, skip this section.
+
+### 6. Problems & friction
+
+Pull from the **Problem** aspect type. Surface recurring issues or blockers, not one-off errors. If the same problem shows up across multiple episodes, name it once and note the pattern.
+
+**Good:** "The asgard gateway wouldn't attach to the workspace across multiple attempts — blocking the Blinkit browser agent experiments. Separately, Gmail search kept hitting HTTP 500s during morning brief runs."
+
+**Bad:** "Problem: gateway not visible. Problem: HTTP 500. Problem: Granola auth expired."
+
+If no meaningful problems recurred, skip this section.
+
+### 7. Open threads
+
+Pull from **Task** and **Problem** aspect types. 2–4 items max. Things that are unresolved, waiting on someone else, or at risk of falling through the cracks. This turns the summary from retrospective into actionable.
+
+**Example:** "Still waiting on Ashok for HDFC account documents. Advance tax status remains unclear. Thomas hasn't replied about credits."
+
+If nothing is meaningfully unresolved, skip this section.
+
+### 8. By the numbers
+
+End with a single compact stats line. Sum across all `memory_explorer` windows:
+
+```
+[totalEpisodes] conversations · [newFacts] new facts · [activeTopics] topics
+```
+
+---
+
+## Step 4: Present
 
 Show the summary. Don't ask for confirmation — just deliver it.
 
-**Email subject:** When delivering via email, start your response with a `**Subject:**` line before the summary body. Generate a short, descriptive subject based on the content — not the skill name or reminder text.
-- Example: `**Subject:** Your week: task lifecycle, reminders, and 213 new facts`
-- Example: `**Subject:** Quiet week — mostly CORE dev and inbox triage`
-- Keep it under 80 characters, lowercase feel, no generic titles like "Weekly Summary"
+**Email subject:** When delivering via email, start your response with a **Subject:** line before the summary body. Generate a short, descriptive subject based on the content — not the skill name.
+
+**Example:** `Subject: This week: positioning locked, Matt churned, four new onboardings`
+
+**Example:** `Subject: Quiet week — mostly integrations and inbox triage`
+
+Keep it under 80 characters, lowercase feel, no generic titles like "Weekly Summary" or "What CORE Learned".
 
 ---
 
-### Edge Cases
+## Writing Rules
 
-- **Very few episodes (< 5)** → Keep it to 2-3 sentences. Don't pad.
-- **One dominant topic (> 70% of episodes)** → Lead with that topic, mention others briefly.
-- **No new facts but many conversations** → Focus on topics and people. Note: "No new preferences or habits picked up this week — mostly continuing existing threads."
-- **User asks for a long range (30+ days)** → Summarize at a higher level. Group weeks if needed. Mention that older details may be less precise.
+- **Synthesis over inventory.** The user doesn't want to see what CORE stored. They want to see what CORE understood. Every sentence should reflect a pattern, arc, or insight — not a database entry.
+- **First person throughout.** "I noticed", "I picked up", "You spent." Never "The data shows" or "The following topics were discussed."
+- **Lead with insight, not data structure.** Never say "here are your topics" or "the entities section contains."
+- **Map sections to aspect types.** Decisions → Decision facts. Identity section → Identity facts. Relationships → Relationship facts. Problems → Problem facts. Open threads → Task + Problem facts. Knowledge and Event facts feed the "where your attention went" narrative.
+- **Skip empty sections.** If a section has nothing meaningful, omit it entirely. Don't write "No new preferences picked up this week" — just leave it out.
+- **Group related topics.** If "CORE Product" and "CORE Development" overlap, merge them into one thread.
+- **Keep it under 500 words** for the default 7-day summary. Shorter periods should be proportionally shorter. If the week was light, 150 words is fine.
+
+---
+
+## Edge Cases
+
+- **Very few episodes (< 5):** Keep it to 2–3 sentences total. Don't pad.
+- **One dominant topic (> 70% of episodes):** Lead with that topic, mention others in one sentence. Acknowledge the concentration: "Almost entirely focused on X this week."
+- **No new facts but many conversations:** Focus on attention distribution and decision arcs. Note: "No new preferences or habits picked up — mostly continuing existing threads."
+- **User asks for a long range (30+ days):** Summarize at a higher level. Group by week if needed. Mention that older details may be less precise.
+- **Lots of automation noise:** Don't count reminder pings, polling events, or drink-water notifications toward episode counts or topic descriptions. These are system hygiene, not user activity.
+- **`memory_explorer` returns truncated data:** The multi-window approach should minimize this. If it still happens, note in the summary: "This was a dense period — some details may be compressed."


### PR DESCRIPTION
## Summary

- Fix YAML frontmatter in `cold_email`, `content_strategy`, `copywriting` — inner double quotes inside double-quoted strings were breaking YAML parsing; replaced with single quotes
- Escape bare `<` characters treated as JSX tags in 10 skill files (`ab_test_setup`, `beachhead_segment`, `churn_prevention`, `cohort_analysis`, `design_growth_loops`, `email_sequence`, `free_tool_strategy`, `market_sizing`, `paid_ads`, `sales_pipeline_review`)
- Escape `{...}` template expressions in `copywriting.mdx` — wrapped formula strings in backticks
- Fix `<head>`/`<body>` raw tags in `schema_markup.mdx` — wrapped in backticks
- Reformat `weekly_learning_summary.mdx` to match standard skill file structure
- Shorten `ai_seo.mdx` description

## Test plan
- [ ] Run `mint dev` locally and confirm no MDX parsing errors
- [ ] Verify all affected skill pages render correctly in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)