### PR TITLE
fix: guarantee conversation status transitions to completed for bg tasks

### DIFF
--- a/apps/webapp/app/services/agent/no-stream-process.ts
+++ b/apps/webapp/app/services/agent/no-stream-process.ts
@@ -21,10 +21,7 @@ import {
   type DecisionContext,
 } from "~/services/agent/types/decision-agent";
 import { type OrchestratorTools } from "~/services/agent/executors/base";
-import {
-  createUIStreamWithApprovals,
-  saveConversationResult,
-} from "./mastra-stream.server";
+import { createUIStreamWithApprovals } from "./mastra-stream.server";
 import { getResumableStreamContext } from "~/bullmq/connection";
 import { deductCredits } from "~/trigger/utils/utils";
 import { addToQueue } from "~/lib/ingest.server";
@@ -210,15 +207,6 @@ export async function noStreamProcess(
         .filter((p: any) => p.type === "text")
         .map((p: any) => p.text)
         .join("");
-      await saveConversationResult({
-        parts: capturedParts,
-        conversationId: body.id,
-        incomingUserText: message,
-        incognito: conversation?.incognito ?? false,
-        userId,
-        workspaceId,
-        isBYOK,
-      });
       return messages;
     },
   };
@@ -273,32 +261,35 @@ export async function noStreamProcess(
     parts: assistantParts,
   };
 
-  await upsertConversationHistory(
-    assistantMessageId,
-    assistantParts,
-    body.id,
-    UserTypeEnum.Agent,
-    false,
-  );
-
-  if (agentResult.text) {
-    await addToQueue(
-      {
-        episodeBody: `<user>${message}</user><assistant>${agentResult.text}</assistant>`,
-        source: body.source,
-        referenceTime: new Date().toISOString(),
-        type: EpisodeType.CONVERSATION,
-        sessionId: body.id,
-      },
-      userId,
-      workspaceId,
+  try {
+    await upsertConversationHistory(
+      assistantMessageId,
+      assistantParts,
+      body.id,
+      UserTypeEnum.Agent,
+      false,
     );
-  }
 
-  if (!isBYOK) {
-    await deductCredits(workspaceId, userId, "chatMessage", 1);
+    if (agentResult.text) {
+      await addToQueue(
+        {
+          episodeBody: `<user>${message}</user><assistant>${agentResult.text}</assistant>`,
+          source: body.source,
+          referenceTime: new Date().toISOString(),
+          type: EpisodeType.CONVERSATION,
+          sessionId: body.id,
+        },
+        userId,
+        workspaceId,
+      );
+    }
+
+    if (!isBYOK) {
+      await deductCredits(workspaceId, userId, "chatMessage", 1);
+    }
+  } finally {
+    await updateConversationStatus(body.id, "completed");
   }
-  await updateConversationStatus(body.id, "completed");
 
   return { ...assistantMessage, text: agentResult.text };
 


### PR DESCRIPTION
## Summary

- **Duplicate side effects removed**: `processOutputResult` in `no-stream-process.ts` was calling `saveConversationResult()` (save history + queue memory + deduct credits + set status `"completed"`), and then the explicit post-`agent.generate()` block ran all four operations again — causing duplicate conversation history entries and double credit charges on every background task turn.
- **Error guard added**: The post-generate block (`upsertConversationHistory` → `addToQueue` → `deductCredits`) was not wrapped in `try/finally`. Any DB or queue failure there would leave the conversation stuck in `"running"` indefinitely. Wrapped in `try { … } finally { updateConversationStatus("completed") }` so the status update is guaranteed after a successful agent run.
- `saveConversationResult` is still correctly used by the streaming web-chat route (`api.v1.conversation._index.tsx`) — that path is untouched.

## Test plan

- [ ] Trigger a background task and confirm the conversation transitions `pending → running → completed`
- [ ] Query `ConversationHistory` for the conversation — exactly **one** assistant message per turn (no duplicates)
- [ ] Verify credits are deducted exactly once per background task run
- [ ] Temporarily make `upsertConversationHistory` throw and confirm status still lands on `"completed"` (not `"running"`)
- [ ] Confirm streaming web chat (`api.v1.conversation._index.tsx`) continues to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)