### PR TITLE
docs: butler narrative update + open source restructure

### DIFF
--- a/docs/access-core/overview.mdx
+++ b/docs/access-core/overview.mdx
@@ -3,13 +3,13 @@ title: "Overview"
 description: "Connect CORE to messaging apps and AI providers"
 ---
 
-CORE is one brain with multiple access points. Connect it to messaging apps to use as your personal assistant, or plug it into AI tools to give them persistent memory and actions.
+Your butler is one brain with multiple access points. Talk to it from messaging apps, or plug it into your AI tools to give them persistent memory and actions.
 
 ## Two Ways to Use CORE
 
-### Use as Your Personal Assistant
+### Talk to Your Butler
 
-Talk directly to CORE's Agent through messaging apps. Ask questions, manage your apps, get summaries, spun a claude code or browser session in your machine - all through chat, from any device.
+Message your butler directly through messaging apps. Ask questions, manage your apps, get summaries, spin up a Claude Code or browser session on your machine — all through chat, from any device.
 
 <CardGroup cols={3}>
   <Card title="Web Dashboard" icon="browser" href="/access-core/channels/web-dashboard">
@@ -51,9 +51,9 @@ Talk directly to CORE's Agent through messaging apps. Ask questions, manage your
 
 ---
 
-### Supercharge Your AI Agents
+### Extend Your Butler to Your Dev Tools
 
-Give any AI tool two superpowers: **persistent memory** across sessions and **actions** in your apps (GitHub, Slack, Linear, Gmail, and more). Connect once and every tool shares the same brain.
+Your butler's memory and toolkit can reach into any MCP-compatible AI tool — Claude Code, Cursor, Windsurf, and more. Connect once and every tool shares the same brain: same memory, same context, same action layer, wherever you're building.
 
 <CardGroup cols={3}>
   <Card title="Cursor" icon="code" href="/providers/cursor">
@@ -89,9 +89,9 @@ Give any AI tool two superpowers: **persistent memory** across sessions and **ac
 
 ## Which Should I Use?
 
-|  | Channels | AI Providers |
+|  | Channels | Dev Tools |
 |---|---|---|
-| **What** | Chat directly with CORE's Meta Agent | Add memory + actions to your existing AI tools |
-| **Best for** | Quick tasks, mobile access, managing apps via chat | Coding, development workflows, persistent context |
+| **What** | Chat directly with your butler | Your butler's memory + actions inside your coding tools |
+| **Best for** | Tasks, mobile access, managing apps, proactive automations | Coding workflows, persistent project context, in-IDE actions |
 
