### PR TITLE
Adds an opt-in history sanitization step in `buildAgentContext()` before `convertMessages(...)`.

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -129,6 +129,11 @@ const EnvironmentSchema = z
     EMBEDDING_MODEL_SIZE: z.string().default("1024"),
     MODEL_TEMPERATURE: z.coerce.number().default(1),
     LLM_TOLERANT_OUTPUT: z.string().optional(),
+    LLM_SANITIZE_AGENT_HISTORY: z
+      .string()
+      .optional()
+      .default("false")
+      .transform((val) => val === "true" || val === "1"),
     OLLAMA_URL: z.string().optional(),
     CHAT_PROVIDER: z.enum(["openai", "anthropic", "google", "ollama", "azure"]).default("openai"),
     EMBEDDINGS_PROVIDER: z.enum(["openai", "google", "ollama", "azure"]).optional(),

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -32,6 +32,8 @@ import { type MessageListInput } from "@mastra/core/agent/message-list";
 import { type ModelConfig } from "~/services/llm-provider.server";
 import { getPageContentAsHtml } from "~/services/hocuspocus/content.server";
 import { getLastCodingSession } from "~/services/coding/coding-session.server";
+import { env } from "~/env.server";
+import { logger } from "~/services/logger.service";
 import { DirectOrchestratorTools } from "./executors";
 import { getTaskPhase } from "~/services/task.phase";
 
@@ -76,6 +78,148 @@ interface AgentContext {
   gatewayAgents: Agent[];
   /** True when running as a background task — ask_user should not be registered */
   isBackgroundExecution: boolean;
+}
+
+function hasApprovalStateDeep(parts: any[]): boolean {
+  for (const part of parts) {
+    if (!part || typeof part !== "object") continue;
+    if (
+      part.state === "approval-requested" ||
+      part.state === "approval-responded"
+    ) {
+      return true;
+    }
+
+    const nestedParts = Array.isArray(part.output?.parts)
+      ? part.output.parts
+      : Array.isArray(part.output?.content)
+        ? part.output.content
+        : [];
+
+    if (nestedParts.length > 0 && hasApprovalStateDeep(nestedParts)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getTopLevelTextParts(parts: any[]): Array<{ type: "text"; text: string }> {
+  return parts
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => ({ type: "text" as const, text: part.text.trim() }))
+    .filter((part) => part.text.length > 0);
+}
+
+function hasOnlyNonEmptyTextParts(parts: any[]): boolean {
+  return (
+    parts.length > 0 &&
+    parts.every(
+      (part) =>
+        part?.type === "text" &&
+        typeof part.text === "string" &&
+        part.text.trim().length > 0,
+    )
+  );
+}
+
+function getToolSummary(parts: any[]): string | null {
+  const tools = parts
+    .filter((part) => typeof part?.type === "string" && part.type.includes("tool-"))
+    .map((part) => {
+      const toolName = String(part.type).replace("tool-", "");
+      const state =
+        typeof part.state === "string" && part.state.length > 0
+          ? ` (${part.state})`
+          : "";
+      return `${toolName}${state}`;
+    });
+
+  if (tools.length === 0) return null;
+
+  return `Prior tool activity omitted for brevity: ${tools.join(", ")}.`;
+}
+
+function sanitizeAssistantMessageForModelContext(message: any) {
+  const normalizedParts = Array.isArray(message?.parts)
+    ? message.parts.filter(Boolean)
+    : [];
+
+  if (normalizedParts.length === 0) {
+    return message;
+  }
+
+  const textParts = getTopLevelTextParts(normalizedParts);
+  if (textParts.length > 0) {
+    if (hasOnlyNonEmptyTextParts(normalizedParts)) {
+      return message;
+    }
+
+    return {
+      ...message,
+      parts: textParts,
+    };
+  }
+
+  const toolSummary = getToolSummary(normalizedParts);
+  if (toolSummary) {
+    return {
+      ...message,
+      parts: [{ type: "text", text: toolSummary }],
+    };
+  }
+
+  // Preserve unrecognized assistant-only shapes on current main
+  // rather than dropping them from model context entirely.
+  return message;
+}
+
+function sanitizeMessagesForModelContext(messages: any[]) {
+  let assistantMessagesSanitized = 0;
+  let assistantToolPartsDropped = 0;
+
+  const sanitized = messages.map((message) => {
+    const normalizedParts = Array.isArray(message?.parts)
+      ? message.parts.filter(Boolean)
+      : [];
+
+    if (
+      message?.role === "assistant" &&
+      normalizedParts.length > 0 &&
+      !hasApprovalStateDeep(normalizedParts)
+    ) {
+      const toolParts = normalizedParts.filter(
+        (part) => typeof part?.type === "string" && part.type.includes("tool-"),
+      ).length;
+      const sanitizedMessage =
+        sanitizeAssistantMessageForModelContext(message);
+
+      if (sanitizedMessage !== message) {
+        assistantMessagesSanitized += 1;
+        assistantToolPartsDropped += toolParts;
+      }
+
+      return sanitizedMessage;
+    }
+
+    return message;
+  });
+
+  if (assistantMessagesSanitized > 0) {
+    const rawChars = JSON.stringify(messages).length;
+    const sanitizedChars = JSON.stringify(sanitized).length;
+    logger.info("Agent context sanitized conversation history", {
+      assistantMessagesSanitized,
+      assistantToolPartsDropped,
+      originalMessages: messages.length,
+      sanitizedMessages: sanitized.length,
+      rawChars,
+      sanitizedChars,
+      reducedChars: rawChars - sanitizedChars,
+    });
+  }
+
+  return sanitized;
 }
 
 export async function buildAgentContext({
@@ -524,9 +668,13 @@ Keep your response concise — this shows up on a scratchpad, not a chat convers
 </scratchpad_context>`;
   }
 
+  const contextMessages = env.LLM_SANITIZE_AGENT_HISTORY
+    ? sanitizeMessagesForModelContext(finalMessages)
+    : finalMessages;
+
   // Convert UI messages to Mastra-compatible ModelMessage format
   const modelMessages: MessageListInput = convertMessages(
-    finalMessages as MessageListInput,
+    contextMessages as MessageListInput,
   ).to("AIV5.Model");
 
   return {


### PR DESCRIPTION
## Summary


When enabled, this reduces replayed assistant-side tool chatter in long conversations by:

- preserving approval-related tool history
- keeping top-level assistant text
- replacing assistant-only tool activity with a short text summary when possible
- leaving unknown assistant message shapes untouched

The feature is gated behind `LLM_SANITIZE_AGENT_HISTORY` and is off by default.

## Why

Current long-running conversations can accumulate a lot of assistant-side tool history that gets replayed back into model context even when most of it is no longer useful for the next turn.

This change is a narrow hygiene pass aimed at reducing that replayed context without changing default behavior and without affecting approval continuation flows.

## What Changed

- Added `LLM_SANITIZE_AGENT_HISTORY` to env parsing, defaulting to `false`
- Added assistant-history sanitization helpers in `services/agent/context.ts`
- Applied sanitization immediately before `convertMessages(...)`

## Scope

This PR is intentionally narrow.

It only targets replayed assistant history in agent context construction. It does not attempt to:

- change provider behavior
- introduce token budgeting
- trim user attachments or other non-assistant payloads
- alter default behavior unless explicitly enabled

## Safety

- Default off
- Approval-bearing tool history is preserved
- Unknown assistant-only message shapes are preserved rather than dropped

## Notes

This is mainly intended as a low-risk long-chat hygiene improvement. It should be especially helpful in conversations where repeated assistant tool output adds noise faster than it adds useful context.
