### PR TITLE
fix(gmail): metadata-only scheduled payload + fix Redis NaN port

### DIFF
--- a/apps/webapp/app/bullmq/connection.ts
+++ b/apps/webapp/app/bullmq/connection.ts
@@ -17,7 +17,7 @@ export function getRedisConnection() {
 
   const redisConfig: RedisOptions = {
     host: process.env.REDIS_HOST,
-    port: parseInt(process.env.REDIS_PORT as string),
+    port: process.env.REDIS_PORT ? parseInt(process.env.REDIS_PORT, 10) : 6379,
     password: process.env.REDIS_PASSWORD,
     maxRetriesPerRequest: null, // Required for BullMQ
     enableReadyCheck: false, // Required for BullMQ

--- a/integrations/gmail/package.json
+++ b/integrations/gmail/package.json
@@ -24,14 +24,14 @@
     "build:frontend": "tsup",
     "dev:frontend": "tsup --watch",
     "lint": "eslint --ext js,ts,tsx src/ --fix",
-    "prettier": "prettier --config .prettierrc --write ."
+    "prettier": "prettier --config .prettierrc --write .",
+    "test": "bun test src/schedule.test.ts"
   },
   "devDependencies": {
     "@types/react": "^19.2.13",
     "react": "^19.2.4",
     "tsup": "^8.0.1",
     "@types/nodemailer": "^6.4.17",
-    "@types/turndown": "^5.0.5",
     "@babel/preset-typescript": "^7.26.0",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.1.0",
@@ -81,7 +81,6 @@
     "openai": "^4.0.0",
     "react-query": "^3.39.3",
     "@redplanethq/sdk": "0.1.18",
-    "turndown": "^7.2.0",
     "@redplanethq/ui": "2.1.4"
   }
 }

