### PR TITLE
feat: add 'Go to Chats' command to command bar

### DIFF
--- a/apps/webapp/app/components/command-bar/command-bar.tsx
+++ b/apps/webapp/app/components/command-bar/command-bar.tsx
@@ -8,6 +8,7 @@ import {
   Brain,
   Clock,
   Library,
+  MessagesSquare,
 } from "lucide-react";
 import {
   CommandDialog,
@@ -26,6 +27,12 @@ import { NewTaskDialog } from "~/components/tasks/new-task-dialog.client";
 import { Task } from "../icons/task";
 
 const NAV_ITEMS = [
+  {
+    label: "Go to Chats",
+    url: "/home/conversation",
+    icon: MessagesSquare,
+    shortcut: "G C",
+  },
   {
     label: "Go to Tasks",
     url: "/home/tasks",

--- a/apps/webapp/app/components/sidebar/app-sidebar.tsx
+++ b/apps/webapp/app/components/sidebar/app-sidebar.tsx
@@ -101,6 +101,7 @@ export function AppSidebar({
         e.preventDefault();
         setCommandBar(true);
       },
+      "g c": whenNotEditing(() => navigate("/home/conversation")),
       "g d": whenNotEditing(() => navigate("/home/daily")),
       "g t": whenNotEditing(() => navigate("/home/tasks")),
       "g m": whenNotEditing(() => navigate("/home/memory")),


### PR DESCRIPTION
## Summary
- Adds a **Go to Chats** entry to the Navigate group in the command bar, navigating to `/home/conversation` (the chats list view) without creating a new conversation
- Registers a **G C** Linear-style keyboard shortcut in the sidebar alongside the other go-to shortcuts (G T, G M, G D, G S)
- Uses `MessagesSquare` icon from lucide-react to distinguish it from the existing `MessageSquare` used for "New Chat"

## Files Changed
- `apps/webapp/app/components/command-bar/command-bar.tsx` — new `Go to Chats` item added to `NAV_ITEMS`
- `apps/webapp/app/components/sidebar/app-sidebar.tsx` — `g c` shortcut registered in tinykeys

## Test plan
- [ ] Open command bar (Cmd+K), verify "Go to Chats" appears in the Navigate group with shortcut hint "G C"
- [ ] Select it and confirm navigation goes to `/home/conversation` without creating a new conversation
- [ ] Press `G C` outside an input/editor and confirm same navigation
- [ ] Search "chats" in command bar and confirm the item appears in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)