-Use both - your memory is shared across all access points. CORE is one brain, you just choose how to talk to it.
+Use both — memory is shared across everything. One butler, everywhere you work.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -1,0 +1,103 @@
+---
+title: "Slack"
+description: "Message your butler directly in Slack: DMs or @mentions."
+---
+
+Once set up, you can DM your butler in Slack or @mention it in any channel. It reads your message, runs through its memory and toolkit, and replies in the thread.
+
+**What you need:** A Slack workspace where you can create and install apps.
+
+---
+
+## Step 1: Create a Slack App
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From scratch**
+2. Name it (e.g. "CORE Butler") and pick your workspace → **Create App**
+
+---
+
+## Step 2: Configure OAuth scopes
+
+Go to **OAuth & Permissions** in the sidebar.
+
+**Bot Token Scopes**: add all of these:
+
+| Scope | Why |
+|-------|-----|
+| `app_mentions:read` | Receive @mention events |
+| `chat:write` | Send messages and replies |
+| `im:history` | Read DM history |
+| `im:read` | Access DM channels |
+| `im:write` | Open DM conversations |
+| `users:read` | Look up user info |
+| `channels:read` | Access channel metadata |
+
+**User Token Scopes**: add these for full activity sync:
+
+`channels:history`, `channels:read`, `channels:write`, `chat:write`, `groups:history`, `groups:read`, `groups:write`, `im:history`, `im:read`, `im:write`, `mpim:history`, `mpim:read`, `mpim:write`, `reactions:read`, `reactions:write`, `search:read`, `stars:read`, `team:read`, `users:read`
+
+**Redirect URL**: under **Redirect URLs**, add:
+```
+https://your-domain.com/api/v1/integrations/slack/callback
+```
+
+---
+
+## Step 3: Enable Event Subscriptions
+
+Go to **Event Subscriptions** → toggle **Enable Events** on.
+
+**Request URL:**
+```
+https://your-domain.com/api/v1/channels/slack
+```
+
+Slack will send a challenge request: your CORE instance must be running and reachable for it to verify.
+
+**Subscribe to bot events**: add both:
+- `app_mention`: fires when someone @mentions your bot in a channel
+- `message.im`: fires when someone DMs your bot
+
+Save changes.
+
+---
+
+## Step 4: Set the signing secret
+
+Go to **Basic Information** → **App Credentials** → copy the **Signing Secret**.
+
+Add to your `.env`:
+
+```env
+SLACK_SIGNING_SECRET=your-signing-secret-here
+```
+
+Restart CORE:
+```bash
+docker compose restart webapp
+```
+
+---
+
+## Step 5: Connect in CORE dashboard
+
+1. Open your CORE dashboard → **Integrations** → find **Slack** → click **Connect**
+2. You'll be redirected to Slack's OAuth page: authorise the app
+3. The app is now installed in your workspace with both a bot token and your user token
+
+---
+
+## Step 6: Talk to your butler
+
+**Via DM:**
+Open Slack → find your app under **Apps** in the sidebar → send a message directly.
+
+**Via @mention:**
+Go to any channel → type `/invite @YourAppName` to add the bot → then use `@YourAppName your message` in any message.
+
+**Verify it's working:**
+```
+@YourAppName what are my open GitHub issues?
+```
+
+Your butler should reply in the thread within a few seconds.

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -1,0 +1,89 @@
+---
+title: "Telegram"
+description: "Message your butler directly on Telegram via a dedicated bot."
+---
+
+Once set up, you can message your butler through any Telegram bot you create. CORE registers the webhook automatically: no manual Telegram configuration needed beyond creating the bot.
+
+<Note>
+  This channel is available in [PR #739](https://github.com/RedPlanetHQ/core/pull/739). Make sure your instance is running that version or later.
+</Note>
+
+**What you need:** A publicly reachable CORE instance (`APP_ORIGIN` must be set in your `.env`).
+
+---
+
+## Step 1: Create a Telegram bot
+
+1. Open Telegram → search for **@BotFather** → `/start`
+2. Send `/newbot` → follow the prompts (pick a display name and a username ending in `bot`)
+3. BotFather replies with your **bot token**: copy it, you'll need it in Step 3
+
+---
+
+## Step 2: Ensure your instance is publicly reachable
+
+Telegram needs to send webhook events to your CORE instance. Confirm `APP_ORIGIN` is set to your public URL in `.env`:
+
+```env
+APP_ORIGIN=https://your-domain.com
+```
+
+CORE uses this to construct the webhook URL it registers with Telegram:
+```
+https://your-domain.com/webhooks/telegram?channelId=<channel-id>
+```
+
+> For local development, use a tunnel like [ngrok](https://ngrok.com): `ngrok http 3033` and set `APP_ORIGIN` to the tunnel URL.
+
+---
+
+## Step 3: Create the channel via the CORE API
+
+CORE stores the bot token in the channel record and **automatically registers the webhook** with Telegram when you create the channel.
+
+Get your API token from the CORE dashboard → **Settings** → **API**, then run:
+
+```bash
+curl -X POST https://your-domain.com/api/v1/channels \
+  -H "Authorization: Bearer <your-api-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My Telegram",
+    "type": "telegram",
+    "config": { "bot_token": "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11" },
+    "isDefault": true
+  }'
+```
+
+A successful response returns `{ "success": true, "channelId": "..." }`.
+
+At this point, CORE has called Telegram's `/setWebhook` with your channel ID: no further Telegram configuration is needed.
+
+---
+
+## Step 4: Talk to your butler
+
+Open Telegram → search for your bot by username → send a message:
+
+```
+What are my open GitHub issues?
+```
+
+Your butler replies directly in the chat.
+
+---
+
+## Managing the channel
+
+**List channels:**
+```bash
+curl https://your-domain.com/api/v1/channels \
+  -H "Authorization: Bearer <your-api-token>"
+```
+
+**Delete a channel** (also deregisters the Telegram webhook automatically):
+```bash
+curl -X DELETE https://your-domain.com/api/v1/channels/<channel-id> \
+  -H "Authorization: Bearer <your-api-token>"
+```

--- a/docs/concepts/memory/how-core-ingests.mdx
+++ b/docs/concepts/memory/how-core-ingests.mdx
@@ -11,6 +11,27 @@ Ingestion is how raw information becomes structured knowledge in your graph. Eve
 
 ## The Ingestion Pipeline
 
+Every conversation is processed into structured facts — not saved as raw text.
+
+```mermaid
+flowchart LR
+    CONV["Conversation or event completes\nchat · reminder execution · email processed"]
+
+    EXTRACT["① Extract entities & relationships\nPeople · projects · companies · concepts\nand how they connect to each other"]
+
+    CLASSIFY["② Classify each fact by type\npreference · decision · goal\ndirective · rule · observation"]
+
+    EPISODE["③ Create an episode\nGroup related facts under a\ntimestamped conversation record"]
+
+    GRAPH["④ Write to Knowledge Graph\nEpisodes · entities · statements\nlinked with timestamps"]
+
+    MEM[("🧠 Memory\nKnowledge Graph")]
+
+    CONV --> EXTRACT --> CLASSIFY --> EPISODE --> GRAPH --> MEM
+```
+
+**What gets stored:** preferences, decisions, goals, directives, relationships, people and topics — not just facts but the *when* and *why* behind them.
+
 <Steps>
   <Step title="Raw Input Capture">
     Information arrives from conversations with the CORE Agent, integration activity (GitHub commits, Slack messages, Linear issues), manual document uploads, or scheduled syncs from connected apps.

--- a/docs/concepts/memory/how-core-searches.mdx
+++ b/docs/concepts/memory/how-core-searches.mdx
@@ -11,6 +11,30 @@ CORE's search is fundamentally different from traditional RAG. Instead of treati
 
 ## The Search Pipeline
 
+Retrieval is intent-driven — not keyword matching.
+
+```mermaid
+flowchart LR
+    QUERY["User message or ActionPlan\narrives at CORE Agent"]
+
+    DECOMP["① Memory Agent decomposes intent\nBreaks the request into\nmultiple targeted sub-queries"]
+
+    subgraph search["② Run searches in parallel"]
+        S1["Entity-centric\nwho is involved"]
+        S2["Relational\nhow things connect"]
+        S3["Semantic\nwhat was meant"]
+        S4["Temporal\nwhen it happened"]
+    end
+
+    RANK["③ Rank & merge results\nDeduplicate · score by relevance\nand recency"]
+
+    CONTEXT["④ Return rich context\nStructured facts with timestamps\nprovenance & relationship links"]
+
+    AGENT["CORE Agent uses context\nto ground its response"]
+
+    QUERY --> DECOMP --> search --> RANK --> CONTEXT --> AGENT
+```
+
 When you ask the CORE Agent a question or search your memory:
 
 <Steps>

--- a/docs/concepts/memory/overview.mdx
+++ b/docs/concepts/memory/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Memory Overview"
-description: "How CORE's temporal knowledge graph stores and organizes your information"
+description: "Your butler never forgets — here's how."
 ---
 
 ## Pillar 1: It Remembers Everything

--- a/docs/concepts/meta-agent.mdx
+++ b/docs/concepts/meta-agent.mdx
@@ -1,21 +1,56 @@
 ---
 title: "CORE Agent"
-description: "The orchestrator that ties memory and actions together across all your tools"
+description: "The brain behind your named butler — memory, actions, and intent tied together"
 ---
 
 ## What is the CORE Agent?
 
-The CORE Agent is the engine behind your personal butler. It sits between you and everything CORE knows and can do - memory, toolkit, connected apps. When you send a message, the agent figures out what you need, pulls the right context, takes the right actions, and responds. Every conversation it has gets ingested back into memory, so your butler gets sharper over time.
+Every butler needs a brain. The CORE Agent is that brain — it's what makes your butler *yours*. It sits between you and everything CORE knows and can do: memory, toolkit, connected apps. When you send a message, it figures out what you need, pulls the right context, takes the right actions, and responds. Every conversation gets ingested back into memory, so your butler gets sharper the more you use it.
 
 You can talk to it from WhatsApp, the web dashboard, email, or through any MCP-compatible agent like Claude Code or Cursor. Same brain, same memory, regardless of where you start.
-
-<Frame>
-  <img src="/images/meta-agent-overview.png" alt="CORE Agent Architecture" />
-</Frame>
 
 ---
 
 ## How It Works
+
+Two paths into CORE — messages from you, and triggers that fire automatically. Both converge on the same intelligence.
+
+```mermaid
+flowchart TD
+    MSG["💬 Your message\nWhatsApp · Slack · Email · Web · API"]
+    TRG["⏰ Automated trigger\nReminder · Webhook · Scheduled job"]
+
+    CASE["① CASE — Decision Agent\nAnalyses trigger · builds ActionPlan\nwhat to do · tone · whether to message"]
+
+    AGENT["② CORE Agent\nReads ActionPlan · loads Persona\ndecides which tools to call"]
+
+    subgraph orch["Orchestrator — routes & coordinates all tool calls"]
+        MEMR["③ memory_explorer\nSearch knowledge graph for\nrelevant context · past decisions · relationships"]
+        TOOLS["④ Toolkit\nExecute the specific actions\nsearch_emails · get_calendar · create_issue · …"]
+        GW["④ Gateways  (if needed)\nClaude Code · Browser · Custom agents"]
+    end
+
+    MEM[("🧠 Memory\nKnowledge Graph")]
+
+    SYNTH["⑤ CORE Agent synthesizes\nCombines memory context + tool results"]
+    RESP["Response delivered\nvia your preferred channel"]
+
+    INGEST["⑥ memory_ingest\nSummarised conversation stored\nback to knowledge graph"]
+
+    MSG --> AGENT
+    TRG --> CASE
+    CASE -->|"ActionPlan"| AGENT
+
+    AGENT --> orch
+    MEMR <-->|"read"| MEM
+
+    orch --> SYNTH
+    SYNTH --> RESP
+    SYNTH --> INGEST
+    INGEST -->|"write"| MEM
+```
+
+### Step by step
 
 When you send a message, here's what happens:
 

--- a/docs/concepts/toolkit.mdx
+++ b/docs/concepts/toolkit.mdx
@@ -9,6 +9,8 @@ The Toolkit is CORE's hands. While the Agent thinks and Memory remembers, the To
 
 You connect each app once. After that, every interface to CORE (WhatsApp, web dashboard, Claude Code, Cursor) can use those integrations. One connection, available everywhere.
 
+**What a multi-step action looks like:** A user emails reporting a bug → your butler creates a Todoist task, spins up a Claude Code session with context from memory, writes a fix, and opens a PR. You come back to a summary and a link. One message, multiple tools, coordinated automatically.
+
 ---
 
 ## How It Works
@@ -17,14 +19,14 @@ You connect each app once. After that, every interface to CORE (WhatsApp, web da
 
 From the [CORE Dashboard](https://app.getcore.me), connect the apps you use daily. Each integration authenticates via OAuth — no API keys to manage.
 
-### 2. Meta Agent Decides What to Use
+### 2. Your Butler Decides What to Use
 
-When you ask CORE to do something, the Meta Agent figures out which integration(s) to use:
+When you ask CORE to do something, the CORE Agent figures out which integration(s) to use:
 
 ```
 You: "Create a GitHub issue for the auth bug and tell Sarah on Slack"
 
-Meta Agent:
+CORE Agent:
 → Uses GitHub integration to create issue with context from memory
 → Uses Slack integration to DM Sarah with a link to the issue
 ```
@@ -98,7 +100,7 @@ See the [Toolkit Overview](/toolkit/overview) for details on how on-demand tool 
     Configure which integrations to expose via MCP
   </Card>
 
-  <Card title="Meta Agent" icon="brain" href="/concepts/meta-agent">
-    How the Meta Agent decides which tools to use
+  <Card title="CORE Agent" icon="brain" href="/concepts/meta-agent">
+    How the CORE Agent decides which tools to use
   </Card>
 </CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -20,11 +20,7 @@
           {
             "group": "Getting Started",
             "pages": [
-              "getting-started",
-              "quickstart/chief-of-staff",
-              "quickstart/supercharge-ai-agents",
-              "quickstart/capture-conversations",
-              "quickstart/remote-coding-sessions"
+              "getting-started"
             ]
           }
         ]
@@ -80,7 +76,7 @@
             ]
           },
           {
-            "group": "AI Providers",
+            "group": "Dev Tools",
             "pages": [
               "providers/memory-rules",
               {
@@ -325,22 +321,29 @@
           {
             "group": "Get Started",
             "pages": [
-              "self-hosting/overview",
-              "self-hosting/docker",
+              "self-hosting/setup"
+            ]
+          },
+          {
+            "group": "Configuration",
+            "pages": [
               "self-hosting/environment-variables",
               "self-hosting/embeddings",
-              "self-hosting/gateway",
               "self-hosting/ai-providers"
             ]
           },
           {
-            "group": "Channel",
-            "pages": ["channels/email-resend"]
+            "group": "Channels",
+            "pages": ["channels/email-resend", "channels/slack", "channels/telegram"]
           },
           {
-            "group": "Integrations",
+            "group": "Remote Sessions",
+            "pages": ["quickstart/remote-coding-sessions"]
+          },
+          {
+            "group": "Build Integrations",
             "pages": [
-              "integrations/building-integrations",
+              "opensource/building-integrations",
               "integrations/schedule-based-guide",
               "integrations/webhook-based-guide",
               "integrations/mcp-hub-guide",
@@ -348,12 +351,12 @@
             ]
           },
           {
-            "group": "Local setup",
-            "pages": ["guides/local-setup", "migrating-from-v1"]
+            "group": "Migration",
+            "pages": ["migrating-from-v1"]
           },
           {
-            "group": "Contributing",
-            "pages": ["opensource/contributing", "opensource/building-integrations"]
+            "group": "Local Development",
+            "pages": ["guides/local-setup"]
           }
         ]
       },

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,54 +1,51 @@
 ---
-title: "Quickstart"
-description: "Get started with CORE in 5 minutes"
+title: "Getting Started"
+description: "Your personal AI butler — open source, named, persistent, yours."
 ---
 
-CORE is your personal butler — it knows your tools, your preferences, and your people. Connect your tools, tell it what matters, and hand off the work. Here's how to get started.
+CORE is your personal AI butler. It knows your tools, your preferences, and your people. It remembers everything across conversations, takes actions across your apps, and works proactively — so you describe outcomes and it does the work.
 
-## Choose Your Deployment
+**Open source. Named. Persistent. Yours.**
 
-<CardGroup cols={3}>
-  <Card title="Cloud" icon="cloud" href="#cloud-setup">
-    Start in 2 minutes.
+---
+
+## How do you want to get started?
+
+<CardGroup cols={2}>
+  <Card title="Join the Cloud Waitlist" icon="cloud" href="https://app.getcore.me">
+    Cloud is coming. Join the waitlist and we'll reach out when your spot is ready.
   </Card>
 
-  <Card title="Self-Hosted" icon="server" href="/self-hosting/overview">
-    Deploy on your own infrastructure with full control.
-  </Card>
-
-  <Card title="Local Development" icon="code" href="/guides/local-setup">
-    Run CORE locally for development and testing.
+  <Card title="Self-Host (Open Source)" icon="server" href="/self-hosting/setup">
+    Run your butler on your own infrastructure today. Docker-based, fully open source, your data stays with you.
   </Card>
 </CardGroup>
 
-## Cloud Setup
+---
 
-<Steps>
-  <Step title="Sign in to Dashboard">
-    Visit [app.getcore.me](https://app.getcore.me) and create your account.
-  </Step>
+## What your butler can do
 
-  <Step title="Connect Gmail and Calendar">
-    Grant CORE access to your Gmail (optional) and Google Calendar. CORE scans them to learn about you so your butler starts with real context from day one.
-  </Step>
+Once you're set up, you can message your butler from WhatsApp, Slack, email, or the web dashboard — like messaging a person:
 
-  <Step title="Review Your Summary">
-    Head to the **Document** section in your dashboard. CORE generates a summary of what it learned about you. This is the foundation of everything your butler knows about you.
-  </Step>
-</Steps>
+- *"What are my priorities for today?"*
+- *"Fix the auth timeout bug in the API repo"*
+- *"When a Sentry alert fires tonight, investigate it and create an issue"*
+- *"Summarise my emails from the last 24 hours"*
 
-## What Can You Do With CORE?
+The more you use it, the more it learns — your preferences, patterns, and relationships. That's what makes it a butler, not just a chatbot.
+
+---
+
+## Want to understand how it works first?
 
 <CardGroup cols={3}>
-  <Card title="Use as your personal assistant" icon="robot" href="/quickstart/chief-of-staff">
-    Message CORE from WhatsApp/slack/email to takes action across your apps, browser, and machine.
+  <Card title="Concepts" icon="brain" href="/concepts/overview">
+    The four pillars: memory, agent, toolkit, proactive actions.
   </Card>
-
-  <Card title="Supercharge Your AI Agents" icon="bolt" href="/quickstart/supercharge-ai-agents">
-    Equip Claude Code and other agents with long-term memory and an extensible action layer
+  <Card title="Memory" icon="database" href="/concepts/memory/overview">
+    How your butler never forgets anything you tell it.
   </Card>
-
-  <Card title="Turn AI Chats into Memory" icon="brain" href="/quickstart/capture-conversations">
-    Sync your ChatGPT and Gemini conversations into CORE - searchable, reusable, and available to every agent.
+  <Card title="Toolkit" icon="wrench" href="/concepts/toolkit">
+    200+ actions across 50+ apps through a single connection.
   </Card>
 </CardGroup>

--- a/docs/integrations/adding-to-instance.mdx
+++ b/docs/integrations/adding-to-instance.mdx
@@ -32,13 +32,13 @@ corebrain integrations add
 
 You will be prompted for:
 
-- **Name** — Display name for the integration
-- **Description** — Short description of what it connects to
-- **Slug** — Unique identifier (e.g. `my-service`)
-- **Auth type** — `API Key` or `OAuth2`
-- **Source URL** — Documentation or homepage URL for the service
-- **Trigger type** — `Webhook` (receives events) or `Schedule` (periodic sync)
-- **Sync interval** — If schedule-based: every 15, 20, or 30 minutes
+- **Name**: Display name for the integration
+- **Description**: Short description of what it connects to
+- **Slug**: Unique identifier (e.g. `my-service`)
+- **Auth type**: `API Key` or `OAuth2`
+- **Source URL**: Documentation or homepage URL for the service
+- **Trigger type**: `Webhook` (receives events) or `Schedule` (periodic sync)
+- **Sync interval**: If schedule-based: every 15, 20, or 30 minutes
 
 The CLI builds a spec from your answers and registers the integration via the API.
 

--- a/docs/integrations/mcp-hub-guide.mdx
+++ b/docs/integrations/mcp-hub-guide.mdx
@@ -2,7 +2,7 @@
 title: MCP Hub
 ---
 
-# MCP Hub Integration
+## MCP Hub Integration
 
 <Note>
 **New to building integrations?** Start with our [step-by-step contributor guide](/opensource/building-integrations) for a quick overview.

--- a/docs/integrations/schedule-based-guide.mdx
+++ b/docs/integrations/schedule-based-guide.mdx
@@ -2,7 +2,7 @@
 title: Schedule based
 ---
 
-# Schedule-Based Sync Integrations
+## Schedule-Based Sync Integrations
 
 <Note>
 **New to building integrations?** Start with our [step-by-step contributor guide](/opensource/building-integrations) for a quick overview.

--- a/docs/integrations/webhook-based-guide.mdx
+++ b/docs/integrations/webhook-based-guide.mdx
@@ -2,7 +2,7 @@
 title: Webhook based
 ---
 
-# Webhook-Based Integrations
+## Webhook-Based Integrations
 
 <Note>
 **New to building integrations?** Start with our [step-by-step contributor guide](/opensource/building-integrations) for a quick overview.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,38 +1,43 @@
 ---
 title: "CORE - Your Personal Butler"
-description: "Connect your tools. Tell it what matters. Hand off the work."
+description: "The first AI butler you actually own. Open source. Named. Persistent. Yours."
 ---
 
-CORE is your personal butler — an always-on AI that knows your tools, your preferences, and your people. Connect your tools, tell it what matters, and hand off the work.
+AI removed the inertia of building. CORE removes the inertia of operating.
+
+You built more tools, more systems, more things that need to run. Then the problem changed — it was no longer about building. It was about operating everything you built. Deployments to watch. Issues to follow up on. Customers to reply to. Systems that only worked if someone kept an eye on them.
+
+Your butler handles that. It knows your tools, your preferences, and your people. It's always on, it remembers everything, and it acts — so you don't have to.
+
+**Open source. Named. Persistent. Yours.**
 
 <CardGroup cols={2}>
   <Card
-    title="Getting Started"
+    title="Get Started"
     icon="rocket"
     href="/getting-started"
   >
-    Connect CORE in mins. Set up your personal assistant, add memory to Claude, Cursor or any AI tool instantly.
+    Ready to set it up? Cloud waitlist or self-host in minutes.
   </Card>
   <Card
-    title="Concepts"
+    title="How It Works"
     icon="brain"
     href="/concepts/overview"
   >
-    Understand CORE Agent, Memory, and Toolkit - the three layers that make CORE work.
+    Want to understand the architecture? Memory, agent, toolkit — the three layers explained.
   </Card>
   <Card
-    title="Connect"
-    icon="plug"
+    title="Talk to Your Butler"
+    icon="message"
     href="/access-core/overview"
   >
-    Connect CORE to channels (whatsapp, email, slack etc) or AI providers (claude, cursor).
+    Connect via WhatsApp, Slack, email, or the web dashboard.
   </Card>
-  <Card title="Self-Hosted" icon="server" href="/self-hosting/overview">
-    Deploy on your own infrastructure with full control.
+  <Card title="Self-Host" icon="server" href="/self-hosting/setup">
+    Open source. Run your butler on your own infrastructure — your data never leaves.
   </Card>
-
   <Card title="Local Development" icon="code" href="/guides/local-setup">
-    Run CORE locally for development and testing.
+    Modify CORE's source code and run it locally.
   </Card>
 </CardGroup>
 

--- a/docs/opensource/building-integrations.mdx
+++ b/docs/opensource/building-integrations.mdx
@@ -2,21 +2,22 @@
 title: Building Integrations
 ---
 
-# Building Integrations
-
 CORE is open-source and welcomes community contributions. You can build integrations for any service to extend CORE's capabilities.
 
 ## What You Can Build
 
 **Project Management:**
+
 - Jira, ClickUp, Trello, Asana (similar to our Linear integration)
 - Task tools: create/update/search issues, manage projects
 
 **Analytics & Insights:**
+
 - GitLab Analytics, Bitbucket Analytics (similar to our GitHub Analytics)
 - Metric tools: get stats, generate reports, track KPIs
 
 **Communication:**
+
 - Microsoft Teams, Discord DMs (similar to our Slack integration)
 - Messaging tools: send messages, manage channels
 
@@ -27,6 +28,7 @@ CORE is open-source and welcomes community contributions. You can build integrat
 Every CORE integration provides **two essential capabilities:**
 
 1. **Activity Sync** - Capture relevant events → knowledge graph
+
    - Schedule-based: Poll API every 5-15 mins (GitHub, Linear)
    - Webhook-based: Real-time events (Slack, Discord)
 
@@ -39,6 +41,7 @@ Every CORE integration provides **two essential capabilities:**
 ### Step 1: Choose Integration Type
 
 **Schedule-Based** (for APIs without webhooks):
+
 ```
 Use when: Service has REST API, no webhooks
 Examples: GitHub, Linear, Todoist
@@ -46,6 +49,7 @@ Structure: index.ts, account-create.ts, schedule.ts, mcp/
 ```
 
 **Webhook-Based** (for real-time events):
+
 ```
 Use when: Service provides webhook events
 Examples: Slack, Discord, Linear webhooks
@@ -82,26 +86,29 @@ export async function integrationCreate(data: any) {
   // Get user info from service API
   const user = await getUser(oauthResponse.access_token);
 
-  return [{
-    type: 'account',
-    data: {
-      accountId: user.id,
-      config: {
-        access_token: oauthResponse.access_token,
-        refresh_token: oauthResponse.refresh_token,
+  return [
+    {
+      type: "account",
+      data: {
+        accountId: user.id,
+        config: {
+          access_token: oauthResponse.access_token,
+          refresh_token: oauthResponse.refresh_token,
+        },
+        settings: {
+          username: user.username,
+          // Add service-specific settings
+        },
       },
-      settings: {
-        username: user.username,
-        // Add service-specific settings
-      }
-    }
-  }];
+    },
+  ];
 }
 ```
 
 ### Step 4: Implement Activity Sync
 
 **For Schedule-Based (schedule.ts):**
+
 ```typescript
 export async function handleSchedule(config: any, state: any) {
   const lastSync = state?.lastSyncTime || getDefault24HoursAgo();
@@ -113,18 +120,18 @@ export async function handleSchedule(config: any, state: any) {
   // Create activity messages
   for (const item of items) {
     activities.push({
-      type: 'activity',
+      type: "activity",
       data: {
         text: `${item.user} created issue #${item.number}: ${item.title}`,
-        sourceURL: item.url
-      }
+        sourceURL: item.url,
+      },
     });
   }
 
   // Save state for next sync
   activities.push({
-    type: 'state',
-    data: { lastSyncTime: new Date().toISOString() }
+    type: "state",
+    data: { lastSyncTime: new Date().toISOString() },
   });
 
   return activities;
