### PR TITLE
feat(mcp): add transport strategies for custom MCP integrations

### DIFF
--- a/apps/webapp/app/components/integrations/custom-mcp-card.tsx
+++ b/apps/webapp/app/components/integrations/custom-mcp-card.tsx
@@ -9,22 +9,7 @@ import {
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Plug, Trash2 } from "lucide-react";
-
-export type McpIntegration = {
-  id: string;
-  name: string;
-  serverUrl: string;
-  oauth?: {
-    accessToken: string;
-    refreshToken?: string;
-    expiresIn?: number;
-    clientId?: string;
-  };
-  apiKey?: {
-    key: string;
-    headerType: "x-api-key" | "Authorization";
-  };
-};
+import type { CustomMcpIntegration as McpIntegration } from "~/utils/mcp/custom-mcp-config";
 
 interface CustomMcpCardProps {
   integration: McpIntegration;
@@ -80,6 +65,12 @@ export function CustomMcpCard({
         <CardTitle className="mt-2 text-base">{integration.name}</CardTitle>
         <CardDescription className="line-clamp-2 text-sm">
           {integration.serverUrl}
+        </CardDescription>
+        <CardDescription className="text-xs">
+          {(integration.transportStrategy || "http-first").replace("-", " · ")}
+          {(integration.headers?.length ?? 0) > 0
+            ? ` · ${integration.headers?.length} header${integration.headers?.length === 1 ? "" : "s"}`
+            : ""}
         </CardDescription>
       </CardHeader>
     </Card>

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -209,6 +209,16 @@ const EnvironmentSchema = z
     MODEL_PROVIDER: z.enum(["vercel-ai"]).default("vercel-ai"),
 
     EXA_API_KEY: z.string().optional(),
+    CUSTOM_MCP_ALLOW_NO_AUTH: z
+      .string()
+      .optional()
+      .default("false")
+      .transform((val) => val === "true" || val === "1"),
+    CUSTOM_MCP_ALLOW_CUSTOM_HEADERS: z
+      .string()
+      .optional()
+      .default("false")
+      .transform((val) => val === "true" || val === "1"),
 
     // Twilio (WhatsApp)
     TWILIO_ACCOUNT_SID: z.string().optional(),

--- a/apps/webapp/app/routes/api.v1.oauth.callback.mcp.tsx
+++ b/apps/webapp/app/routes/api.v1.oauth.callback.mcp.tsx
@@ -1,0 +1,136 @@
+import { type LoaderFunctionArgs } from "@remix-run/node";
+import { completeCustomMcpOAuth } from "@core/mcp-proxy";
+import { logger } from "~/services/logger.service";
+import { env } from "~/env.server";
+import { customMcpOAuthSession } from "./api.v1.oauth.custom-mcp";
+import { prisma } from "~/db.server";
+import { updateUser } from "~/models/user.server";
+import {
+  buildCustomMcpIntegration,
+  isCustomMcpIntegrationEnabled,
+  type CustomMcpIntegration as McpIntegration,
+} from "~/utils/mcp/custom-mcp-config";
+
+const MCP_CALLBACK_URL = `${env.APP_ORIGIN}/api/v1/oauth/callback/mcp`;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const authorizationCode = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+
+  if (!authorizationCode || !state) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${env.APP_ORIGIN}/home/integrations?success=false&error=${encodeURIComponent(
+          "Missing authorization code or state"
+        )}`,
+      },
+    });
+  }
+
+  const session = customMcpOAuthSession[state];
+  if (!session) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${env.APP_ORIGIN}/home/integrations?success=false&error=${encodeURIComponent(
+          "Invalid or expired session"
+        )}`,
+      },
+    });
+  }
+
+  const {
+    userId,
+    serverUrl,
+    name,
+    redirectURL,
+    sessionData,
+    transportStrategy,
+    headers,
+  } = session;
+
+  // Clean up session
+  delete customMcpOAuthSession[state];
+
+  try {
+    const result = await completeCustomMcpOAuth({
+      serverUrl,
+      redirectUrl: MCP_CALLBACK_URL,
+      authorizationCode,
+      sessionData,
+      clientName: "Core MCP Client",
+    });
+
+    // Get user and update metadata with OAuth tokens
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const metadata = (user.metadata as any) || {};
+    const currentIntegrations = (metadata?.mcpIntegrations ||
+      []) as McpIntegration[];
+
+    // Create new integration with OAuth data
+    const newIntegration = buildCustomMcpIntegration({
+      name,
+      serverUrl,
+      transportStrategy,
+      headers,
+      oauth: {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        clientId: result.clientId,
+        clientSecret: result.clientSecret,
+      },
+    });
+
+    if (
+      !isCustomMcpIntegrationEnabled(newIntegration, {
+        allowNoAuth: env.CUSTOM_MCP_ALLOW_NO_AUTH,
+        allowCustomHeaders: env.CUSTOM_MCP_ALLOW_CUSTOM_HEADERS,
+      })
+    ) {
+      throw new Error("Unsupported custom MCP configuration");
+    }
+
+    const updatedIntegrations = [...currentIntegrations, newIntegration];
+
+    await updateUser({
+      id: userId,
+      metadata: {
+        ...metadata,
+        mcpIntegrations: updatedIntegrations,
+      },
+      onboardingComplete: user.onboardingComplete,
+    });
+
+    logger.info(`Custom MCP OAuth completed for ${name}`);
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${redirectURL}?success=true&integrationName=${encodeURIComponent(
+          name
+        )}`,
+      },
+    });
+  } catch (error: any) {
+    logger.error("Custom MCP OAuth callback error:", error);
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `${redirectURL}?success=false&error=${encodeURIComponent(
+          error.message || "OAuth callback failed"
+        )}`,
+      },
+    });
+  }
+}

--- a/apps/webapp/app/routes/api.v1.oauth.custom-mcp.tsx
+++ b/apps/webapp/app/routes/api.v1.oauth.custom-mcp.tsx
@@ -1,0 +1,122 @@
+import { json } from "@remix-run/node";
+import { type ActionFunctionArgs } from "@remix-run/server-runtime";
+import { requireUserId } from "~/services/session.server";
+import {
+  getCustomMcpAuthorizationUrl,
+  type CustomMcpOAuthSession,
+} from "@core/mcp-proxy";
+import { env } from "~/env.server";
+import { logger } from "~/services/logger.service";
+import { z } from "zod";
+import {
+  CUSTOM_MCP_TRANSPORT_STRATEGIES,
+  parseCustomMcpHeadersInput,
+  type CustomMcpHeaderConfig,
+  type CustomMcpTransportStrategy,
+} from "~/utils/mcp/custom-mcp-config";
+
+const MCP_CALLBACK_URL = `${env.APP_ORIGIN}/api/v1/oauth/callback/mcp`;
+
+// Session store for custom MCP OAuth flows
+export const customMcpOAuthSession: Record<
+  string,
+  {
+    userId: string;
+    serverUrl: string;
+    name: string;
+    redirectURL: string;
+    transportStrategy: CustomMcpTransportStrategy;
+    headers: CustomMcpHeaderConfig[];
+    sessionData: CustomMcpOAuthSession;
+  }
+> = {};
+
+const InitiateOAuthSchema = z.object({
+  intent: z.literal("initiate"),
+  name: z.string().min(1),
+  serverUrl: z.string().url(),
+  transportStrategy: z.enum(CUSTOM_MCP_TRANSPORT_STRATEGIES).default("http-first"),
+  redirectURL: z.string().optional(),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const userId = await requireUserId(request);
+  const formData = await request.formData();
+  const intent = formData.get("intent");
+
+  if (intent === "initiate") {
+    const name = formData.get("name") as string;
+    const serverUrl = formData.get("serverUrl") as string;
+    const transportStrategy = (formData.get("transportStrategy") ||
+      "http-first") as CustomMcpTransportStrategy;
+    const rawHeaders = (formData.get("headers") as string) || "";
+    const redirectURL =
+      (formData.get("redirectURL") as string) ||
+      `${env.APP_ORIGIN}/home/integrations`;
+
+    try {
+      if (rawHeaders.trim().length > 0 && !env.CUSTOM_MCP_ALLOW_CUSTOM_HEADERS) {
+        throw new Error("Custom MCP headers are disabled");
+      }
+
+      const { headers, error } = parseCustomMcpHeadersInput(rawHeaders);
+      if (error) {
+        throw new Error(error);
+      }
+
+      // Validate inputs
+      InitiateOAuthSchema.parse({
+        intent,
+        name,
+        serverUrl,
+        transportStrategy,
+        redirectURL,
+      });
+
+      const { authUrl, sessionData } = await getCustomMcpAuthorizationUrl({
+        serverUrl,
+        redirectUrl: MCP_CALLBACK_URL,
+        clientName: "Core MCP Client",
+      });
+
+      // Generate a unique state for this session
+      const state = crypto.randomUUID();
+
+      // Store session data for callback
+      customMcpOAuthSession[state] = {
+        userId,
+        serverUrl,
+        name,
+        redirectURL,
+        transportStrategy,
+        headers,
+        sessionData,
+      };
+
+      // Append state to auth URL if not already present
+      const authUrlObj = new URL(authUrl);
+      if (!authUrlObj.searchParams.has("state")) {
+        authUrlObj.searchParams.set("state", state);
+      }
+
+      logger.info(`Custom MCP OAuth initiated for ${name} at ${serverUrl}`);
+
+      return json({
+        success: true,
+        redirectURL: authUrlObj.toString(),
+        state,
+      });
+    } catch (error: any) {
+      logger.error("Custom MCP OAuth initiation error:", error);
+      return json(
+        {
+          success: false,
+          error: error.message || "Failed to initiate OAuth",
+        },
+        { status: 400 }
+      );
+    }
+  }
+
+  return json({ error: "Invalid intent" }, { status: 400 });
+}

--- a/apps/webapp/app/routes/home.integrations.tsx
+++ b/apps/webapp/app/routes/home.integrations.tsx
@@ -20,6 +20,7 @@ import { PageHeader } from "~/components/common/page-header";
 import { Plus, Search } from "lucide-react";
 import { prisma } from "~/db.server";
 import { updateUser } from "~/models/user.server";
+import { env } from "~/env.server";
 
 import { Button, Input } from "~/components/ui";
 import {
@@ -37,6 +38,13 @@ import {
   CardTitle,
 } from "~/components/ui/card";
 import { useToast } from "~/hooks/use-toast";
+import {
+  buildCustomMcpIntegration,
+  CUSTOM_MCP_TRANSPORT_STRATEGIES,
+  isCustomMcpIntegrationEnabled,
+  parseCustomMcpHeadersInput,
+  type CustomMcpTransportStrategy,
+} from "~/utils/mcp/custom-mcp-config";
 
 export const meta = () => [{ title: "Integrations" }];
 
@@ -50,7 +58,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
   });
 
   const metadata = (user?.metadata as any) || {};
-  const mcpIntegrations = (metadata?.mcpIntegrations || []) as McpIntegration[];
+  const customMcpFeatureFlags = {
+    allowNoAuth: env.CUSTOM_MCP_ALLOW_NO_AUTH,
+    allowCustomHeaders: env.CUSTOM_MCP_ALLOW_CUSTOM_HEADERS,
+  };
+  const mcpIntegrations = ((metadata?.mcpIntegrations || []) as McpIntegration[]).filter(
+    (integration) =>
+      isCustomMcpIntegrationEnabled(integration, customMcpFeatureFlags),
+  );
 
   if (!workspace) {
     return json({
@@ -58,6 +73,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       integrationAccounts: [],
       mcpIntegrations,
       userId,
+      customMcpFeatureFlags,
     });
   }
 
@@ -73,6 +89,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     integrationAccounts,
     mcpIntegrations,
     userId,
+    customMcpFeatureFlags,
   });
 }
 
@@ -102,6 +119,9 @@ export async function action({ request }: ActionFunctionArgs) {
         const apiKeyValue = formData.get("apiKey") as string | undefined;
         const headerType =
           (formData.get("headerType") as string) || "x-api-key";
+        const transportStrategy = (formData.get("transportStrategy") ||
+          "http-first") as CustomMcpTransportStrategy;
+        const headerConfig = formData.get("headers") as string | undefined;
 
         if (!name || !serverUrl) {
           return json(
@@ -110,10 +130,39 @@ export async function action({ request }: ActionFunctionArgs) {
           );
         }
 
-        const newIntegration: McpIntegration = {
-          id: crypto.randomUUID(),
+        if (!CUSTOM_MCP_TRANSPORT_STRATEGIES.includes(transportStrategy)) {
+          return json({ error: "Invalid transport strategy" }, { status: 400 });
+        }
+
+        if (headerConfig?.trim() && !env.CUSTOM_MCP_ALLOW_CUSTOM_HEADERS) {
+          return json(
+            { error: "Custom MCP headers are disabled" },
+            { status: 400 },
+          );
+        }
+
+        const { headers, error } = parseCustomMcpHeadersInput(headerConfig || "");
+        if (error) {
+          return json({ error }, { status: 400 });
+        }
+
+        if (
+          !accessToken?.trim() &&
+          !apiKeyValue?.trim() &&
+          headers.length === 0 &&
+          !env.CUSTOM_MCP_ALLOW_NO_AUTH
+        ) {
+          return json(
+            { error: "OAuth or direct credentials are required" },
+            { status: 400 },
+          );
+        }
+
+        const newIntegration = buildCustomMcpIntegration({
           name,
           serverUrl,
+          transportStrategy,
+          headers,
           ...(apiKeyValue && {
             apiKey: {
               key: apiKeyValue,
@@ -126,7 +175,7 @@ export async function action({ request }: ActionFunctionArgs) {
                 accessToken,
               },
             }),
-        };
+        });
 
         const updatedIntegrations = [...currentIntegrations, newIntegration];
 
@@ -179,9 +228,14 @@ export async function action({ request }: ActionFunctionArgs) {
 function NewIntegrationForm({
   onCancel,
   onSuccess,
+  featureFlags,
 }: {
   onCancel: () => void;
   onSuccess: () => void;
+  featureFlags: {
+    allowNoAuth: boolean;
+    allowCustomHeaders: boolean;
+  };
 }) {
   const fetcher = useFetcher<{
     success: boolean;
@@ -196,6 +250,10 @@ function NewIntegrationForm({
   const [headerType, setHeaderType] = useState<"x-api-key" | "Authorization">(
     "x-api-key",
   );
+  const [useOAuth, setUseOAuth] = useState(true);
+  const [transportStrategy, setTransportStrategy] =
+    useState<CustomMcpTransportStrategy>("http-first");
+  const [headersInput, setHeadersInput] = useState("");
 
   useEffect(() => {
     if (fetcher.data?.success && fetcher.data?.redirectURL) {
@@ -210,18 +268,31 @@ function NewIntegrationForm({
     }
   }, [localFetcher.data, onSuccess]);
 
+  const hasCustomHeaders =
+    featureFlags.allowCustomHeaders && headersInput.trim().length > 0;
+  const shouldCreateDirectly =
+    (authMode === "apikey" && apiKey.trim().length > 0) ||
+    accessToken.trim().length > 0 ||
+    hasCustomHeaders ||
+    (featureFlags.allowNoAuth && authMode === "oauth" && !useOAuth);
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
+    formData.set("transportStrategy", transportStrategy);
+    if (featureFlags.allowCustomHeaders) {
+      formData.set("headers", headersInput);
+    }
 
-    if (authMode === "apikey" && apiKey.trim()) {
+    if (shouldCreateDirectly) {
       formData.set("intent", "create");
-      formData.set("apiKey", apiKey);
-      formData.set("headerType", headerType);
-      localFetcher.submit(formData, { method: "post" });
-    } else if (accessToken.trim()) {
-      formData.set("intent", "create");
-      formData.set("accessToken", accessToken);
+      if (authMode === "apikey" && apiKey.trim()) {
+        formData.set("apiKey", apiKey);
+        formData.set("headerType", headerType);
+      }
+      if (accessToken.trim()) {
+        formData.set("accessToken", accessToken);
+      }
       localFetcher.submit(formData, { method: "post" });
     } else {
       formData.set("intent", "initiate");
@@ -241,7 +312,12 @@ function NewIntegrationForm({
       <CardHeader className="p-0 pb-4">
         <CardTitle>New Custom Integration</CardTitle>
         <CardDescription>
-          Connect an external MCP server using OAuth or an access token
+          Connect an external MCP server using OAuth, an access token, or an
+          API key.
+          {featureFlags.allowCustomHeaders
+            ? " Additional static headers are available when needed."
+            : ""}
+          {featureFlags.allowNoAuth ? " No-auth servers can also be added." : ""}
         </CardDescription>
       </CardHeader>
       <CardContent className="p-0">
@@ -285,6 +361,47 @@ function NewIntegrationForm({
               </SelectContent>
             </Select>
           </div>
+
+          <div className="space-y-2">
+            <label htmlFor="transportStrategy" className="text-sm font-medium">
+              Transport
+            </label>
+            <select
+              id="transportStrategy"
+              name="transportStrategy"
+              className="bg-background flex h-10 w-full rounded-md border px-3 py-2 text-sm"
+              value={transportStrategy}
+              onChange={(e) =>
+                setTransportStrategy(
+                  e.target.value as CustomMcpTransportStrategy,
+                )
+              }
+            >
+              <option value="http-first">HTTP first</option>
+              <option value="sse-first">SSE first</option>
+              <option value="http-only">HTTP only</option>
+              <option value="sse-only">SSE only</option>
+            </select>
+            <p className="text-muted-foreground text-xs">
+              Default is HTTP first with automatic fallback when supported.
+            </p>
+          </div>
+
+          {authMode === "oauth" && featureFlags.allowNoAuth && (
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-sm font-medium">
+                <input
+                  type="checkbox"
+                  checked={useOAuth}
+                  onChange={(e) => setUseOAuth(e.target.checked)}
+                />
+                Use OAuth if the MCP server supports it
+              </label>
+              <p className="text-muted-foreground text-xs">
+                Turn this off for static-header or no-auth MCP servers.
+              </p>
+            </div>
+          )}
 
           {authMode === "apikey" ? (
             <div className="space-y-2">
@@ -331,8 +448,33 @@ function NewIntegrationForm({
                 onChange={(e) => setAccessToken(e.target.value)}
               />
               <p className="text-muted-foreground text-xs">
-                Provide an access token to skip OAuth, or leave empty to
-                authenticate via OAuth
+                Provide a bearer token to skip OAuth.
+                {featureFlags.allowNoAuth
+                  ? " Leave empty if the server uses OAuth, custom headers, or no auth."
+                  : " Leave empty to authenticate via OAuth."}
+              </p>
+            </div>
+          )}
+
+          {featureFlags.allowCustomHeaders && (
+            <div className="space-y-2">
+              <label htmlFor="headers" className="text-sm font-medium">
+                Additional headers (optional)
+              </label>
+              <textarea
+                id="headers"
+                name="headers"
+                className="bg-background flex min-h-28 w-full rounded-md border px-3 py-2 text-sm"
+                placeholder={[
+                  "X-API-Key=env:MCP_EXAMPLE_API_KEY",
+                  "X-Tenant=acme",
+                ].join("\n")}
+                value={headersInput}
+                onChange={(e) => setHeadersInput(e.target.value)}
+              />
+              <p className="text-muted-foreground text-xs">
+                One header per line. Use <code>Header=env:MCP_KEY</code> for
+                env-backed secrets. Only <code>MCP_*</code> env vars are allowed.
               </p>
             </div>
           )}
@@ -356,7 +498,7 @@ function NewIntegrationForm({
                 ? "Connecting..."
                 : isRedirecting
                   ? "Redirecting..."
-                  : authMode === "apikey" || accessToken.trim()
+                  : shouldCreateDirectly
                     ? "Add Integration"
                     : "Connect with OAuth"}
             </Button>
@@ -368,8 +510,12 @@ function NewIntegrationForm({
 }
 
 export default function Integrations() {
-  const { integrationDefinitions, integrationAccounts, mcpIntegrations } =
-    useLoaderData<typeof loader>();
+  const {
+    integrationDefinitions,
+    integrationAccounts,
+    mcpIntegrations,
+    customMcpFeatureFlags,
+  } = useLoaderData<typeof loader>();
   const revalidator = useRevalidator();
   const [showNewForm, setShowNewForm] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -424,7 +570,6 @@ export default function Integrations() {
       <PageHeader title="Integrations" />
       <div className="home flex h-page-sm justify-center overflow-y-auto p-4 px-5 md:h-page">
         <div className="flex w-full max-w-3xl flex-col items-center gap-6">
-          {/* Integrations Section */}
           <div className="w-full space-y-3">
             <div className="flex items-start justify-between gap-4">
               <div>
@@ -450,7 +595,6 @@ export default function Integrations() {
             />
           </div>
 
-          {/* Custom MCP Integrations Section */}
           <div className="w-full space-y-3">
             <div className="flex items-start justify-between">
               <div>
@@ -478,6 +622,7 @@ export default function Integrations() {
                   setShowNewForm(false);
                   revalidator.revalidate();
                 }}
+                featureFlags={customMcpFeatureFlags}
               />
             )}
 

--- a/apps/webapp/app/utils/mcp/custom-mcp-config.ts
+++ b/apps/webapp/app/utils/mcp/custom-mcp-config.ts
@@ -1,0 +1,166 @@
+export const CUSTOM_MCP_ENV_PREFIX = "MCP_";
+
+export const CUSTOM_MCP_TRANSPORT_STRATEGIES = [
+  "http-first",
+  "sse-first",
+  "http-only",
+  "sse-only",
+] as const;
+
+export type CustomMcpTransportStrategy =
+  (typeof CUSTOM_MCP_TRANSPORT_STRATEGIES)[number];
+
+export interface CustomMcpHeaderConfig {
+  name: string;
+  value?: string;
+  envKey?: string;
+}
+
+export interface CustomMcpOAuthConfig {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export interface CustomMcpApiKeyConfig {
+  key: string;
+  headerType: "x-api-key" | "Authorization";
+}
+
+export interface CustomMcpIntegration {
+  id: string;
+  name: string;
+  serverUrl: string;
+  transportStrategy?: CustomMcpTransportStrategy;
+  headers?: CustomMcpHeaderConfig[];
+  oauth?: CustomMcpOAuthConfig;
+  apiKey?: CustomMcpApiKeyConfig;
+}
+
+export interface CustomMcpFeatureFlags {
+  allowNoAuth: boolean;
+  allowCustomHeaders: boolean;
+}
+
+export function buildCustomMcpIntegration(params: {
+  id?: string;
+  name: string;
+  serverUrl: string;
+  transportStrategy?: CustomMcpTransportStrategy;
+  headers?: CustomMcpHeaderConfig[];
+  oauth?: CustomMcpOAuthConfig;
+  apiKey?: CustomMcpApiKeyConfig;
+}): CustomMcpIntegration {
+  const { id, name, serverUrl, transportStrategy, headers, oauth, apiKey } =
+    params;
+
+  return {
+    id: id ?? crypto.randomUUID(),
+    name,
+    serverUrl,
+    ...(transportStrategy ? { transportStrategy } : {}),
+    ...(headers && headers.length > 0 ? { headers } : {}),
+    ...(oauth ? { oauth } : {}),
+    ...(apiKey ? { apiKey } : {}),
+  };
+}
+
+export function isCustomMcpIntegrationEnabled(
+  integration: CustomMcpIntegration,
+  featureFlags: CustomMcpFeatureFlags,
+): boolean {
+  const hasHeaders = (integration.headers?.length ?? 0) > 0;
+  const hasAccessToken = !!integration.oauth?.accessToken;
+  const hasApiKey = !!integration.apiKey?.key;
+
+  if (hasHeaders && !featureFlags.allowCustomHeaders) {
+    return false;
+  }
+
+  if (!hasAccessToken && !hasApiKey && !hasHeaders && !featureFlags.allowNoAuth) {
+    return false;
+  }
+
+  return true;
+}
+
+export function parseCustomMcpHeadersInput(input: string): {
+  headers: CustomMcpHeaderConfig[];
+  error?: string;
+} {
+  const headers: CustomMcpHeaderConfig[] = [];
+
+  for (const [index, rawLine] of input.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) {
+      return {
+        headers: [],
+        error: `Invalid header on line ${index + 1}. Use Header-Name=value or Header-Name=env:${CUSTOM_MCP_ENV_PREFIX}KEY.`,
+      };
+    }
+
+    const name = line.slice(0, separatorIndex).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
+
+    if (!name || !rawValue) {
+      return {
+        headers: [],
+        error: `Invalid header on line ${index + 1}. Header name and value are required.`,
+      };
+    }
+
+    if (rawValue.startsWith("env:")) {
+      const envKey = rawValue.slice(4).trim();
+      if (!new RegExp(`^${CUSTOM_MCP_ENV_PREFIX}[A-Z0-9_]+$`).test(envKey)) {
+        return {
+          headers: [],
+          error: `Invalid env key on line ${index + 1}. Only ${CUSTOM_MCP_ENV_PREFIX}* variables are allowed.`,
+        };
+      }
+
+      headers.push({ name, envKey });
+      continue;
+    }
+
+    headers.push({ name, value: rawValue });
+  }
+
+  return { headers };
+}
+
+export function resolveCustomMcpHeaders(
+  headers: CustomMcpHeaderConfig[] | undefined,
+  envSource?: Record<string, string | undefined>,
+): Record<string, string> {
+  if (!headers || headers.length === 0) {
+    return {};
+  }
+
+  const source =
+    envSource ??
+    (typeof process !== "undefined" ? process.env : ({} as Record<string, string | undefined>));
+  const resolvedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    if (header.envKey) {
+      const envValue = source[header.envKey];
+      if (envValue) {
+        resolvedHeaders[header.name] = envValue;
+      }
+      continue;
+    }
+
+    if (header.value) {
+      resolvedHeaders[header.name] = header.value;
+    }
+  }
+
+  return resolvedHeaders;
+}

--- a/apps/webapp/app/utils/mcp/integration-loader.ts
+++ b/apps/webapp/app/utils/mcp/integration-loader.ts
@@ -1,21 +1,13 @@
 import { prisma } from "~/db.server";
 import { IntegrationRunner } from "~/services/integrations/integration-runner";
-
-export interface CustomMcpIntegration {
-  id: string;
-  name: string;
-  serverUrl: string;
-  oauth?: {
-    accessToken: string;
-    refreshToken?: string;
-    expiresIn?: number;
-    clientId?: string;
-  };
-  apiKey?: {
-    key: string;
-    headerType: "x-api-key" | "Authorization";
-  };
-}
+import { env } from "~/env.server";
+import {
+  isCustomMcpIntegrationEnabled,
+  resolveCustomMcpHeaders,
+  type CustomMcpFeatureFlags,
+  type CustomMcpIntegration,
+  type CustomMcpTransportStrategy,
+} from "./custom-mcp-config";
 
 export interface CustomMcpAccount {
   id: string;
@@ -35,6 +27,8 @@ export interface CustomMcpAccount {
     key: string;
     headerType: "x-api-key" | "Authorization";
   };
+  headers?: Record<string, string>;
+  transportStrategy?: CustomMcpTransportStrategy;
 }
 
 export interface IntegrationAccountWithDefinition {
@@ -55,6 +49,13 @@ export interface IntegrationAccountWithDefinition {
  * Loads and manages integration accounts for MCP sessions
  */
 export class IntegrationLoader {
+  private static getCustomMcpFeatureFlags(): CustomMcpFeatureFlags {
+    return {
+      allowNoAuth: env.CUSTOM_MCP_ALLOW_NO_AUTH,
+      allowCustomHeaders: env.CUSTOM_MCP_ALLOW_CUSTOM_HEADERS,
+    };
+  }
+
   /**
    * Get all connected and active integration accounts for a user/workspace
    * Filtered by integration slugs if provided
@@ -103,17 +104,23 @@ export class IntegrationLoader {
     });
 
     const metadata = (user?.metadata as any) || {};
+    const featureFlags = this.getCustomMcpFeatureFlags();
     const customMcpIntegrations = (metadata?.mcpIntegrations ||
-      []) as CustomMcpIntegration[];
+      []).filter((mcp: CustomMcpIntegration) =>
+      isCustomMcpIntegrationEnabled(mcp, featureFlags),
+    ) as CustomMcpIntegration[];
 
     // Convert custom MCPs to the same format as regular integration accounts
-    const customMcpAccounts: CustomMcpAccount[] = customMcpIntegrations
-      .filter((mcp) => mcp.oauth?.accessToken || mcp.apiKey?.key) // Include OAuth or API key MCPs
-      .map((mcp) => ({
+    const customMcpAccounts: CustomMcpAccount[] = customMcpIntegrations.map(
+      (mcp) => ({
         id: mcp.id,
         accountId: mcp.id,
         integrationConfiguration: {
           accessToken: mcp.oauth?.accessToken,
+          refreshToken: mcp.oauth?.refreshToken,
+          expiresIn: mcp.oauth?.expiresIn,
+          clientId: mcp.oauth?.clientId,
+          clientSecret: mcp.oauth?.clientSecret,
         },
         isActive: true,
         isCustomMcp: true as const,
@@ -126,7 +133,10 @@ export class IntegrationLoader {
         serverUrl: mcp.serverUrl,
         accessToken: mcp.oauth?.accessToken,
         apiKey: mcp.apiKey,
-      }));
+        headers: resolveCustomMcpHeaders(mcp.headers),
+        transportStrategy: mcp.transportStrategy,
+      }),
+    );
 
     return [...integrationAccounts, ...customMcpAccounts];
   }
@@ -184,11 +194,12 @@ export class IntegrationLoader {
     });
 
     const metadata = (user?.metadata as any) || {};
+    const featureFlags = this.getCustomMcpFeatureFlags();
     const customMcpIntegrations = (metadata?.mcpIntegrations ||
       []) as CustomMcpIntegration[];
 
     const mcp = customMcpIntegrations.find((m) => m.id === mcpId);
-    if (!mcp || (!mcp.oauth?.accessToken && !mcp.apiKey?.key)) {
+    if (!mcp || !isCustomMcpIntegrationEnabled(mcp, featureFlags)) {
       return null;
     }
 
@@ -200,6 +211,7 @@ export class IntegrationLoader {
         refreshToken: mcp.oauth?.refreshToken,
         expiresIn: mcp.oauth?.expiresIn,
         clientId: mcp.oauth?.clientId,
+        clientSecret: mcp.oauth?.clientSecret,
       },
       isActive: true,
       isCustomMcp: true as const,
@@ -212,6 +224,8 @@ export class IntegrationLoader {
       serverUrl: mcp.serverUrl,
       accessToken: mcp.oauth?.accessToken,
       apiKey: mcp.apiKey,
+      headers: resolveCustomMcpHeaders(mcp.headers),
+      transportStrategy: mcp.transportStrategy,
     };
   }
 

--- a/apps/webapp/app/utils/mcp/integration-operations.ts
+++ b/apps/webapp/app/utils/mcp/integration-operations.ts
@@ -178,11 +178,14 @@ export async function getIntegrationActions(
         : await createCustomMcpClient({
             serverUrl: account.serverUrl,
             credentials: {
-              accessToken: account.accessToken!,
+              accessToken: account.accessToken,
               refreshToken: account.integrationConfiguration.refreshToken,
               expiresIn: account.integrationConfiguration.expiresIn,
               clientId: account.integrationConfiguration.clientId,
+              clientSecret: account.integrationConfiguration.clientSecret,
             },
+            headers: account.headers,
+            transportStrategy: account.transportStrategy,
             onTokensRefreshed: userId
               ? createTokenRefreshCallback(userId, account.id)
               : undefined,
@@ -297,11 +300,14 @@ export async function executeIntegrationAction(
           : await createCustomMcpClient({
               serverUrl: account.serverUrl,
               credentials: {
-                accessToken: account.accessToken!,
+                accessToken: account.accessToken,
                 refreshToken: account.integrationConfiguration.refreshToken,
                 expiresIn: account.integrationConfiguration.expiresIn,
                 clientId: account.integrationConfiguration.clientId,
+                clientSecret: account.integrationConfiguration.clientSecret,
               },
+              headers: account.headers,
+              transportStrategy: account.transportStrategy,
               onTokensRefreshed: createTokenRefreshCallback(userId, account.id),
             });
 

--- a/packages/mcp-proxy/src/lib/custom-mcp-oauth.ts
+++ b/packages/mcp-proxy/src/lib/custom-mcp-oauth.ts
@@ -11,12 +11,16 @@ import {
 } from "@modelcontextprotocol/sdk/client/auth.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  connectToRemoteServer,
+  type TransportStrategy,
+} from "./utils.js";
 
 /**
  * Stored OAuth credentials for a custom MCP integration
  */
 export interface CustomMcpStoredCredentials {
-  accessToken: string;
+  accessToken?: string;
   refreshToken?: string;
   expiresIn?: number;
   clientId?: string;
@@ -67,7 +71,7 @@ export async function createApiKeyMcpClient(options: {
  * Use this when you have stored OAuth credentials and want to create a client.
  */
 export class CustomMcpTokenProvider implements OAuthClientProvider {
-  private _tokens: OAuthTokens;
+  private _tokens?: OAuthTokens;
   private _clientInformation?: OAuthClientInformationFull;
   private _serverUrl: string;
 
@@ -79,12 +83,14 @@ export class CustomMcpTokenProvider implements OAuthClientProvider {
     ) => Promise<void>
   ) {
     this._serverUrl = serverUrl;
-    this._tokens = {
-      access_token: credentials.accessToken,
-      refresh_token: credentials.refreshToken,
-      expires_in: credentials.expiresIn,
-      token_type: "Bearer",
-    };
+    if (credentials.accessToken) {
+      this._tokens = {
+        access_token: credentials.accessToken,
+        refresh_token: credentials.refreshToken,
+        expires_in: credentials.expiresIn,
+        token_type: "Bearer",
+      };
+    }
 
     if (credentials.clientId) {
       this._clientInformation = {
@@ -151,7 +157,7 @@ export class CustomMcpTokenProvider implements OAuthClientProvider {
    * Attempt to refresh the access token using the refresh token
    */
   async refreshTokens(): Promise<boolean> {
-    if (!this._tokens.refresh_token) {
+    if (!this._tokens?.refresh_token) {
       return false;
     }
 
@@ -179,10 +185,18 @@ export class CustomMcpTokenProvider implements OAuthClientProvider {
  */
 export async function createCustomMcpClient(options: {
   serverUrl: string;
-  credentials: CustomMcpStoredCredentials;
+  credentials?: CustomMcpStoredCredentials;
+  headers?: Record<string, string>;
+  transportStrategy?: TransportStrategy;
   onTokensRefreshed?: (newCredentials: CustomMcpStoredCredentials) => Promise<void>;
 }): Promise<Client> {
-  const { serverUrl, credentials, onTokensRefreshed } = options;
+  const {
+    serverUrl,
+    credentials = {},
+    headers = {},
+    transportStrategy = "http-first",
+    onTokensRefreshed,
+  } = options;
 
   const authProvider = new CustomMcpTokenProvider(serverUrl, credentials, onTokensRefreshed);
 
@@ -194,12 +208,19 @@ export async function createCustomMcpClient(options: {
     { capabilities: {} }
   );
 
-  const baseUrl = new URL(serverUrl);
-  const transport = new StreamableHTTPClientTransport(baseUrl, {
+  await connectToRemoteServer(
+    client,
+    serverUrl,
     authProvider,
-  });
-
-  await client.connect(transport as any);
+    headers,
+    async () => ({
+      waitForAuthCode: async () => {
+        throw new Error("Interactive OAuth is not available for stored custom MCP connections");
+      },
+      skipBrowserAuth: true,
+    }),
+    transportStrategy,
+  );
 
   return client;
 }


### PR DESCRIPTION
## Summary

Adds transport strategy support for custom MCP integrations and broadens the custom MCP connection flow to handle more server configurations.

This also introduces optional support for bearer-token, no-auth, and custom-header setups, but those paths are gated behind env flags and remain off by default.

## Why

Custom MCP servers do not all behave the same way.

Some prefer HTTP transport, some prefer SSE, and some require non-OAuth authentication patterns. The existing custom MCP flow assumed a narrower setup, which made otherwise valid servers harder to connect.

This change improves compatibility while keeping the more permissive connection modes opt-in.

## What Changed

- Added transport strategy selection for custom MCP integrations:
  - `http-first`
  - `sse-first`
  - `http-only`
  - `sse-only`
- Persist transport strategy with saved custom MCP integrations
- Pass transport strategy through to custom MCP client creation
- Added shared custom MCP config/types/helpers
- Allowed stored custom MCP connections to work without a required access token
- Added support for optional custom headers and no-auth custom MCP setups

## Safety / Defaults

The more permissive modes are disabled by default:

- `CUSTOM_MCP_ALLOW_NO_AUTH=false`
- `CUSTOM_MCP_ALLOW_CUSTOM_HEADERS=false`

When those flags are off:
- the UI does not expose those controls
- server-side validation rejects unsupported submissions

So the default product behavior stays close to the existing shape.

## Scope

This PR is focused on custom MCP connection/configuration behavior.

It does not change:
- regular built-in integrations
- general MCP session handling outside custom integrations
- default auth requirements unless the new env flags are explicitly enabled

## Notes

The main compatibility improvement here is transport strategy support.

The gated no-auth and custom-header paths are included for environments that need them, while preserving a conservative default for hosted deployments.