--- a/integrations/gmail/src/schedule.test.ts
+++ b/integrations/gmail/src/schedule.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for Gmail scheduled activity payload.
+ *
+ * Key assertions:
+ * - Activity data contains only email metadata fields (no body/text/html/raw)
+ * - All expected metadata fields are present (id, threadId, subject, from, to,
+ *   date, internalDate, snippet, labelIds, sourceURL)
+ * - format:'metadata' is passed to gmail.users.messages.get (no body fetched)
+ *
+ * Run with: bun test ./src/schedule.test.ts
+ */
+import { describe, it, expect, mock } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mock ./utils so no real googleapis / OAuth client is needed
+// ---------------------------------------------------------------------------
+const mockGmailClient = {
+  users: {
+    getProfile: mock(async () => ({ data: { emailAddress: 'user@example.com' } })),
+    messages: {
+      list: mock(async ({ q }: { q: string }) => {
+        if (q.includes('in:inbox')) {
+          return { data: { messages: [{ id: 'inbox-1' }] } };
+        }
+        if (q.includes('in:sent')) {
+          return { data: { messages: [{ id: 'sent-1' }] } };
+        }
+        return { data: { messages: [] } };
+      }),
+      get: mock(async ({ id, format }: { id: string; format: string }) => {
+        // Verify metadata format is requested (not 'full' which would include body)
+        if (format !== 'metadata') {
+          throw new Error(`Expected format:'metadata' but got '${format}'`);
+        }
+        const now = Date.now();
+        if (id === 'inbox-1') {
+          return {
+            data: {
+              id,
+              threadId: 'thread-inbox-1',
+              internalDate: String(now + 5000),
+              snippet: 'Preview of the received email',
+              labelIds: ['INBOX', 'IMPORTANT'],
+              payload: {
+                headers: [
+                  { name: 'From', value: 'Alice <alice@example.com>' },
+                  { name: 'To', value: 'user@example.com' },
+                  { name: 'Subject', value: 'Meeting tomorrow' },
+                  { name: 'Date', value: 'Mon, 07 Apr 2026 09:00:00 +0000' },
+                ],
+              },
+            },
+          };
+        }
+        // sent-1
+        return {
+          data: {
+            id,
+            threadId: 'thread-sent-1',
+            internalDate: String(now + 10000),
+            snippet: 'Preview of the sent email',
+            labelIds: ['SENT'],
+            payload: {
+              headers: [
+                { name: 'From', value: 'user@example.com' },
+                { name: 'To', value: 'Bob <bob@example.com>' },
+                { name: 'Subject', value: 'Re: Meeting tomorrow' },
+                { name: 'Date', value: 'Mon, 07 Apr 2026 09:05:00 +0000' },
+              ],
+            },
+          },
+        };
+      }),
+    },
+  },
+};
+
+mock.module('./utils', () => ({
+  getGmailClient: mock(async () => mockGmailClient),
+  formatEmailSender: (from: string) => {
+    const match = from.match(/^(.+?)\s*<.+?>$/);
+    return match ? match[1].trim() : from;
+  },
+}));
+
+// Import AFTER mocks are registered
+const { handleSchedule } = await import('./schedule');
+
+// ---------------------------------------------------------------------------
+
+function makeConfig() {
+  return { access_token: 'fake-token', refresh_token: 'fake-refresh' };
+}
+
+function makeIntegrationDefinition() {
+  return { config: { clientId: 'cid', clientSecret: 'csec' } };
+}
+
+describe('handleSchedule — metadata-only payload', () => {
+  it('requests format:metadata (never format:full)', async () => {
+    await handleSchedule(makeConfig(), makeIntegrationDefinition(), {});
+    const calls = (mockGmailClient.users.messages.get as ReturnType<typeof mock>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [args] of calls) {
+      expect((args as any).format).toBe('metadata');
+    }
+  });
+
+  it('activity text contains no body/HTML/raw markers', async () => {
+    const messages = await handleSchedule(makeConfig(), makeIntegrationDefinition(), {});
+    const activities = messages.filter((m: any) => m.type === 'activity');
+    expect(activities.length).toBeGreaterThan(0);
+
+    for (const activity of activities) {
+      const text: string = activity.data.text;
+      expect(text).not.toMatch(/Content-Type:/i);
+      expect(text).not.toMatch(/Content-Transfer-Encoding:/i);
+      expect(text).not.toMatch(/<html/i);
+      expect(text).not.toMatch(/base64/i);
+    }
+  });
+
+  it('activity text includes all required metadata labels', async () => {
+    const messages = await handleSchedule(makeConfig(), makeIntegrationDefinition(), {});
+    const activities = messages.filter((m: any) => m.type === 'activity');
+    expect(activities.length).toBeGreaterThan(0);
+
+    for (const activity of activities) {
+      const text: string = activity.data.text;
+      expect(text).toMatch(/\*\*From:\*\*/);
+      expect(text).toMatch(/\*\*To:\*\*/);
+      expect(text).toMatch(/\*\*Subject:\*\*/);
+      expect(text).toMatch(/\*\*Date:\*\*/);
+      expect(text).toMatch(/\*\*Thread ID:\*\*/);
+      expect(text).toMatch(/\*\*Labels:\*\*/);
+      expect(text).toMatch(/\*\*Snippet:\*\*/);
+    }
+  });
+
+  it('activity sourceURL points to mail.google.com', async () => {
+    const messages = await handleSchedule(makeConfig(), makeIntegrationDefinition(), {});
+    const activities = messages.filter((m: any) => m.type === 'activity');
+    for (const activity of activities) {
+      expect(activity.data.sourceURL).toMatch(/^https:\/\/mail\.google\.com/);
+    }
+  });
+
+  it('received email sourceURL includes #inbox/', async () => {
+    const messages = await handleSchedule(makeConfig(), makeIntegrationDefinition(), {});
+    const inbox = messages.find(
+      (m: any) => m.type === 'activity' && m.data.sourceURL.includes('#inbox/')
+    );
+    expect(inbox).toBeDefined();
+  });
+
+  it('sent email sourceURL includes #sent/', async () => {
+    const messages = await handleSchedule(makeConfig(), makeIntegrationDefinition(), {});
+    const sent = messages.find(
+      (m: any) => m.type === 'activity' && m.data.sourceURL.includes('#sent/')
+    );
+    expect(sent).toBeDefined();
+  });
+
+  it('returns empty array when access_token is missing', async () => {
+    const result = await handleSchedule({}, makeIntegrationDefinition(), {});
+    expect(result).toEqual([]);
+  });
+
+  it('GmailScheduledEmailMetadata shape contains only metadata fields — no body fields', () => {
+    // Verify that the allowed key set does not include any body/content fields.
+    const allowedKeys = [
+      'id', 'threadId', 'subject', 'from', 'to',
+      'date', 'internalDate', 'snippet', 'labelIds', 'sourceURL',
+    ];
+    const forbiddenKeys = ['body', 'text', 'html', 'raw', 'parts', 'payload', 'content'];
+
+    for (const key of forbiddenKeys) {
+      expect(allowedKeys.includes(key)).toBe(false);
+    }
+
+    // A concrete metadata object should have exactly the allowed keys
+    const meta = {
+      id: 'msg-1',
+      threadId: 'thread-1',
+      subject: 'Test Subject',
+      from: 'sender@example.com',
+      to: 'recipient@example.com',
+      date: 'Mon, 07 Apr 2026 09:00:00 +0000',
+      internalDate: Date.now(),
+      snippet: 'Short preview only',
+      labelIds: ['INBOX'],
+      sourceURL: 'https://mail.google.com/mail/u/0/#inbox/msg-1',
+    };
+
+    for (const key of forbiddenKeys) {
+      expect(Object.prototype.hasOwnProperty.call(meta, key)).toBe(false);
+    }
+    for (const key of allowedKeys) {
+      expect(Object.prototype.hasOwnProperty.call(meta, key)).toBe(true);
+    }
+  });
+});

