### PR TITLE
fix: abort Mastra stream on stop button click (#709)

### DIFF
--- a/apps/webapp/app/components/conversation/__tests__/conversation-view-stop.test.ts
+++ b/apps/webapp/app/components/conversation/__tests__/conversation-view-stop.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Structural tests verifying the frontend stop button wiring.
+ *
+ * Full React component tests would require jsdom + mocking @ai-sdk/react,
+ * which is heavy for this fix. These tests validate the critical code
+ * changes that make the stop button work:
+ *
+ * 1. handleStop calls both stop() and the /stop endpoint
+ * 2. The stop prop is wired to handleStop (not the raw stop())
+ */
+
+describe("ConversationView stop button wiring", () => {
+  const componentPath = resolve(
+    __dirname,
+    "../conversation-view.client.tsx",
+  );
+  const source = readFileSync(componentPath, "utf-8");
+
+  it("defines handleStop callback", () => {
+    expect(source).toContain("const handleStop = useCallback(");
+  });
+
+  it("handleStop calls useChat stop()", () => {
+    // The stop() call should be inside handleStop
+    const handleStopBlock = source.match(
+      /const handleStop = useCallback\(\(\) => \{[\s\S]*?\}, \[/,
+    );
+    expect(handleStopBlock).not.toBeNull();
+    expect(handleStopBlock![0]).toContain("stop()");
+  });
+
+  it("handleStop calls the stop endpoint", () => {
+    const handleStopBlock = source.match(
+      /const handleStop = useCallback\(\(\) => \{[\s\S]*?\}, \[/,
+    );
+    expect(handleStopBlock).not.toBeNull();
+    expect(handleStopBlock![0]).toContain("/stop");
+    expect(handleStopBlock![0]).toContain('method: "POST"');
+  });
+
+  it("passes handleStop to ConversationTextarea (not raw stop)", () => {
+    // Should use stop={handleStop}, NOT stop={() => stop()}
+    expect(source).toContain("stop={handleStop}");
+    expect(source).not.toContain("stop={() => stop()}");
+  });
+
+  it("handleStop depends on conversationId for correct URL", () => {
+    expect(source).toMatch(/\[stop,\s*conversationId\]/);
+  });
+});

--- a/apps/webapp/app/components/conversation/conversation-view.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-view.client.tsx
@@ -151,6 +151,15 @@ export function ConversationView({
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
 
+  const handleStop = useCallback(() => {
+    stop();
+    fetch(`/api/v1/conversation/${conversationId}/stop`, {
+      method: "POST",
+    }).catch(() => {
+      // best-effort — the abort signal on the stream handles the critical path
+    });
+  }, [stop, conversationId]);
+
   useEffect(() => {
     if (autoRegenerate && history.length === 1) {
       regenerate();
@@ -290,7 +299,7 @@ export function ConversationView({
             onConversationCreated={(message) => {
               if (message) sendMessage({ text: message });
             }}
-            stop={() => stop()}
+            stop={handleStop}
             models={modelsProp}
             selectedModelId={selectedModelId}
             onModelChange={handleModelChange}

--- a/apps/webapp/app/routes/__tests__/api.v1.conversation.abort-signal.test.ts
+++ b/apps/webapp/app/routes/__tests__/api.v1.conversation.abort-signal.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Focused unit test verifying that request.signal is wired through to
+ * agent.stream() as abortSignal, and that aborting marks the conversation
+ * as completed.
+ *
+ * Because the conversation route has many heavy dependencies (Mastra, Prisma,
+ * LLM providers), this test validates the critical wiring in isolation by
+ * reading the source and asserting on the code structure. For integration
+ * testing, use a running dev server.
+ */
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("api.v1.conversation._index abort signal wiring", () => {
+  const routePath = resolve(
+    __dirname,
+    "../../routes/api.v1.conversation._index.tsx",
+  );
+  const source = readFileSync(routePath, "utf-8");
+
+  it("destructures request from handler args", () => {
+    expect(source).toMatch(/async\s*\(\{[^}]*request[^}]*\}\)/);
+  });
+
+  it("extracts abortSignal from request.signal", () => {
+    expect(source).toContain("const abortSignal = request.signal");
+  });
+
+  it("passes abortSignal to agent.stream()", () => {
+    // Should appear inside the agent.stream() options object
+    const streamCallMatch = source.match(
+      /agent\.stream\([\s\S]*?\{[\s\S]*?abortSignal[\s\S]*?\}\)/,
+    );
+    expect(streamCallMatch).not.toBeNull();
+  });
+
+  it("listens for abort event to update conversation status", () => {
+    expect(source).toContain('abortSignal.addEventListener');
+    expect(source).toContain('"abort"');
+    expect(source).toMatch(
+      /updateConversationStatus\(body\.id,\s*"completed"\)/,
+    );
+  });
+
+  it("uses { once: true } to avoid listener leaks", () => {
+    expect(source).toContain("{ once: true }");
+  });
+});

--- a/apps/webapp/app/routes/__tests__/api.v1.conversation.stop.test.ts
+++ b/apps/webapp/app/routes/__tests__/api.v1.conversation.stop.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the module under test
+const mockGetConversation = vi.fn();
+const mockUpdateConversationStatus = vi.fn();
+const mockLogger = { info: vi.fn(), error: vi.fn() };
+
+vi.mock("~/services/conversation.server", () => ({
+  getConversation: mockGetConversation,
+  updateConversationStatus: mockUpdateConversationStatus,
+}));
+
+vi.mock("~/services/logger.service", () => ({
+  logger: mockLogger,
+}));
+
+vi.mock("~/services/routeBuilders/apiBuilder.server", () => ({
+  createHybridActionApiRoute: (
+    _opts: any,
+    handler: (args: any) => Promise<Response>,
+  ) => {
+    // Expose the handler so tests can call it directly
+    return {
+      loader: async () => new Response(null, { status: 405 }),
+      action: async (args: any) => handler(args),
+      __handler: handler,
+    };
+  },
+}));
+
+describe("POST /api/v1/conversation/:conversationId/stop", () => {
+  let handler: (args: any) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import(
+      "../../routes/api.v1.conversation.$conversationId.stop"
+    );
+    // The action export is what gets called for POST
+    handler = (mod.action as any).__handler ?? mod.action;
+  });
+
+  it("returns 404 when conversation does not exist", async () => {
+    mockGetConversation.mockResolvedValue(null);
+
+    const response = await handler({
+      params: { conversationId: "conv-123" },
+      authentication: { userId: "user-1" },
+    });
+
+    const body = await response.json();
+    expect(response.status).toBe(404);
+    expect(body.error).toBe("Conversation not found");
+    expect(mockUpdateConversationStatus).not.toHaveBeenCalled();
+  });
+
+  it("marks running conversation as completed", async () => {
+    mockGetConversation.mockResolvedValue({
+      id: "conv-123",
+      status: "running",
+    });
+    mockUpdateConversationStatus.mockResolvedValue(undefined);
+
+    const response = await handler({
+      params: { conversationId: "conv-123" },
+      authentication: { userId: "user-1" },
+    });
+
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockUpdateConversationStatus).toHaveBeenCalledWith(
+      "conv-123",
+      "completed",
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining("stopped by user"),
+    );
+  });
+
+  it("is idempotent — does not update if not running", async () => {
+    mockGetConversation.mockResolvedValue({
+      id: "conv-123",
+      status: "completed",
+    });
+
+    const response = await handler({
+      params: { conversationId: "conv-123" },
+      authentication: { userId: "user-1" },
+    });
+
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockUpdateConversationStatus).not.toHaveBeenCalled();
+  });
+
+  it("scopes lookup to authenticated user", async () => {
+    mockGetConversation.mockResolvedValue(null);
+
+    await handler({
+      params: { conversationId: "conv-123" },
+      authentication: { userId: "user-other" },
+    });
+
+    expect(mockGetConversation).toHaveBeenCalledWith("conv-123", "user-other");
+  });
+});

--- a/apps/webapp/app/routes/api.v1.conversation.$conversationId.stop.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation.$conversationId.stop.tsx
@@ -1,0 +1,43 @@
+import { json } from "@remix-run/node";
+import { z } from "zod";
+import { createHybridActionApiRoute } from "~/services/routeBuilders/apiBuilder.server";
+import {
+  getConversation,
+  updateConversationStatus,
+} from "~/services/conversation.server";
+import { logger } from "~/services/logger.service";
+
+const ParamsSchema = z.object({
+  conversationId: z.string(),
+});
+
+const { loader, action } = createHybridActionApiRoute(
+  {
+    params: ParamsSchema,
+    allowJWT: true,
+    authorization: { action: "conversation" },
+    corsStrategy: "all",
+    method: "POST",
+  },
+  async ({ params, authentication }) => {
+    const conversation = await getConversation(
+      params.conversationId,
+      authentication.userId,
+    );
+
+    if (!conversation) {
+      return json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    if (conversation.status === "running") {
+      await updateConversationStatus(params.conversationId, "completed");
+      logger.info(
+        `[conversation] stopped by user, conversationId=${params.conversationId}`,
+      );
+    }
+
+    return json({ ok: true, status: "completed" });
+  },
+);
+
+export { loader, action };

--- a/apps/webapp/app/routes/api.v1.conversation._index.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation._index.tsx
@@ -70,7 +70,7 @@ const { loader, action } = createHybridActionApiRoute(
     authorization: { action: "conversation" },
     corsStrategy: "all",
   },
-  async ({ body, authentication }) => {
+  async ({ body, authentication, request }) => {
     const conversation = await getConversationAndHistory(
       body.id,
       authentication.userId,
@@ -313,6 +313,8 @@ const { loader, action } = createHybridActionApiRoute(
     // -----------------------------------------------------------------------
     await updateConversationStatus(body.id, "running");
 
+    const abortSignal = request.signal;
+
     const stream = await agent.stream(modelMessages, {
       toolsets: { core: tools },
       runId: body.id,
@@ -320,7 +322,18 @@ const { loader, action } = createHybridActionApiRoute(
       toolCallConcurrency: 1,
       outputProcessors: [messageHistoryProcessor as OutputProcessor],
       modelSettings: { temperature: 0.5 },
+      abortSignal,
     });
+
+    // When the client disconnects (stop button / navigation), mark
+    // the conversation as completed so it doesn't stay "running" forever.
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        updateConversationStatus(body.id, "completed").catch(() => {});
+      },
+      { once: true },
+    );
 
     return streamToUIResponse(stream);
   },


### PR DESCRIPTION
Wire the client stop button to both abort the Vercel AI stream and hit a new POST /api/v1/conversation/:id/stop endpoint so the server-side Mastra agent stream is cancelled via request.signal and the conversation status is set to "completed" instead of staying "running" forever.