@@ -132,13 +139,16 @@ export async function handleSchedule(config: any, state: any) {
 ```
 
 **For Webhook-Based (create-activity.ts + identify.ts):**
+
 ```typescript
 // identify.ts - Extract user ID for routing
 export async function identify(integration: any, eventBody: any) {
-  return [{
-    type: 'identifier',
-    data: eventBody.event.user
-  }];
+  return [
+    {
+      type: "identifier",
+      data: eventBody.event.user,
+    },
+  ];
 }
 
 // create-activity.ts - Process webhook event
@@ -148,10 +158,12 @@ export async function createActivityEvent(eventData: any, config: any) {
   const text = `${event.user} mentioned you: ${event.message}`;
   const url = await getPermalink(config.access_token, event.id);
 
-  return [{
-    type: 'activity',
-    data: { text, sourceURL: url }
-  }];
+  return [
+    {
+      type: "activity",
+      data: { text, sourceURL: url },
+    },
+  ];
 }
 ```
 
@@ -159,32 +171,32 @@ export async function createActivityEvent(eventData: any, config: any) {
 
 ```typescript
 // src/mcp/index.ts
-import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 // Define tool schemas
 const CreateIssueSchema = z.object({
-  title: z.string().describe('Issue title'),
-  description: z.string().optional().describe('Issue description'),
-  assignee: z.string().optional().describe('User to assign'),
+  title: z.string().describe("Issue title"),
+  description: z.string().optional().describe("Issue description"),
+  assignee: z.string().optional().describe("User to assign"),
 });
 
 const SearchIssuesSchema = z.object({
-  query: z.string().describe('Search query'),
-  status: z.string().optional().describe('Filter by status'),
+  query: z.string().describe("Search query"),
+  status: z.string().optional().describe("Filter by status"),
 });
 
 // Export tools list
 export async function getTools() {
   return [
     {
-      name: 'create_issue',
-      description: 'Create a new issue in the project',
+      name: "create_issue",
+      description: "Create a new issue in the project",
       inputSchema: zodToJsonSchema(CreateIssueSchema),
     },
     {
-      name: 'search_issues',
-      description: 'Search for issues',
+      name: "search_issues",
+      description: "Search for issues",
       inputSchema: zodToJsonSchema(SearchIssuesSchema),
     },
   ];
@@ -193,13 +205,13 @@ export async function getTools() {
 // Implement tool execution
 export async function callTool(name: string, args: any, apiKey: string) {
   switch (name) {
-    case 'create_issue':
+    case "create_issue":
       const issue = await createIssue(apiKey, args);
-      return { content: [{ type: 'text', text: `Created issue #${issue.id}` }] };
+      return { content: [{ type: "text", text: `Created issue #${issue.id}` }] };
 
-    case 'search_issues':
+    case "search_issues":
       const results = await searchIssues(apiKey, args);
-      return { content: [{ type: 'text', text: JSON.stringify(results) }] };
+      return { content: [{ type: "text", text: JSON.stringify(results) }] };
 
     default:
       throw new Error(`Unknown tool: ${name}`);
@@ -211,10 +223,15 @@ export async function callTool(name: string, args: any, apiKey: string) {
 
 ```typescript
 // src/index.ts
-import { IntegrationCLI, IntegrationEventPayload, IntegrationEventType, Spec } from '@redplanethq/sdk';
-import { integrationCreate } from './account-create';
-import { handleSchedule } from './schedule'; // or createActivityEvent + identify
-import { getTools, callTool } from './mcp';
+import {
+  IntegrationCLI,
+  IntegrationEventPayload,
+  IntegrationEventType,
+  Spec,
+} from "@redplanethq/sdk";
+import { integrationCreate } from "./account-create";
+import { handleSchedule } from "./schedule"; // or createActivityEvent + identify
+import { getTools, callTool } from "./mcp";
 
 export async function run(eventPayload: IntegrationEventPayload) {
   switch (eventPayload.event) {
@@ -238,7 +255,7 @@ export async function run(eventPayload: IntegrationEventPayload) {
 
 class YourServiceCLI extends IntegrationCLI {
   constructor() {
-    super('your-service', '1.0.0');
+    super("your-service", "1.0.0");
   }
 
   protected async handleEvent(eventPayload: IntegrationEventPayload) {
@@ -247,20 +264,20 @@ class YourServiceCLI extends IntegrationCLI {
 
   protected async getSpec(): Promise<Spec> {
     return {
-      name: 'Your Service',
-      key: 'your-service',
-      description: 'Integration description',
-      icon: 'your-service',
-      schedule: { frequency: '*/5 * * * *' }, // For schedule-based
+      name: "Your Service",
+      key: "your-service",
+      description: "Integration description",
+      icon: "your-service",
+      schedule: { frequency: "*/5 * * * *" }, // For schedule-based
       auth: {
         OAuth2: {
-          token_url: 'https://api.service.com/oauth/token',
-          authorization_url: 'https://api.service.com/oauth/authorize',
-          scopes: ['read', 'write'],
-          scope_separator: ',',
+          token_url: "https://api.service.com/oauth/token",
+          authorization_url: "https://api.service.com/oauth/authorize",
+          scopes: ["read", "write"],
+          scope_separator: ",",
         },
       },
-      mcp: { type: 'cli' },
+      mcp: { type: "cli" },
     };
   }
 }
@@ -291,6 +308,7 @@ git push origin add-your-service-integration
 ```
 
 Open a PR with:
+
 - Description of what the integration does
 - List of MCP tools provided
 - Screenshots of it working
@@ -301,4 +319,15 @@ Open a PR with:
 - **Webhook-based**: [Slack](/integrations/slack), [Discord](/integrations/discord)
 - **Analytics**: [GitHub Analytics](/integrations/github-analytics)
 
-For detailed API reference, see [Integration Reference](/integrations/building-integrations).
+---
+
+## Contributing
+
+Other ways to contribute beyond integrations:
+
+- **Report bugs**: [GitHub Issues](https://github.com/RedPlanetHQ/core/issues) with steps to reproduce
+- **Improve docs**: fix anything unclear, add examples, correct errors
+- **Code review**: comment on open PRs
+- **Share CORE**: write about your setup, share in communities
+
+Open a PR against [RedPlanetHQ/core](https://github.com/RedPlanetHQ/core). Join [Discord](https://discord.gg/dVTC3BmgEq) for questions.

--- a/docs/quickstart/chief-of-staff.mdx
+++ b/docs/quickstart/chief-of-staff.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use As Your Personal Assistant"
-description: "Talk to CORE Agent directly - ask questions, draft emails, manage your schedule"
+title: "Talk to Your Butler"
+description: "Your butler is always on — ask questions, hand off tasks, manage your apps from anywhere"
 ---
 
-CORE's Agent is an always-on AI that remembers everything about you. Talk to it from the web dashboard or WhatsApp — it can answer questions, take actions, and manage things across your connected apps.
+Your butler is an always-on AI that remembers everything about you. Talk to it from the web dashboard or WhatsApp — it answers questions, takes actions, and manages things across your connected apps without you switching context.
 
-## Personal Assistant Setup
+## Setup
 
 <Steps>
-  <Step title="Pick channel to start talking to CORE Agent">
+  <Step title="Pick a channel to start talking to your butler">
     - Web Dashboard — Go to [app.getcore.me](https://app.getcore.me) and open the chat.
     - WhatsApp (Recommended) - Currently in private beta. [Join the waitlist](https://getcore.me/whatsapp). Once approved, you can message CORE like any WhatsApp contact.
   </Step>
@@ -22,18 +22,18 @@ Try taking an action in gmail or calendar.
 Connect Gmail, Calendar from Integrations section if you didn't gave scopes during signing up.
   </Step>
 
-  <Step title="Run Remote Claude Code Sessions from WhatsApp/Slack Using CORE Agent">
-Once your WhatsApp agent is connected, you can start Claude Code sessions on your machine directly from your phone.
+  <Step title="Run Remote Claude Code Sessions from WhatsApp or Slack">
+Once your WhatsApp is connected, you can start Claude Code sessions on your machine directly from your phone.
 
 Example: *"Start a Claude Code session to fix the auth bug in my repo"*
 
-CORE spins up the session, keeps you posted on progress, and sends a summary when it's done — no laptop needed.
+Your butler spins up the session, keeps you posted on progress, and sends a summary when it's done — no laptop needed.
 
 Follow the [remote sessions setup guide](/quickstart/remote-coding-sessions) to get started.
   </Step>
 
   <Step title="Connect More Apps (Optional)">
-By default, CORE can read and act on your Gmail and Calendar. To expand what it can do, connect more apps from the [Toolkit](/toolkit/overview):
+By default, your butler can read and act on your Gmail and Calendar. To expand what it can do, connect more apps from the [Toolkit](/toolkit/overview):
 
 - **GitHub** — Create issues, review PRs
 - **Linear** — Manage tasks

--- a/docs/quickstart/remote-coding-sessions.mdx
+++ b/docs/quickstart/remote-coding-sessions.mdx
@@ -1,28 +1,28 @@
 ---
-title: "Run Remote Claude Code Sessions from WhatsApp/Slack"
-description: "Start and manage Claude Code sessions on your machine from WhatsApp or Slack using CORE Agent"
+title: "Remote Claude Code Sessions"
+description: "Trigger Claude Code sessions on your machine from WhatsApp or Slack: no laptop needed."
 ---
 
-If you have the WhatsApp (or Slack) agent connected to CORE, you can kick off a Claude Code session on your machine from your phone — no laptop needed.
+Once the Gateway is running on your machine, you can kick off a Claude Code session from your phone via WhatsApp or Slack. CORE routes the message through the Gateway, spawns the session, and reports back when it's done.
+
+## Connect the Gateway to your instance
+
+The CORE CLI connects to CORE Cloud by default. For a self-hosted instance, point it at your own deployment when logging in:
+
+```bash
+npm install -g @redplanethq/corebrain
+corebrain login
+# When prompted for instance URL, enter your APP_ORIGIN (e.g. https://your-domain.com)
+# Leave blank for localhost
+```
+
+Make sure `APP_ORIGIN` and `LOGIN_ORIGIN` are set correctly in your `.env`: see [Docker setup](/self-hosting/setup#connect-a-channel).
 
 ## Setup
 
 <Steps>
-  <Step title="Install the CLI">
-    ```bash
-    npm install -g @redplanethq/corebrain
-    ```
-  </Step>
-
-  <Step title="Login">
-    Authenticate with your CORE account:
-    ```bash
-    corebrain login
-    ```
-  </Step>
-
   <Step title="Install the Claude Code Plugin (Optional but Recommended)">
-    The CORE Brain plugin gives Claude Code persistent memory across sessions — your preferences, past decisions, and project context load automatically every time.
+    The CORE Brain plugin gives Claude Code persistent memory across sessions: your preferences, past decisions, and project context load automatically every time.
 
     Open Claude Code and run:
     ```bash
@@ -68,9 +68,9 @@ CORE will create the branch, launch Claude Code, and keep you updated as it work
 
 ### Tips for remote sessions
 
-- **Always include the repo path** — e.g., `~/Github/core` or `/Users/you/projects/myapp`
-- **Always include the branch** — CORE will create and checkout the branch from `main`
-- **Be specific with the task** — the more precise, the better the output
+- **Always include the repo path**: e.g., `~/Github/core` or `/Users/you/projects/myapp`
+- **Always include the branch**: CORE will create and checkout the branch from `main`
+- **Be specific with the task**: the more precise, the better the output
 
 ---
 
@@ -81,7 +81,7 @@ Not sure what to start with? Try asking CORE to summarize the codebase:
 > start a claude code session
 > repo: ~/Github/core
 > branch: explore/codebase-overview
-> task: explain this codebase to me in a brief summary — what it does, key directories, and main entry points
+> task: explain this codebase to me in a brief summary: what it does, key directories, and main entry points
 
 CORE will start the session and send you a summary when it's done.
 
@@ -91,9 +91,9 @@ CORE will start the session and send you a summary when it's done.
 
 CORE reports progress in milestones:
 
-- **started** — session created and agent launched
-- **checkpoint(s)** — e.g., "tests passing", "fix landed", "PR ready"
-- **complete** — summary of changes, files modified, and next action for you
+- **started**: session created and agent launched
+- **checkpoint(s)**: e.g., "tests passing", "fix landed", "PR ready"
+- **complete**: summary of changes, files modified, and next action for you
 
 You can also check in anytime:
 

--- a/docs/self-hosting/ai-providers.mdx
+++ b/docs/self-hosting/ai-providers.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Connect AI Providers"
-description: "Connect AI tools to your self-hosted CORE instance via MCP"
+title: "Extend to Dev Tools (MCP)"
+description: "Give Claude Code, Cursor, and other MCP-compatible tools access to your self-hosted butler's memory and toolkit."
 ---
 
-Any AI provider that supports MCP can connect directly to your self-hosted instance. You just point it at your instance's MCP endpoint instead of CORE Cloud.
+Any MCP-compatible dev tool (Claude Code, Cursor, VS Code, etc.) can connect to your self-hosted CORE instance the same way it would connect to CORE Cloud: just point it at your own MCP endpoint instead.
 
 ## MCP Endpoint
 

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -80,8 +80,8 @@ APP_ORIGIN=https://your-domain.com
 LOGIN_ORIGIN=https://your-domain.com
 ```
 
-- **`APP_ORIGIN`** — The public URL of your CORE instance. Used by the Gateway and channel integrations to construct callback and webhook URLs.
-- **`LOGIN_ORIGIN`** — The URL used for authentication flows (magic links, OAuth redirects). Usually the same as `APP_ORIGIN`.
+- **`APP_ORIGIN`**: The public URL of your CORE instance. Used by the Gateway and channel integrations to construct callback and webhook URLs.
+- **`LOGIN_ORIGIN`**: The URL used for authentication flows (magic links, OAuth redirects). Usually the same as `APP_ORIGIN`.
 
 > If these are not set correctly, Gateway connections and channel webhooks (e.g. Slack events, WhatsApp callbacks) will fail to reach your instance.
 

--- a/docs/self-hosting/embeddings.mdx
+++ b/docs/self-hosting/embeddings.mdx
@@ -3,7 +3,7 @@ title: "Embedding Models"
 description: "Configure embedding models for semantic search and memory retrieval"
 ---
 
-CORE uses embedding models to convert text into vector representations for semantic search, memory retrieval, and knowledge graph operations. Vectors are stored in pgvector with a fixed dimension — all embeddings must match the configured `EMBEDDING_MODEL_SIZE`.
+CORE uses embedding models to convert text into vector representations for semantic search, memory retrieval, and knowledge graph operations. Vectors are stored in pgvector with a fixed dimension: all embeddings must match the configured `EMBEDDING_MODEL_SIZE`.
 
 ## Configuration
 
@@ -53,7 +53,7 @@ GOOGLE_GENERATIVE_AI_API_KEY=AIza...
 
 ### Ollama (Self-Hosted)
 
-Requires a running Ollama instance. No API key needed — fully local and private.
+Requires a running Ollama instance. No API key needed: fully local and private.
 
 | Model | Dimensions | Notes |
 |-------|-----------|-------|
@@ -90,8 +90,8 @@ OLLAMA_URL=http://ollama:11434
 
 pgvector columns are created with a fixed dimension. If the embedding model returns vectors that don't match `EMBEDDING_MODEL_SIZE`:
 
-- **Too short** — padded with zeros. Works but degrades retrieval quality. A warning is logged.
-- **Too long** — fails with an error. Update `EMBEDDING_MODEL_SIZE` and re-embed.
+- **Too short**: padded with zeros. Works but degrades retrieval quality. A warning is logged.
+- **Too long**: fails with an error. Update `EMBEDDING_MODEL_SIZE` and re-embed.
 
 ## Switching Embedding Models
 

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -3,8 +3,6 @@ title: "Environment Variables"
 description: "Environment variables for CORE self-hosting"
 ---
 
-# Environment Variables
-
 Environment variables for the CORE webapp container.
 
 | Name                                    | Required | Default                                        | Description                                                                                     |
@@ -12,9 +10,9 @@ Environment variables for the CORE webapp container.
 | **Version**                             |          |                                                |                                                                                                 |
 | `VERSION`                               | No       | 0.1.12                                         | CORE version identifier                                                                          |
 | **Secrets**                             |          |                                                |                                                                                                 |
-| `SESSION_SECRET`                        | Yes      | —                                              | Session encryption secret. Run: `openssl rand -hex 16`                                          |
-| `MAGIC_LINK_SECRET`                     | Yes      | —                                              | Magic link encryption secret. Run: `openssl rand -hex 16`                                       |
-| `ENCRYPTION_KEY`                        | Yes      | —                                              | Data encryption key. Run: `openssl rand -hex 16`                                                |
+| `SESSION_SECRET`                        | Yes      | none                                              | Session encryption secret. Run: `openssl rand -hex 16`                                          |
+| `MAGIC_LINK_SECRET`                     | Yes      | none                                              | Magic link encryption secret. Run: `openssl rand -hex 16`                                       |
+| `ENCRYPTION_KEY`                        | Yes      | none                                              | Data encryption key. Run: `openssl rand -hex 16`                                                |
 | **Application & Domains**               |          |                                                |                                                                                                 |
 | `REMIX_APP_PORT`                        | No       | 3033                                           | Application port number                                                                          |
 | `APP_ENV`                               | No       | production                                     | Application environment (development, production)                                                |
@@ -33,7 +31,7 @@ Environment variables for the CORE webapp container.
 | **Database - Neo4j (Memory Graph)**     |          |                                                |                                                                                                 |
 | `NEO4J_URI`                             | Yes      | bolt://neo4j:7687                              | Neo4j connection URI                                                                             |
 | `NEO4J_USERNAME`                        | Yes      | neo4j                                          | Neo4j username                                                                                   |
-| `NEO4J_PASSWORD`                        | Yes      | —                                              | Neo4j password. Run: `openssl rand -hex 16`                                                     |
+| `NEO4J_PASSWORD`                        | Yes      | none                                              | Neo4j password. Run: `openssl rand -hex 16`                                                     |
 | `NEO4J_AUTH`                            | Yes      | neo4j/password                                 | Neo4j authentication (username/password format)                                                 |
 | **Redis**                               |          |                                                |                                                                                                 |
 | `REDIS_HOST`                            | Yes      | redis                                          | Redis host (use container name for Docker)                                                      |
@@ -41,14 +39,14 @@ Environment variables for the CORE webapp container.
 | `REDIS_TLS_DISABLED`                    | No       | true                                           | Disable Redis TLS for local development                                                         |
 | **Authentication**                      |          |                                                |                                                                                                 |
 | `ENABLE_EMAIL_LOGIN`                    | No       | true                                           | Enable email-based authentication                                                               |
-| `AUTH_GOOGLE_CLIENT_ID`                 | No       | —                                              | Google OAuth client ID                                                                           |
-| `AUTH_GOOGLE_CLIENT_SECRET`             | No       | —                                              | Google OAuth client secret                                                                       |
+| `AUTH_GOOGLE_CLIENT_ID`                 | No       | none                                              | Google OAuth client ID                                                                           |
+| `AUTH_GOOGLE_CLIENT_SECRET`             | No       | none                                              | Google OAuth client secret                                                                       |
 | **AI Providers**                        |          |                                                |                                                                                                 |
-| `OPENAI_API_KEY`                        | No       | —                                              | OpenAI API key. Required for OpenAI; for many OpenAI-compatible proxies any non-empty value works |
-| `OPENAI_BASE_URL`                       | No       | —                                              | OpenAI-compatible API base URL (e.g. proxy endpoint)                                             |
+| `OPENAI_API_KEY`                        | No       | none                                              | OpenAI API key. Required for OpenAI; for many OpenAI-compatible proxies any non-empty value works |
+| `OPENAI_BASE_URL`                       | No       | none                                              | OpenAI-compatible API base URL (e.g. proxy endpoint)                                             |
 | `OPENAI_API_MODE`                       | No       | responses                                     | OpenAI API mode: `responses` (default) or `chat_completions` (common for proxies)               |
-| `GOOGLE_GENERATIVE_AI_API_KEY`          | No       | —                                              | Google AI API key (required when CHAT_PROVIDER=google or EMBEDDINGS_PROVIDER=google)             |
-| `ANTHROPIC_API_KEY`                     | No       | —                                              | Anthropic API key (required when CHAT_PROVIDER=anthropic)                                        |
+| `GOOGLE_GENERATIVE_AI_API_KEY`          | No       | none                                              | Google AI API key (required when CHAT_PROVIDER=google or EMBEDDINGS_PROVIDER=google)             |
+| `ANTHROPIC_API_KEY`                     | No       | none                                              | Anthropic API key (required when CHAT_PROVIDER=anthropic)                                        |
 | `MODEL`                                 | No       | gpt-4-turbo-2024-04-09                         | Default chat model                                                                               |
 | `CHAT_PROVIDER`                         | No       | openai                                        | Chat provider: `openai` (default), `anthropic`, `google`, or `ollama`                            |
 | `EMBEDDINGS_PROVIDER`                   | No       | openai                                        | Embeddings provider: `openai` (default), `google`, or `ollama`. See [Embedding Models](/self-hosting/embeddings) |
@@ -57,8 +55,8 @@ Environment variables for the CORE webapp container.
 | `OLLAMA_URL`                            | No       | http://ollama:11434                            | Ollama server URL for local models                                                               |
 | **Background Jobs**                     |          |                                                |                                                                                                 |
 | `QUEUE_PROVIDER`                        | No       | trigger                                        | Queue provider: "trigger" for Trigger.dev or "bullmq" for BullMQ (Redis-based)                  |
-| `TRIGGER_PROJECT_ID`                    | Conditional | —                                           | Trigger.dev project identifier (required only when QUEUE_PROVIDER=trigger)                       |
-| `TRIGGER_SECRET_KEY`                    | Conditional | —                                           | Trigger.dev authentication secret (required only when QUEUE_PROVIDER=trigger)                    |
+| `TRIGGER_PROJECT_ID`                    | Conditional | none                                           | Trigger.dev project identifier (required only when QUEUE_PROVIDER=trigger)                       |
+| `TRIGGER_SECRET_KEY`                    | Conditional | none                                           | Trigger.dev authentication secret (required only when QUEUE_PROVIDER=trigger)                    |
 | `TRIGGER_API_URL`                       | Conditional | http://host.docker.internal:8030            | Trigger.dev API endpoint (required only when QUEUE_PROVIDER=trigger)                             |
 | `TRIGGER_DB`                            | No       | trigger                                        | Database name for Trigger.dev                                                                    |
 | **Telemetry**                           |          |                                                |                                                                                                 |
@@ -71,29 +69,29 @@ Environment variables for the CORE webapp container.
 | `MODEL_PROVIDER`                        | No       | vercel-ai                                      | Model provider abstraction layer                                                                 |
 | **Reranking**                           |          |                                                |                                                                                                 |
 | `RERANK_PROVIDER`                       | No       | none                                           | Reranking provider: "cohere", "ollama", or "none"                                               |
-| `COHERE_API_KEY`                        | No       | —                                              | Cohere API key (required when RERANK_PROVIDER=cohere)                                           |
+| `COHERE_API_KEY`                        | No       | none                                              | Cohere API key (required when RERANK_PROVIDER=cohere)                                           |
 | `COHERE_RERANK_MODEL`                   | No       | rerank-english-v3.0                            | Cohere reranking model                                                                           |
 | `COHERE_SCORE_THRESHOLD`                | No       | 0.3                                            | Minimum score threshold for Cohere reranking                                                    |
 | `OLLAMA_RERANK_MODEL`                   | No       | dengcao/Qwen3-Reranker-8B:Q4_K_M              | Ollama reranking model                                                                           |
 | `OLLAMA_SCORE_THRESHOLD`                | No       | 0.3                                            | Minimum score threshold for Ollama reranking                                                    |
 | **Email / SMTP**                        |          |                                                |                                                                                                 |
-| `EMAIL_TRANSPORT`                       | No       | —                                              | Email transport: "smtp" or "resend"                                                             |
-| `FROM_EMAIL`                            | No       | —                                              | Sender email address                                                                             |
-| `REPLY_TO_EMAIL`                        | No       | —                                              | Reply-to email address                                                                           |
-| `RESEND_API_KEY`                        | No       | —                                              | Resend API key (required when EMAIL_TRANSPORT=resend)                                           |
-| `RESEND_WEBHOOK_SECRET`                 | No       | —                                              | Resend webhook signing secret                                                                   |
-| `SMTP_HOST`                             | No       | —                                              | SMTP server hostname                                                                             |
-| `SMTP_PORT`                             | No       | —                                              | SMTP server port                                                                                 |
-| `SMTP_SECURE`                           | No       | —                                              | Use TLS for SMTP (true/false)                                                                   |
-| `SMTP_USER`                             | No       | —                                              | SMTP authentication username                                                                    |
-| `SMTP_PASSWORD`                         | No       | —                                              | SMTP authentication password                                                                    |
+| `EMAIL_TRANSPORT`                       | No       | none                                              | Email transport: "smtp" or "resend"                                                             |
+| `FROM_EMAIL`                            | No       | none                                              | Sender email address                                                                             |
+| `REPLY_TO_EMAIL`                        | No       | none                                              | Reply-to email address                                                                           |
+| `RESEND_API_KEY`                        | No       | none                                              | Resend API key (required when EMAIL_TRANSPORT=resend)                                           |
+| `RESEND_WEBHOOK_SECRET`                 | No       | none                                              | Resend webhook signing secret                                                                   |
+| `SMTP_HOST`                             | No       | none                                              | SMTP server hostname                                                                             |
+| `SMTP_PORT`                             | No       | none                                              | SMTP server port                                                                                 |
+| `SMTP_SECURE`                           | No       | none                                              | Use TLS for SMTP (true/false)                                                                   |
+| `SMTP_USER`                             | No       | none                                              | SMTP authentication username                                                                    |
+| `SMTP_PASSWORD`                         | No       | none                                              | SMTP authentication password                                                                    |
 | **Channels**                            |          |                                                |                                                                                                 |
-| `SLACK_SIGNING_SECRET`                  | No       | —                                              | Slack app signing secret for webhook verification                                               |
-| `TWILIO_ACCOUNT_SID`                    | No       | —                                              | Twilio account SID (required for WhatsApp channel)                                              |
-| `TWILIO_AUTH_TOKEN`                     | No       | —                                              | Twilio auth token (required for WhatsApp channel)                                               |
-| `TWILIO_WHATSAPP_NUMBER`                | No       | —                                              | Twilio WhatsApp number (e.g. whatsapp:+14155238886)                                             |
+| `SLACK_SIGNING_SECRET`                  | No       | none                                              | Slack app signing secret for webhook verification                                               |
+| `TWILIO_ACCOUNT_SID`                    | No       | none                                              | Twilio account SID (required for WhatsApp channel)                                              |
+| `TWILIO_AUTH_TOKEN`                     | No       | none                                              | Twilio auth token (required for WhatsApp channel)                                               |
+| `TWILIO_WHATSAPP_NUMBER`                | No       | none                                              | Twilio WhatsApp number (e.g. whatsapp:+14155238886)                                             |
 | **Other**                               |          |                                                |                                                                                                 |
-| `EXA_API_KEY`                           | No       | —                                              | Exa API key for web search capabilities                                                         |
+| `EXA_API_KEY`                           | No       | none                                              | Exa API key for web search capabilities                                                         |
 
 
 ## Security Considerations

--- a/docs/self-hosting/gateway.mdx
+++ b/docs/self-hosting/gateway.mdx
@@ -15,6 +15,6 @@ corebrain login
 # https://your-domain.com
 ```
 
-This connects the Gateway to your own CORE instance instead of CORE Cloud. Make sure `APP_ORIGIN` and `LOGIN_ORIGIN` are set correctly in your `.env` file — see [Docker setup](/self-hosting/docker#configuring-your-host-url).
+This connects the Gateway to your own CORE instance instead of CORE Cloud. Make sure `APP_ORIGIN` and `LOGIN_ORIGIN` are set correctly in your `.env` file: see [Docker setup](/self-hosting/docker#configuring-your-host-url).
 
 For full Gateway setup and capabilities, see the [Gateway overview](/gateway/overview).

--- a/docs/self-hosting/setup.mdx
+++ b/docs/self-hosting/setup.mdx
@@ -1,0 +1,121 @@
+---
+title: "Self-Host CORE"
+description: "Run your butler on your own infrastructure. Docker-based, fully open source."
+---
+
+CORE runs as a set of Docker containers: the web app, PostgreSQL, Neo4j (memory graph), and Redis. You manage the infrastructure; your data never leaves your machine.
+
+**Requirements:** Docker 20.10+, Docker Compose 2.20+, 4 vCPU / 8 GB RAM / 20 GB storage
+
+---
+
+## Option A: One-click on Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/core?referralCode=LHvbIb&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
+Railway sets up all services automatically. Skip to [Connect a channel](#connect-a-channel) once deployed.
+
+---
+
+## Option B: Docker (manual)
+
+<Steps>
+
+<Step title="Clone and configure">
+
+```bash
+git clone https://github.com/RedPlanetHQ/core.git
+cd core/hosting/docker
+cp .env.example .env
+```
+
+Open `.env` and fill in the required values:
+
+```env
+# Generate all four secrets with: openssl rand -hex 16
+SESSION_SECRET=
+MAGIC_LINK_SECRET=
+ENCRYPTION_KEY=
+NEO4J_PASSWORD=                        # also update NEO4J_AUTH below
+NEO4J_AUTH=neo4j/<your-neo4j-password>
+
+# Pick one AI provider
+ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# GOOGLE_GENERATIVE_AI_API_KEY=...
+
+# Set CHAT_PROVIDER to match (default is openai)
+CHAT_PROVIDER=anthropic
+MODEL=claude-sonnet-4-5
+
+# Only needed if deploying publicly (not localhost)
+# APP_ORIGIN=https://your-domain.com
+# LOGIN_ORIGIN=https://your-domain.com
+```
+
+Everything else in `.env` has working defaults for a local Docker deployment.
+
+</Step>
+
+<Step title="Start CORE">
+
+```bash
+docker compose up -d
+```
+
+Wait ~30 seconds for all services to initialise.
+
+**Verify:** Open [http://localhost:3033](http://localhost:3033): you should see the CORE login screen. If it doesn't load, check logs with `docker compose logs -f webapp`.
+
+</Step>
+
+<Step title="Create your account">
+
+Sign in with your email. CORE sends a magic link: check your terminal logs if you haven't configured an email provider yet:
+
+```bash
+docker compose logs webapp | grep "magic link"
+```
+
+Copy the link from the logs and open it in your browser.
+
+</Step>
+
+<Step title="Connect a channel">
+
+A channel is how you message your butler. **Email is the easiest to start with**: it requires a [Resend](https://resend.com) account and a verified domain.
+
+→ [Set up Email with Resend](/channels/email-resend)
+
+| Channel        | Effort    | Guide |
+| -------------- | --------- | ----- |
+| Email (Resend) | Low       | [Setup guide](/channels/email-resend) |
+| Slack          | Medium    | [Setup guide](/channels/slack) |
+| WhatsApp       | Medium    | Requires Twilio: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_NUMBER` |
+| Telegram       | Community | [Setup guide](/channels/telegram) |
+
+Once a channel is connected, send your first message: your butler will respond.
+
+</Step>
+
+</Steps>
+
+---
+
+## Next steps
+
+<CardGroup cols={3}>
+  <Card title="Environment Variables" icon="gear" href="/self-hosting/environment-variables">
+    Full reference for all configuration options.
+  </Card>
+  <Card title="Embedding Models" icon="database" href="/self-hosting/embeddings">
+    Configure OpenAI, Google, or local Ollama embeddings.
+  </Card>
+  <Card title="Remote Sessions" icon="terminal" href="/quickstart/remote-coding-sessions">
+    Trigger Claude Code sessions from WhatsApp or Slack.
+  </Card>
+</CardGroup>
+
+---
+
+> Need help? Join [#self-hosting on Discord](https://discord.gg/dVTC3BmgEq).

--- a/docs/skills/overview.mdx
+++ b/docs/skills/overview.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Skills"
-description: "Reusable instruction sets that give CORE consistent, memory-powered workflows for your most important use cases"
+description: "Tell your butler how to handle things once — it handles them every time."
 ---
 
-Skills are saved instruction sets that teach CORE how to handle a specific workflow — consistently, every time. Instead of explaining what to do each time, you write it once and trigger it by intent.
+Tell your butler how to handle something once. It handles it every time.
 
-Each skill searches your memory before running, so it already knows your product, vendors, and preferences without you repeating them.
+Skills are saved instructions that teach your butler how to run a specific workflow — consistently, with your memory already loaded. No re-explaining your preferences, your tools, or your context. Write it once, trigger it by intent.
 
-To create one: **Dashboard → Agent → Skills → New Skill**. Add a title, instructions, and a short description so CORE knows when to invoke it.
+To create one: **Dashboard → Agent → Skills → New Skill**. Add a title, instructions, and a short description so your butler knows when to invoke it.
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrites welcome/concepts sections with the new butler narrative (named, persistent, open source)
- Adds mermaid diagrams for agent flow, memory ingest, and memory search pipelines
- New `self-hosting/setup.mdx`: single agent-executable entry point with minimum `.env` block and verification steps at each stage
- New `channels/slack.mdx` and `channels/telegram.mdx` setup guides
- Restructures Open Source nav: Get Started / Configuration / Channels / Remote Sessions / Build Integrations / Migration / Local Dev
- Renames `ai-providers` page to "Extend to Dev Tools (MCP)" to remove ambiguity
- Folds contributing bullets into `building-integrations`, folds gateway content into `remote-coding-sessions`
- Removes em dashes and duplicate H1 headings across all Open Source docs
- Fixes broken `/opensource/get-started` links → `/self-hosting/setup`

## Files changed

- `docs/introduction.mdx`, `docs/getting-started.mdx` — butler narrative, waitlist mode
- `docs/concepts/meta-agent.mdx`, `docs/concepts/toolkit.mdx`, `docs/concepts/memory/*` — mermaid diagrams, butler framing
- `docs/self-hosting/setup.mdx` (new) — agent-executable setup guide
- `docs/channels/slack.mdx` (new), `docs/channels/telegram.mdx` (new)
- `docs/docs.json` — nav restructure
- `docs/self-hosting/*`, `docs/integrations/*`, `docs/opensource/*` — em dash cleanup, H1 fixes