--- a/integrations/gmail/src/schedule.ts
+++ b/integrations/gmail/src/schedule.ts
@@ -1,5 +1,4 @@
-import { getGmailClient, parseEmailContent, formatEmailSender, GmailConfig } from './utils';
-import TurndownService from 'turndown';
+import { getGmailClient, formatEmailSender, GmailConfig } from './utils';
 
 interface GmailSettings {
   lastSyncTime?: string;
@@ -7,20 +6,42 @@ interface GmailSettings {
   emailAddress?: string;
 }
 
-interface GmailActivityCreateParams {
-  text: string;
+/**
+ * Metadata-only representation of a scheduled Gmail email activity.
+ * No message body or raw content is included.
+ */
+export interface GmailScheduledEmailMetadata {
+  id: string;
+  threadId: string;
+  subject: string;
+  from: string;
+  to: string;
+  date: string;
+  internalDate: number;
+  snippet: string;
+  labelIds: string[];
   sourceURL: string;
 }
 
 /**
- * Creates an activity message based on Gmail data
+ * Creates an activity message containing only email metadata (no body/text)
  */
-function createActivityMessage(params: GmailActivityCreateParams) {
+function createActivityMessage(metadata: GmailScheduledEmailMetadata) {
+  const lines = [
+    `**From:** ${metadata.from}`,
+    `**To:** ${metadata.to}`,
+    `**Subject:** ${metadata.subject}`,
+    `**Date:** ${metadata.date}`,
+    `**Thread ID:** ${metadata.threadId}`,
+    `**Labels:** ${metadata.labelIds.join(', ')}`,
+    `**Snippet:** ${metadata.snippet}`,
+  ];
+
   return {
     type: 'activity',
     data: {
-      text: params.text,
-      sourceURL: params.sourceURL,
+      text: lines.join('\n'),
+      sourceURL: metadata.sourceURL,
     },
   };
 }
@@ -33,35 +54,6 @@ function getDefaultSyncTime(): string {
 }
 
 /**
- * Initialize Turndown service for HTML to Markdown conversion
- */
-const turndownService = new TurndownService({
-  headingStyle: 'atx',
-  codeBlockStyle: 'fenced',
-  emDelimiter: '*',
-});
-
-// Remove style, script, and other unwanted elements
-turndownService.remove(['style', 'script', 'noscript', 'iframe', 'object', 'embed']);
-
-/**
- * Clean and convert email content to markdown
- */
-function cleanEmailContent(htmlContent: string, textContent: string): string {
-  // If we have HTML content, convert it to markdown
-  if (htmlContent) {
-    const markdown = turndownService.turndown(htmlContent);
-    return markdown
-      .replace(/\n\n+/g, '\n\n') // Remove excessive line breaks
-      .replace(/\s+/g, ' ') // Normalize spaces
-      .trim();
-  }
-
-  // Otherwise use text content and clean it
-  return textContent.replace(/\r/g, '').replace(/\n\n+/g, '\n\n').replace(/\s+/g, ' ').trim();
-}
-
-/**
  * Convert ISO date to Gmail query format as Unix timestamp in seconds
  * Using timestamp is more precise than YYYY/MM/DD which truncates to day
  */
@@ -70,7 +62,7 @@ function toGmailTimestamp(isoDate: string): number {
 }
 
 /**
- * Fetch and process received emails
+ * Fetch and process received emails — metadata only, no body parts
  */
 async function processReceivedEmails(
   gmail: any,
@@ -82,7 +74,6 @@ async function processReceivedEmails(
   let lastEmailTime = 0;
 
   try {
-    // Query for important received emails after lastSyncTime
     const response = await gmail.users.messages.list({
       userId: 'me',
       q: `in:inbox is:important after:${afterTimestamp}`,
@@ -93,21 +84,26 @@ async function processReceivedEmails(
 
     for (const message of messages) {
       try {
-        // Get full message details
-        const fullMessage = await gmail.users.messages.get({
+        // Fetch metadata only — no body parts returned
+        const metaMessage = await gmail.users.messages.get({
           userId: 'me',
           id: message.id,
-          format: 'full',
+          format: 'metadata',
+          metadataHeaders: ['From', 'To', 'Subject', 'Date'],
         });
 
-        const headers = fullMessage.data.payload.headers;
+        const headers = metaMessage.data.payload?.headers ?? [];
         const from = headers.find((h: any) => h.name === 'From')?.value || 'Unknown';
+        const to = headers.find((h: any) => h.name === 'To')?.value || emailAddress;
         const subject = headers.find((h: any) => h.name === 'Subject')?.value || '(No subject)';
         const date = headers.find((h: any) => h.name === 'Date')?.value || '';
 
-        const internalDate = parseInt(fullMessage.data.internalDate || '0');
+        const internalDate = parseInt(metaMessage.data.internalDate || '0');
+        const snippet = metaMessage.data.snippet || '';
+        const labelIds: string[] = metaMessage.data.labelIds || [];
+        const threadId: string = metaMessage.data.threadId || '';
 
-        // Skip emails that are at or before lastSyncTime (Gmail after: is not precise at second level)
+        // Skip emails at or before lastSyncTime
         const lastSyncMs = new Date(lastSyncTime).getTime();
         if (internalDate <= lastSyncMs) {
           continue;
@@ -118,38 +114,23 @@ async function processReceivedEmails(
         }
 
         const sender = formatEmailSender(from);
-        const threadId = fullMessage.data.threadId || '';
-        const { textContent, htmlContent } = parseEmailContent(fullMessage.data.payload);
-
-        // Clean and convert email content to markdown
-        const cleanedContent = cleanEmailContent(htmlContent, textContent);
-
-        // Skip if no meaningful content
-        if (!cleanedContent || cleanedContent.length < 10) {
-          continue;
-        }
-
-        // Create Gmail web URL
         const sourceURL = `https://mail.google.com/mail/u/0/#inbox/${message.id}`;
 
-        // Format activity text with full email content as markdown
-        const text = `## 📧 Email from ${sender}
+        const metadata: GmailScheduledEmailMetadata = {
+          id: message.id,
+          threadId,
+          subject,
+          from,
+          to,
+          date,
+          internalDate,
+          snippet,
+          labelIds,
+          sourceURL,
+        };
 
-**From:** ${from}
-**Subject:** ${subject}
-**Date:** ${date}
-**Thread ID:** ${threadId}
-
-${cleanedContent}`;
-
-        activities.push(
-          createActivityMessage({
-            text,
-            sourceURL,
-          })
-        );
+        activities.push(createActivityMessage(metadata));
       } catch (error) {
-        // Silently ignore errors for individual messages
         console.error('Error processing received email:', error);
       }
     }
@@ -161,7 +142,7 @@ ${cleanedContent}`;
 }
 
 /**
- * Fetch and process sent emails
+ * Fetch and process sent emails — metadata only, no body parts
  */
 async function processSentEmails(
   gmail: any,
@@ -173,7 +154,6 @@ async function processSentEmails(
   let lastEmailTime = 0;
 
   try {
-    // Query for sent emails after lastSyncTime
     const response = await gmail.users.messages.list({
       userId: 'me',
       q: `in:sent after:${afterTimestamp}`,
@@ -184,21 +164,25 @@ async function processSentEmails(
 
     for (const message of messages) {
       try {
-        // Get full message details
-        const fullMessage = await gmail.users.messages.get({
+        // Fetch metadata only — no body parts returned
+        const metaMessage = await gmail.users.messages.get({
           userId: 'me',
           id: message.id,
-          format: 'full',
+          format: 'metadata',
+          metadataHeaders: ['From', 'To', 'Subject', 'Date'],
         });
 
-        const headers = fullMessage.data.payload.headers;
+        const headers = metaMessage.data.payload?.headers ?? [];
         const to = headers.find((h: any) => h.name === 'To')?.value || 'Unknown';
         const subject = headers.find((h: any) => h.name === 'Subject')?.value || '(No subject)';
         const date = headers.find((h: any) => h.name === 'Date')?.value || '';
 
-        const internalDate = parseInt(fullMessage.data.internalDate || '0');
+        const internalDate = parseInt(metaMessage.data.internalDate || '0');
+        const snippet = metaMessage.data.snippet || '';
+        const labelIds: string[] = metaMessage.data.labelIds || [];
+        const threadId: string = metaMessage.data.threadId || message.id;
 
-        // Skip emails that are at or before lastSyncTime
+        // Skip emails at or before lastSyncTime
         const lastSyncMs = new Date(lastSyncTime).getTime();
         if (internalDate <= lastSyncMs) {
           continue;
@@ -208,39 +192,23 @@ async function processSentEmails(
           lastEmailTime = internalDate;
         }
 
-        const threadId = fullMessage.data.threadId || message.id;
-        const { textContent, htmlContent } = parseEmailContent(fullMessage.data.payload);
-
-        // Clean and convert email content to markdown
-        const cleanedContent = cleanEmailContent(htmlContent, textContent);
-
-        // Skip if no meaningful content
-        if (!cleanedContent || cleanedContent.length < 10) {
-          continue;
-        }
-
-        // Create Gmail web URL
         const sourceURL = `https://mail.google.com/mail/u/0/#sent/${message.id}`;
 
-        // Format activity text with full email content as markdown
-        const text = `## 📤 Sent to ${to}
+        const metadata: GmailScheduledEmailMetadata = {
+          id: message.id,
+          threadId,
+          subject,
+          from: emailAddress,
+          to,
+          date,
+          internalDate,
+          snippet,
+          labelIds,
+          sourceURL,
+        };
 
-**From:** ${emailAddress}
-**To:** ${to}
-**Subject:** ${subject}
-**Date:** ${date}
-**Thread ID:** ${threadId}
-
-${cleanedContent}`;
-
-        activities.push(
-          createActivityMessage({
-            text,
-            sourceURL,
-          })
-        );
+        activities.push(createActivityMessage(metadata));
       } catch (error) {
-        // Silently ignore errors for individual messages
         console.error('Error processing sent email:', error);
       }
     }


### PR DESCRIPTION
## Summary

- **Gmail scheduled sync** now fetches `format:'metadata'` instead of `format:'full'`, so no email body, HTML, raw parts or base64 content is ever included in the activity payload.
- Defines an explicit `GmailScheduledEmailMetadata` interface (id, threadId, subject, from, to, date, internalDate, snippet, labelIds, sourceURL) with no body fields — enforced at compile time.
- Activity text contains only metadata labels (From / To / Subject / Date / Thread ID / Labels / Snippet).
- Removes unused `turndown` / `@types/turndown` dependencies (HTML-to-Markdown conversion is no longer needed).
- Adds `bun test` suite (`schedule.test.ts`) verifying: correct `format:'metadata'` API call, absence of body/HTML/raw content, presence of all metadata fields, correct source URLs.
- **Fixes runtime error** `Port should be >= 0 and < 65536. Received type number (NaN)`: `parseInt(undefined)` returns `NaN` when `REDIS_PORT` env var is absent; now defaults to `6379`.

## API Contract / Migration Notes

| Change | Before | After |
|--------|--------|-------|
| Gmail API call format | `format: 'full'` | `format: 'metadata'` + `metadataHeaders` |
| Activity `data.text` | Full email body (HTML→Markdown) | Metadata-only (From/To/Subject/Date/Thread ID/Labels/Snippet) |
| Activity `data.sourceURL` | Unchanged | Unchanged |
| `GmailActivityCreateParams` | `{ text, sourceURL }` | Replaced by `GmailScheduledEmailMetadata` interface |
| `turndown` dependency | Present | Removed |
| `parseEmailContent` / `cleanEmailContent` | Used in schedule | Removed from schedule (still in utils/mcp for tool calls) |

No DB schema changes. Existing stored activities are unaffected. New activities will be smaller in size (metadata only).

## Test plan

- [x] 8 unit tests pass (`bun test ./src/schedule.test.ts`)
- [x] Verified `format:'metadata'` is requested (never `format:'full'`)
- [x] Activity text verified to contain no `Content-Type`, `Content-Transfer-Encoding`, `base64`, or `<html` markers
- [x] All 7 metadata fields present in activity text
- [x] Source URLs correct for inbox and sent messages
- [x] Returns `[]` when `access_token` is missing
- [x] Redis port defaults to 6379 when `REDIS_PORT` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)