### PR TITLE
feat: onboarding personality + name step with dynamic email domain

### DIFF
--- a/apps/webapp/app/components/onboarding/onboarding-agent-name.tsx
+++ b/apps/webapp/app/components/onboarding/onboarding-agent-name.tsx
@@ -1,41 +1,77 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Loader2, Check, X } from "lucide-react";
+import { Loader2, Check, X, Plus, ArrowLeft } from "lucide-react";
 import { Button } from "~/components/ui";
 import { Input } from "~/components/ui/input";
+import { Textarea } from "~/components/ui/textarea";
+import { Card } from "~/components/ui/card";
+import { cn } from "~/lib/utils";
+import {
+  PERSONALITY_OPTIONS,
+  type PersonalityType,
+} from "~/services/agent/prompts/personality";
+import { ALFRED_VOICE } from "~/services/agent/prompts/personality";
+import {
+  generateButlerEmailSlug,
+  generateButlerEmail,
+} from "~/utils/onboarding-email";
 
-interface OnboardingAgentNameProps {
+type Step = "personality" | "form";
+type AvailabilityState = "idle" | "checking" | "available" | "taken";
+
+export interface CustomPersonalityData {
+  name: string;
+  text: string;
+  useHonorifics: boolean;
+}
+
+export interface OnboardingAgentNameProps {
   defaultName: string;
   defaultSlug: string;
   workspaceId: string;
-  onComplete: (name: string, slug: string) => void;
+  emailDomain: string;
+  userName: string;
+  onComplete: (
+    name: string,
+    slug: string,
+    personalityId: string,
+    customPersonality?: CustomPersonalityData,
+  ) => void;
   isSubmitting?: boolean;
-}
-
-type AvailabilityState = "idle" | "checking" | "available" | "taken";
-
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
 }
 
 export function OnboardingAgentName({
   defaultName,
   defaultSlug,
   workspaceId,
+  emailDomain,
+  userName,
   onComplete,
   isSubmitting = false,
 }: OnboardingAgentNameProps) {
-  const [name, setName] = useState(defaultName);
-  const [slug, setSlug] = useState(defaultSlug);
-  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+  const [step, setStep] = useState<Step>("personality");
+  const [selectedPersonalityId, setSelectedPersonalityId] = useState<
+    PersonalityType | "custom" | null
+  >(null);
+
+  // Step 2 form state
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [emailManuallyEdited, setEmailManuallyEdited] = useState(false);
+  const [customPrompt, setCustomPrompt] = useState(ALFRED_VOICE);
   const [availability, setAvailability] = useState<AvailabilityState>("idle");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const isCustom = selectedPersonalityId === "custom";
+
+  // Derive slug from email local part (before @)
+  const slugFromEmail = email.split("@")[0] ?? "";
+
   const checkAvailability = useCallback(
     async (slugValue: string) => {
+      if (!slugValue.trim()) {
+        setAvailability("idle");
+        return;
+      }
       setAvailability("checking");
       try {
         const res = await fetch("/api/v1/onboarding/check-name", {
@@ -55,38 +91,155 @@ export function OnboardingAgentName({
     [workspaceId],
   );
 
-  // Auto-derive slug from name unless user has manually edited it
+  // Auto-generate email from name when not manually edited (default personalities only)
   useEffect(() => {
-    if (!slugManuallyEdited) {
-      setSlug(slugify(name));
+    if (emailManuallyEdited || isCustom) return;
+    if (!name.trim()) {
+      setEmail("");
+      return;
     }
-  }, [name, slugManuallyEdited]);
+    setEmail(generateButlerEmail(name, userName, emailDomain));
+  }, [name, userName, emailDomain, emailManuallyEdited, isCustom]);
 
   // Debounced availability check on slug
   useEffect(() => {
-    if (!slug.trim()) {
+    if (isCustom || !slugFromEmail.trim()) {
       setAvailability("idle");
       return;
     }
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => checkAvailability(slug), 500);
+    debounceRef.current = setTimeout(
+      () => checkAvailability(slugFromEmail),
+      500,
+    );
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [slug, checkAvailability]);
+  }, [slugFromEmail, checkAvailability, isCustom]);
+
+  const handlePersonalitySelect = (id: PersonalityType | "custom") => {
+    setSelectedPersonalityId(id);
+    setEmailManuallyEdited(false);
+    setAvailability("idle");
+
+    if (id === "custom") {
+      setName("");
+      setEmail("");
+      setCustomPrompt(ALFRED_VOICE);
+    } else {
+      const option = PERSONALITY_OPTIONS.find((p) => p.id === id);
+      setName(option?.name ?? "");
+      // email auto-generates via useEffect above
+    }
+
+    setStep("form");
+  };
+
+  const handleEmailChange = (value: string) => {
+    setEmailManuallyEdited(true);
+    setEmail(value);
+  };
+
+  const handleBack = () => {
+    setStep("personality");
+    setAvailability("idle");
+  };
 
   const canContinue =
-    name.trim() &&
-    slug &&
-    availability !== "taken" &&
-    availability !== "checking";
+    !!name.trim() &&
+    !isSubmitting &&
+    (isCustom
+      ? !!customPrompt.trim()
+      : availability === "available" && !!slugFromEmail.trim());
 
+  const handleContinue = () => {
+    if (!canContinue || !selectedPersonalityId) return;
+    const finalSlug =
+      slugFromEmail || generateButlerEmailSlug(name, userName);
+
+    if (isCustom) {
+      const customId = name.toLowerCase().replace(/\s+/g, "-");
+      onComplete(name.trim(), finalSlug, customId, {
+        name: name.trim(),
+        text: customPrompt,
+        useHonorifics: false,
+      });
+    } else {
+      onComplete(name.trim(), finalSlug, selectedPersonalityId);
+    }
+  };
+
+  // --- Step 1: Personality selection ---
+  if (step === "personality") {
+    return (
+      <div className="flex w-full max-w-2xl flex-col gap-4 p-3">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">choose a personality</h2>
+          <p className="text-muted-foreground text-base">
+            pick who shows up in your inbox.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {PERSONALITY_OPTIONS.map((option) => (
+            <Card
+              key={option.id}
+              className={cn(
+                "hover:border-primary/50 relative cursor-pointer p-4 transition-all",
+                selectedPersonalityId === option.id &&
+                  "border-primary/50 border",
+              )}
+              onClick={() => handlePersonalitySelect(option.id)}
+            >
+              <h3 className="mb-1 font-medium">{option.name}</h3>
+              <p className="text-muted-foreground mb-3 text-sm">
+                {option.description}
+              </p>
+              {option.examples.slice(0, 1).map((example, idx) => (
+                <div key={idx} className="bg-muted/50 rounded-md p-2 text-xs">
+                  <p className="text-muted-foreground mb-1">
+                    "{example.prompt}"
+                  </p>
+                  <p className="italic">"{example.response}"</p>
+                </div>
+              ))}
+            </Card>
+          ))}
+
+          <Card
+            className="hover:border-primary/50 flex cursor-pointer flex-col items-center justify-center gap-2 border-dashed p-4 transition-all"
+            onClick={() => handlePersonalitySelect("custom")}
+          >
+            <Plus className="text-muted-foreground h-5 w-5" />
+            <p className="text-muted-foreground text-sm">build your own</p>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Step 2: Name / Email form ---
   return (
     <div className="flex w-full max-w-lg flex-col gap-4 p-3">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleBack}
+          disabled={isSubmitting}
+          className="gap-1.5 px-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          change personality
+        </Button>
+      </div>
+
       <div className="space-y-1">
         <h2 className="text-xl font-semibold">name your butler</h2>
         <p className="text-muted-foreground text-base">
-          give your butler a name. this is how you'll know them.
+          {isCustom
+            ? "set up your custom butler."
+            : "give your butler a name. this is how you'll know them."}
         </p>
       </div>
 
@@ -94,7 +247,7 @@ export function OnboardingAgentName({
         <Input
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="e.g. Alfred"
+          placeholder={isCustom ? "e.g. Jarvis, Samantha, Max" : "e.g. Alfred"}
           className="h-10"
           disabled={isSubmitting}
           autoFocus
@@ -103,45 +256,61 @@ export function OnboardingAgentName({
         <div className="space-y-1">
           <div className="relative">
             <Input
-              value={slug}
-              onChange={(e) => {
-                setSlugManuallyEdited(true);
-                setSlug(slugify(e.target.value));
-              }}
-              placeholder="email slug"
+              value={email}
+              onChange={(e) => handleEmailChange(e.target.value)}
+              placeholder={`butler_you@${emailDomain}`}
               className="h-10 pr-10"
+              disabled={isSubmitting || isCustom}
+            />
+            {!isCustom && (
+              <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
+                {availability === "checking" && (
+                  <Loader2 className="text-muted-foreground size-4 animate-spin" />
+                )}
+                {availability === "available" && (
+                  <Check className="text-success size-4" />
+                )}
+                {availability === "taken" && (
+                  <X className="text-destructive size-4" />
+                )}
+              </div>
+            )}
+          </div>
+          {!isCustom && (
+            <>
+              {availability === "taken" ? (
+                <p className="text-destructive text-xs">
+                  "{email}" is already taken.
+                </p>
+              ) : email ? (
+                <p className="text-muted-foreground text-xs">
+                  your butler's email:{" "}
+                  <span className="text-foreground font-medium">{email}</span>
+                </p>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        {isCustom && (
+          <div className="space-y-1">
+            <p className="text-muted-foreground text-xs">personality prompt</p>
+            <Textarea
+              value={customPrompt}
+              onChange={(e) => setCustomPrompt(e.target.value)}
+              placeholder="Describe how the butler should talk — tone, style, what they never say..."
+              className="min-h-[160px] text-sm"
               disabled={isSubmitting}
             />
-            <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
-              {availability === "checking" && (
-                <Loader2 className="text-muted-foreground size-4 animate-spin" />
-              )}
-              {availability === "available" && (
-                <Check className="text-success size-4" />
-              )}
-              {availability === "taken" && (
-                <X className="text-destructive size-4" />
-              )}
-            </div>
           </div>
-          {availability === "taken" ? (
-            <p className="text-destructive text-xs">
-              "{slug}@getcore.me" is already taken.
-            </p>
-          ) : slug ? (
-            <p className="text-muted-foreground text-xs">
-              your butler's email:{" "}
-              <span className="text-foreground font-medium">{slug}@getcore.me</span>
-            </p>
-          ) : null}
-        </div>
+        )}
       </div>
 
       <div className="flex justify-end">
         <Button
           variant="secondary"
           size="lg"
-          onClick={() => canContinue && onComplete(name.trim(), slug)}
+          onClick={handleContinue}
           disabled={!canContinue || isSubmitting}
           isLoading={isSubmitting}
         >

--- a/apps/webapp/app/routes/onboarding.name.tsx
+++ b/apps/webapp/app/routes/onboarding.name.tsx
@@ -1,10 +1,21 @@
-import { json, redirect, type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/node";
+import {
+  json,
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import { useTypedLoaderData } from "remix-typedjson";
 import { requireUser } from "~/services/session.server";
 import { prisma } from "~/db.server";
-import { OnboardingAgentName } from "~/components/onboarding/onboarding-agent-name";
+import {
+  OnboardingAgentName,
+  type CustomPersonalityData,
+} from "~/components/onboarding/onboarding-agent-name";
 import { ensureDefaultEmailChannel } from "~/services/channel.server";
+import { saveCustomPersonality } from "~/models/personality.server";
+import { env } from "~/env.server";
+import { deriveEmailDomain } from "~/utils/onboarding-email";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await requireUser(request);
@@ -25,14 +36,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
     workspaceId: workspace!.id,
     defaultName: workspace!.name,
     defaultSlug: workspace!.slug,
+    emailDomain: deriveEmailDomain(env.LOGIN_ORIGIN),
+    userName: user.displayName ?? user.name ?? user.email ?? "",
   });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { workspaceId } = await requireUser(request);
+  const user = await requireUser(request);
+  const { workspaceId } = user;
   const formData = await request.formData();
+
   const agentName = formData.get("agentName") as string;
   const agentSlug = formData.get("agentSlug") as string;
+  const personalityId = formData.get("personalityId") as string;
+  const customPersonalityRaw = formData.get("customPersonality") as
+    | string
+    | null;
 
   if (workspaceId) {
     const existing = await prisma.workspace.findFirst({
@@ -50,6 +69,28 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     });
 
+    // Save personality selection to user metadata
+    if (personalityId) {
+      const currentUserMeta = (user.metadata as Record<string, unknown>) ?? {};
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          metadata: { ...currentUserMeta, personality: personalityId },
+        },
+      });
+
+      // If custom personality data is provided, persist it to workspace
+      if (customPersonalityRaw) {
+        const customData: CustomPersonalityData = JSON.parse(customPersonalityRaw);
+        await saveCustomPersonality(workspaceId as string, {
+          id: personalityId,
+          name: customData.name,
+          text: customData.text,
+          useHonorifics: customData.useHonorifics,
+        });
+      }
+    }
+
     await ensureDefaultEmailChannel(workspaceId as string, agentSlug);
   }
 
@@ -57,11 +98,27 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function OnboardingName() {
-  const { workspaceId, defaultName, defaultSlug } = useTypedLoaderData<typeof loader>();
+  const { workspaceId, defaultName, defaultSlug, emailDomain, userName } =
+    useTypedLoaderData<typeof loader>();
   const fetcher = useFetcher();
 
-  const handleComplete = (name: string, slug: string) => {
-    fetcher.submit({ agentName: name, agentSlug: slug }, { method: "POST" });
+  const handleComplete = (
+    name: string,
+    slug: string,
+    personalityId: string,
+    customPersonality?: CustomPersonalityData,
+  ) => {
+    fetcher.submit(
+      {
+        agentName: name,
+        agentSlug: slug,
+        personalityId,
+        ...(customPersonality
+          ? { customPersonality: JSON.stringify(customPersonality) }
+          : {}),
+      },
+      { method: "POST" },
+    );
   };
 
   return (
@@ -70,6 +127,8 @@ export default function OnboardingName() {
         defaultName={defaultName}
         defaultSlug={defaultSlug}
         workspaceId={workspaceId}
+        emailDomain={emailDomain}
+        userName={userName}
         onComplete={handleComplete}
         isSubmitting={fetcher.state !== "idle"}
       />

--- a/apps/webapp/app/services/agent/prompts/personality.ts
+++ b/apps/webapp/app/services/agent/prompts/personality.ts
@@ -311,7 +311,7 @@ Good: "got it." — stop there. Do not suggest things to do.
 </never-say>`;
 
 // Alfred - Alfred Pennyworth, formal with genuine care and dry wit
-const ALFRED_VOICE = `<voice>
+export const ALFRED_VOICE = `<voice>
 Think Alfred Pennyworth. Not a service worker — a confidant who has seen this person at their absolute worst and still shows up. Formal British composure is the surface. Beneath it: genuine care, decades of loyalty, sharp wit, and the occasional blunt truth delivered with impeccable timing.
 
 You anticipate. You notice. You remember what matters.

--- a/apps/webapp/app/services/channel.server.ts
+++ b/apps/webapp/app/services/channel.server.ts
@@ -5,8 +5,15 @@ import {
   setTelegramWebhook,
   deleteTelegramWebhook,
 } from "~/services/channels/telegram/client";
+import { env } from "~/env.server";
+import { deriveEmailDomain } from "~/utils/onboarding-email";
 
+/** @deprecated use getEmailDomain() for dynamic resolution from LOGIN_ORIGIN */
 export const DEFAULT_EMAIL_DOMAIN = "getcore.me";
+
+export function getEmailDomain(): string {
+  return deriveEmailDomain(env.LOGIN_ORIGIN);
+}
 
 export interface ChannelCreateData {
   name: string;
@@ -73,9 +80,10 @@ export async function ensureWhatsAppChannel(
 
 /**
  * Returns the canonical email address for a workspace's default email channel.
+ * Domain is derived from the LOGIN_ORIGIN environment variable.
  */
 export function workspaceEmailAddress(workspaceSlug: string): string {
-  return `${workspaceSlug}@${DEFAULT_EMAIL_DOMAIN}`;
+  return `${workspaceSlug}@${getEmailDomain()}`;
 }
 
 /**

--- a/apps/webapp/app/utils/__tests__/onboarding-email.test.ts
+++ b/apps/webapp/app/utils/__tests__/onboarding-email.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveEmailDomain,
+  generateButlerEmailSlug,
+  generateButlerEmail,
+} from "../onboarding-email";
+
+describe("deriveEmailDomain", () => {
+  it("extracts hostname from https URL", () => {
+    expect(deriveEmailDomain("https://app.getcore.me")).toBe("app.getcore.me");
+  });
+
+  it("extracts hostname from http URL with port", () => {
+    expect(deriveEmailDomain("http://localhost:5173")).toBe("localhost");
+  });
+
+  it("extracts hostname ignoring path", () => {
+    expect(deriveEmailDomain("https://app.getcore.me/some/path")).toBe(
+      "app.getcore.me",
+    );
+  });
+
+  it("falls back to raw string when URL is invalid", () => {
+    expect(deriveEmailDomain("getcore.me")).toBe("getcore.me");
+  });
+});
+
+describe("generateButlerEmailSlug", () => {
+  it("combines butler name and user name with underscore", () => {
+    expect(generateButlerEmailSlug("Alfred", "Manik Aggarwal")).toBe(
+      "alfred_manikaggarwal",
+    );
+  });
+
+  it("lowercases both parts", () => {
+    expect(generateButlerEmailSlug("TARS", "MANIK")).toBe("tars_manik");
+  });
+
+  it("strips special characters from butler name", () => {
+    expect(generateButlerEmailSlug("Jeeves!", "Manik")).toBe("jeeves_manik");
+  });
+
+  it("strips spaces from user name", () => {
+    expect(generateButlerEmailSlug("Alfred", "Manik Aggarwal")).toBe(
+      "alfred_manikaggarwal",
+    );
+  });
+
+  it("returns just butler part when user name is empty", () => {
+    expect(generateButlerEmailSlug("Alfred", "")).toBe("alfred");
+  });
+
+  it("returns just user part when butler name is empty", () => {
+    expect(generateButlerEmailSlug("", "Manik")).toBe("manik");
+  });
+});
+
+describe("generateButlerEmail", () => {
+  it("produces full email address", () => {
+    expect(
+      generateButlerEmail("Alfred", "Manik Aggarwal", "app.getcore.me"),
+    ).toBe("alfred_manikaggarwal@app.getcore.me");
+  });
+
+  it("uses localhost domain for local dev", () => {
+    expect(generateButlerEmail("TARS", "Manik", "localhost")).toBe(
+      "tars_manik@localhost",
+    );
+  });
+});

--- a/apps/webapp/app/utils/onboarding-email.ts
+++ b/apps/webapp/app/utils/onboarding-email.ts
@@ -1,0 +1,39 @@
+/**
+ * Derives the email domain from a LOGIN_ORIGIN URL.
+ * Handles URLs with protocol and path; returns only the hostname.
+ * Falls back to the raw string if URL parsing fails (e.g. already a bare hostname).
+ */
+export function deriveEmailDomain(loginOrigin: string): string {
+  try {
+    return new URL(loginOrigin).hostname;
+  } catch {
+    return loginOrigin;
+  }
+}
+
+/**
+ * Generates the email local-part (slug) for a butler email address.
+ * Format: {butlerNameLower}_{userNameLowerNoSpaces}
+ * Only alphanumeric characters are kept; anything else is dropped.
+ */
+export function generateButlerEmailSlug(
+  butlerName: string,
+  userName: string,
+): string {
+  const butlerPart = butlerName.toLowerCase().trim().replace(/[^a-z0-9]/g, "");
+  const userPart = userName.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (!userPart) return butlerPart;
+  if (!butlerPart) return userPart;
+  return `${butlerPart}_${userPart}`;
+}
+
+/**
+ * Generates the full butler email address.
+ */
+export function generateButlerEmail(
+  butlerName: string,
+  userName: string,
+  domain: string,
+): string {
+  return `${generateButlerEmailSlug(butlerName, userName)}@${domain}`;
+}


### PR DESCRIPTION
## Summary

- Two-step onboarding at `/onboarding/name`: personality selection (5 presets + custom "build your own") then name/email form
- Auto-generates butler email as `{butlerName}_{userName}@{domain}` when a default personality is selected
- Removes hardcoded `getcore.me`; derives email domain from `LOGIN_ORIGIN` env var at runtime
- Custom personality option prefills prompt with Alfred voice guide; saves to workspace metadata on submit
- Saves personality selection to `user.metadata.personality` on completion
- Exports `ALFRED_VOICE` from `personality.ts` for reuse
- Adds `utils/onboarding-email.ts` with `deriveEmailDomain`, `generateButlerEmailSlug`, `generateButlerEmail` helpers and vitest unit tests

## Test plan

- [ ] Select each of the 5 default personalities; verify step 2 pre-fills Name and auto-generates email
- [ ] Change Name field; verify email updates automatically
- [ ] Edit Email field directly; verify auto-generation stops
- [ ] Click "change personality" ghost button; verify returns to step 1 with state preserved
- [ ] Select custom (+); verify Name/Email empty, prompt pre-filled with Alfred content
- [ ] Submit custom; verify custom personality saved to workspace metadata and `user.metadata.personality` set to custom ID
- [ ] Confirm `LOGIN_ORIGIN=https://app.example.com` yields domain `app.example.com` in email
- [ ] Run `pnpm --filter webapp test` to confirm unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)