### PR TITLE
feat: resume stream functionality

### DIFF
--- a/apps/webapp/app/components/conversation/conversation-list.tsx
+++ b/apps/webapp/app/components/conversation/conversation-list.tsx
@@ -18,6 +18,9 @@ import { useLocalCommonState } from "~/hooks/use-local-state";
 import { SourceFolderMenu } from "./source-folder-menu";
 import { ConversationListOptions } from "./conversation-list-options";
 
+const EXCLUDED_SOURCES = new Set(["task", "scheduled-task", "daily"]);
+const POLL_INTERVAL_MS = 3000;
+
 export function getSourceIcon(source: string) {
   if (!source || source === "core") return null;
   if (source === "reminder") return <Timer size={13} />;
@@ -83,6 +86,9 @@ function SourceFolder({
   const fetcher = useFetcher<ConversationListResponse>({
     key: `conv-list-${source}`,
   });
+  const pollFetcher = useFetcher<ConversationListResponse>({
+    key: `conv-list-poll-${source}`,
+  });
   const icon = getSourceIcon(source);
   const label = getSourceLabel(source);
   const [open, setOpen] = useLocalCommonState<boolean>(
@@ -142,6 +148,33 @@ function SourceFolder({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetcher.data, fetcher.state]);
+
+  // Merge in polling updates without touching pagination
+  useEffect(() => {
+    if (pollFetcher.data && pollFetcher.state === "idle") {
+      const incoming = new Map(
+        pollFetcher.data.conversations.map((c) => [c.id, c]),
+      );
+      setConversations((prev) =>
+        prev.map((c) => incoming.get(c.id) ?? c),
+      );
+    }
+  }, [pollFetcher.data, pollFetcher.state]);
+
+  // Poll every few seconds while any loaded conversation is running
+  const hasRunning = conversations.some((c) => c.status === "running");
+  useEffect(() => {
+    if (!hasRunning) return;
+    const sourceParam =
+      source === "core" ? "&source=core" : `&source=${source}`;
+    const interval = setInterval(() => {
+      pollFetcher.load(
+        `/api/v1/conversations?unread=false&page=1&limit=10${sourceParam}`,
+      );
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasRunning, source]);
 
   const isOpen = open ?? false;
 
@@ -216,6 +249,9 @@ function SourceFolder({
                       "Untitled Conversation"
                     : "Untitled Conversation"}
                 </span>
+                {conversation.status === "running" && (
+                  <LoaderCircle className="text-muted-foreground ml-auto h-3.5 w-3.5 shrink-0 animate-spin" />
+                )}
               </Button>
             </div>
           ))}
@@ -256,11 +292,13 @@ export const ConversationList = ({
     [],
   );
 
-  const sorted = [...conversationSources].sort((a, b) => {
-    if (a.source === "core") return -1;
-    if (b.source === "core") return 1;
-    return getSourceLabel(a.source).localeCompare(getSourceLabel(b.source));
-  });
+  const sorted = [...conversationSources]
+    .filter(({ source }) => !EXCLUDED_SOURCES.has(source))
+    .sort((a, b) => {
+      if (a.source === "core") return -1;
+      if (b.source === "core") return 1;
+      return getSourceLabel(a.source).localeCompare(getSourceLabel(b.source));
+    });
 
   const hidden = hiddenSources ?? [];
   const filtered = sorted.filter(({ source }) => !hidden.includes(source));

--- a/apps/webapp/app/components/conversation/conversation-textarea.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-textarea.client.tsx
@@ -36,6 +36,7 @@ interface ConversationTextareaProps {
   defaultValue?: string;
   placeholder?: string;
   isLoading?: boolean;
+  isStopping?: boolean;
   className?: string;
   onChange?: (text: string) => void;
   disabled?: boolean;
@@ -53,6 +54,7 @@ interface ConversationTextareaProps {
 export function ConversationTextarea({
   defaultValue,
   isLoading = false,
+  isStopping = false,
   placeholder,
   onChange,
   onConversationCreated,
@@ -209,20 +211,23 @@ export function ConversationTextarea({
             variant="secondary"
             className="gap-1 shadow-none transition-all duration-500 ease-in-out"
             onClick={() => {
-              if (!isLoading && !disabled) {
-                handleSend();
-              } else if (!disabled) {
+              if (isStopping || disabled) return;
+              if (isLoading) {
                 stop && stop();
+              } else {
+                handleSend();
               }
             }}
-            disabled={disabled}
+            disabled={disabled || isStopping}
             size="lg"
           >
-            {isLoading ? (
+            {isStopping ? (
               <>
                 <LoaderCircle size={18} className="mr-1 animate-spin" />
-                Stop
+                Stopping
               </>
+            ) : isLoading ? (
+              <>Stop</>
             ) : (
               <>Chat</>
             )}

--- a/apps/webapp/app/components/conversation/conversation-view.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-view.client.tsx
@@ -52,9 +52,17 @@ export function ConversationView({
   integrationAccountMap = {},
   integrationFrontendMap = {},
   autoRegenerate = false,
-  conversationStatus,
+  conversationStatus: conversationStatusProp,
   models: modelsProp = [],
 }: ConversationViewProps) {
+  // Local mirror of the loader-provided status — stays fresh across stop/
+  // completion events without needing a route revalidation.
+  const [conversationStatus, setConversationStatus] = useState(
+    conversationStatusProp,
+  );
+  useEffect(() => {
+    setConversationStatus(conversationStatusProp);
+  }, [conversationStatusProp]);
   const history = historyProp ?? [];
   const readFetcher = useFetcher();
   const skillsFetcher = useFetcher<{
@@ -87,6 +95,26 @@ export function ConversationView({
   const handleModelChange = (modelId: string) => {
     setSelectedModelId(modelId);
   };
+
+  // Captures useChat.stop so handleStop can reference it without depending on
+  // the hook call order.
+  const stopRef = useRef<(() => void) | null>(null);
+
+  const [isStopping, setIsStopping] = useState(false);
+
+  const handleStop = useCallback(async () => {
+    setIsStopping(true);
+    try {
+      await fetch(`/api/v1/conversation/${conversationId}/stop`, {
+        method: "POST",
+      });
+    } catch {
+      // best-effort: network issues shouldn't block the local UI stop
+    }
+    stopRef.current?.();
+    setConversationStatus("cancelled");
+    setIsStopping(false);
+  }, [conversationId]);
 
   const [permissionMode, setPermissionMode] = useLocalCommonState<PermissionMode>(
     "conversationPermissionMode",
@@ -132,6 +160,7 @@ export function ConversationView({
     onFinish: () => {
       toolArgOverridesRef.current = {};
       pendingApprovalRequestsRef.current = [];
+      setConversationStatus("completed");
       readFetcher.submit(null, {
         method: "GET",
         action: `/api/v1/conversation/${conversationId}/read`,
@@ -171,11 +200,16 @@ export function ConversationView({
           },
         };
       },
+      prepareReconnectToStreamRequest: ({ id }) => ({
+        api: `/api/v1/conversation/${id}/stream`,
+      }),
     }),
     // Fire when every suspended tool (across the full agent hierarchy) has a
     // recorded approve/decline decision in toolArgOverridesRef.
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
+
+  stopRef.current = stop;
 
   useEffect(() => {
     if (
@@ -326,25 +360,25 @@ export function ConversationView({
       <div className="flex w-full shrink-0 flex-col items-center">
         <div ref={composerRef} className="w-full max-w-[90ch] px-4">
           <ThinkingIndicator
-            isLoading={status === "streaming" || status === "submitted"}
+            isLoading={
+              status === "streaming" ||
+              status === "submitted" ||
+              conversationStatus === "running"
+            }
           />
           <ConversationTextarea
             className="pt-4"
             isLoading={
               status === "streaming" ||
               status === "submitted" ||
-              (messages[messages.length - 1]?.role === "assistant" &&
-                conversationStatus === "running")
+              conversationStatus === "running"
             }
-            disabled={
-              needsApproval ||
-              (messages[messages.length - 1]?.role === "assistant" &&
-                conversationStatus === "running")
-            }
+            isStopping={isStopping}
+            disabled={needsApproval}
             onConversationCreated={(message) => {
               if (message) sendMessage({ text: message });
             }}
-            stop={() => stop()}
+            stop={handleStop}
             models={modelsProp}
             selectedModelId={selectedModelId}
             onModelChange={handleModelChange}
@@ -356,8 +390,7 @@ export function ConversationView({
                 disabled={
                   status === "streaming" ||
                   status === "submitted" ||
-                  (messages[messages.length - 1]?.role === "assistant" &&
-                    conversationStatus === "running")
+                  conversationStatus === "running"
                 }
               />
             }

--- a/apps/webapp/app/routes/api.v1.conversation.$conversationId.stop.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation.$conversationId.stop.tsx
@@ -1,0 +1,53 @@
+import { json } from "@remix-run/node";
+import { z } from "zod";
+import { createHybridActionApiRoute } from "~/services/routeBuilders/apiBuilder.server";
+import { prisma } from "~/db.server";
+import {
+  clearActiveStreamId,
+  updateConversationStatus,
+} from "~/services/conversation.server";
+import { stopStream } from "~/services/agent/stream-registry.server";
+import { logger } from "~/services/logger.service";
+
+const ParamsSchema = z.object({
+  conversationId: z.string(),
+});
+
+const { action, loader } = createHybridActionApiRoute(
+  {
+    params: ParamsSchema,
+    allowJWT: true,
+    corsStrategy: "all",
+  },
+  async ({ params, authentication }) => {
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id: params.conversationId,
+        userId: authentication.userId,
+        deleted: null,
+      },
+      select: { activeStreamId: true, status: true },
+    });
+
+    if (!conversation) {
+      return json({ ok: false, reason: "not_found" }, { status: 404 });
+    }
+
+    if (!conversation.activeStreamId) {
+      return json({ ok: true, reason: "no_active_stream" });
+    }
+
+    logger.info("[conversation] stop requested", {
+      conversationId: params.conversationId,
+      streamId: conversation.activeStreamId,
+    });
+
+    await stopStream(conversation.activeStreamId, "user_stopped");
+    await updateConversationStatus(params.conversationId, "cancelled");
+    await clearActiveStreamId(params.conversationId);
+
+    return json({ ok: true });
+  },
+);
+
+export { action, loader };

--- a/apps/webapp/app/routes/api.v1.conversation._index.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation._index.tsx
@@ -6,6 +6,8 @@ import {
   getConversationAndHistory,
   updateConversationStatus,
   upsertConversationHistory,
+  setActiveStreamId,
+  clearActiveStreamId,
 } from "~/services/conversation.server";
 import {
   getDefaultChatModelId,
@@ -20,9 +22,13 @@ import { logger } from "~/services/logger.service";
 
 import {
   saveConversationResult,
-  streamToUIResponse,
+  createResumableUIResponse,
   drainAgentResult,
 } from "~/services/agent/mastra-stream.server";
+import {
+  registerStream,
+  unregisterStream,
+} from "~/services/agent/stream-registry.server";
 import { type OutputProcessor, type Processor } from "@mastra/core/processors";
 import { patchArgsDeep } from "~/services/agent/tool-args-patch-processor";
 import {
@@ -281,6 +287,12 @@ const { loader, action } = createHybridActionApiRoute(
         `[conversation] resuming: ${toolDecisions.length} approval(s), runId=${body.id}`,
       );
 
+      const resumeStreamId = generateId();
+      const resumeAbortController = new AbortController();
+      registerStream(resumeStreamId, resumeAbortController);
+      await updateConversationStatus(body.id, "running");
+      await setActiveStreamId(body.id, resumeStreamId);
+
       let resumeResult: any;
 
       // Build nested arg overrides: strip 'approved' from each entry so only
@@ -309,6 +321,7 @@ const { loader, action } = createHybridActionApiRoute(
               toolCallId,
               toolCallConcurrency: 1,
               requestContext,
+              abortSignal: resumeAbortController.signal,
               prepareStep: (stepArgs) => {
                 if (Object.keys(nestedArgOverrides).length === 0) return;
                 // Deep-walk messages and patch args for any matching toolCallId,
@@ -330,6 +343,7 @@ const { loader, action } = createHybridActionApiRoute(
             resumeResult = await agent.declineToolCall({
               runId: body.id,
               toolCallId,
+              abortSignal: resumeAbortController.signal,
               outputProcessors: [messageHistoryProcessor as OutputProcessor],
             });
           }
@@ -349,11 +363,18 @@ const { loader, action } = createHybridActionApiRoute(
           error: String(err),
           stack: (err as any)?.stack,
         });
+        unregisterStream(resumeStreamId);
+        await clearActiveStreamId(body.id);
         await updateConversationStatus(body.id, "failed");
         throw err;
       }
 
-      return streamToUIResponse(resumeResult);
+      return createResumableUIResponse({
+        agentResult: resumeResult,
+        streamId: resumeStreamId,
+        conversationId: body.id,
+        abortSignal: resumeAbortController.signal,
+      });
     }
 
     // -----------------------------------------------------------------------
@@ -361,20 +382,10 @@ const { loader, action } = createHybridActionApiRoute(
     // -----------------------------------------------------------------------
     await updateConversationStatus(body.id, "running");
 
+    const streamId = generateId();
     const abortController = new AbortController();
-
-    const cancelStream = () => {
-      if (!abortController.signal.aborted) {
-        logger.info(
-          `[conversation] client disconnected, aborting stream for ${body.id}`,
-        );
-        abortController.abort();
-        updateConversationStatus(body.id, "completed").catch(() => {});
-      }
-    };
-
-    // Belt-and-suspenders: also fire if request.signal ever works
-    request.signal.addEventListener("abort", cancelStream);
+    registerStream(streamId, abortController);
+    await setActiveStreamId(body.id, streamId);
 
     let stream;
     try {
@@ -400,11 +411,18 @@ const { loader, action } = createHybridActionApiRoute(
         kind,
         error: error instanceof Error ? error.message : String(error),
       });
+      unregisterStream(streamId);
+      await clearActiveStreamId(body.id);
       await updateConversationStatus(body.id, "failed");
       throw error;
     }
 
-    return streamToUIResponse(stream, cancelStream);
+    return createResumableUIResponse({
+      agentResult: stream,
+      streamId,
+      conversationId: body.id,
+      abortSignal: abortController.signal,
+    });
   },
 );
 

--- a/apps/webapp/app/routes/home.conversation.$conversationId.tsx
+++ b/apps/webapp/app/routes/home.conversation.$conversationId.tsx
@@ -119,6 +119,7 @@ export default function SingleConversation() {
   return (
     <div className="h-page relative flex w-full flex-col items-center justify-center overflow-hidden">
       <ConversationView
+        key={conversationId as string}
         conversationId={conversationId as string}
         history={conversation.ConversationHistory}
         integrationAccountMap={integrationAccountMap}

--- a/apps/webapp/app/services/agent/mastra-stream.server.ts
+++ b/apps/webapp/app/services/agent/mastra-stream.server.ts
@@ -1,14 +1,22 @@
-import { generateId, createUIMessageStreamResponse } from "ai";
+import {
+  generateId,
+  createUIMessageStreamResponse,
+  JsonToSseTransformStream,
+  UI_MESSAGE_STREAM_HEADERS,
+} from "ai";
 import { toAISdkStream } from "@redplanethq/ai";
 import { EpisodeType, UserTypeEnum } from "@core/types";
 import { addToQueue } from "~/lib/ingest.server";
 import {
   upsertConversationHistory,
   updateConversationStatus,
+  clearActiveStreamId,
 } from "~/services/conversation.server";
 import { deductCredits } from "~/trigger/utils/utils";
 import { logger } from "~/services/logger.service";
 import { convertMastraChunkToAISDKv5 } from "@mastra/core/stream";
+import { getResumableStreamContext } from "~/bullmq/connection";
+import { unregisterStream } from "./stream-registry.server";
 
 /**
  * Builds assistant message parts from LLMStepResult[].
@@ -158,6 +166,99 @@ export function streamToUIResponse(
 
   return createUIMessageStreamResponse({
     stream,
+  });
+}
+
+/**
+ * Wraps a Mastra agent result in a resumable SSE stream keyed by `streamId`.
+ *
+ * The underlying run survives client disconnects: the stream is buffered in
+ * Redis via `resumable-stream`, so tab closes / network flaps don't abort it.
+ * Only an explicit stop (via `stream-registry.stopStream`) or successful
+ * completion terminates the producer.
+ *
+ * Finalization responsibilities:
+ *  - On success: `messageHistoryProcessor` already sets status=completed and
+ *    persists the assistant message. This helper only clears `activeStreamId`
+ *    and unregisters the abort controller.
+ *  - On cancel/failure: sets status=cancelled/failed and clears activeStreamId.
+ *    No partial assistant message is persisted (cancelled runs leave no trace).
+ */
+export async function createResumableUIResponse(params: {
+  agentResult: any;
+  streamId: string;
+  conversationId: string;
+  abortSignal: AbortSignal;
+  onApprovalDetected?: (toolCallId: string, approvalId: string) => Promise<void>;
+}): Promise<Response> {
+  const {
+    agentResult,
+    streamId,
+    conversationId,
+    abortSignal,
+    onApprovalDetected,
+  } = params;
+
+  const source = createUIStreamWithApprovals(
+    agentResult,
+    onApprovalDetected,
+  ).pipeThrough(new JsonToSseTransformStream());
+
+  let settled = false;
+  const settle = async (status: "completed" | "cancelled" | "failed") => {
+    if (settled) return;
+    settled = true;
+    try {
+      if (status !== "completed") {
+        await updateConversationStatus(conversationId, status);
+      }
+      await clearActiveStreamId(conversationId);
+      unregisterStream(streamId);
+    } catch (err) {
+      logger.error("[conversation] stream finalize failed", {
+        conversationId,
+        streamId,
+        status,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const makeStream = (): ReadableStream<string> =>
+    new ReadableStream<string>({
+      async start(controller) {
+        const reader = source.getReader();
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            controller.enqueue(value);
+          }
+          controller.close();
+          await settle("completed");
+        } catch (err) {
+          const isAbort = abortSignal.aborted;
+          controller.error(err);
+          await settle(isAbort ? "cancelled" : "failed");
+        } finally {
+          try {
+            reader.releaseLock();
+          } catch {
+            // reader already released — ignore
+          }
+        }
+      },
+    });
+
+  const ctx = getResumableStreamContext();
+  const resumable = await ctx.createNewResumableStream(streamId, makeStream);
+  if (!resumable) {
+    await settle("failed");
+    return new Response(null, { status: 204 });
+  }
+
+  return new Response(resumable as unknown as BodyInit, {
+    headers: UI_MESSAGE_STREAM_HEADERS,
   });
 }
 

--- a/apps/webapp/app/services/agent/stream-registry.server.ts
+++ b/apps/webapp/app/services/agent/stream-registry.server.ts
@@ -1,0 +1,78 @@
+import { getRedisConnection } from "~/bullmq/connection";
+import { logger } from "~/services/logger.service";
+
+const STOP_CHANNEL = "conversation:stream:stop";
+
+const controllers = new Map<string, AbortController>();
+let subscriberInitialized = false;
+
+function ensureSubscriber(): void {
+  if (subscriberInitialized) return;
+  subscriberInitialized = true;
+
+  const subscriber = getRedisConnection().duplicate();
+  subscriber.subscribe(STOP_CHANNEL).catch((err) => {
+    logger.error("[stream-registry] failed to subscribe to stop channel", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  subscriber.on("message", (channel, raw) => {
+    if (channel !== STOP_CHANNEL) return;
+    try {
+      const { streamId, reason } = JSON.parse(raw) as {
+        streamId: string;
+        reason?: string;
+      };
+      abortLocal(streamId, reason ?? "remote_stop");
+    } catch (err) {
+      logger.warn("[stream-registry] invalid stop payload", {
+        raw,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+}
+
+function abortLocal(streamId: string, reason: string): boolean {
+  const ctrl = controllers.get(streamId);
+  if (!ctrl) return false;
+  if (!ctrl.signal.aborted) {
+    ctrl.abort(reason);
+  }
+  return true;
+}
+
+export function registerStream(
+  streamId: string,
+  controller: AbortController,
+): void {
+  ensureSubscriber();
+  controllers.set(streamId, controller);
+}
+
+export function unregisterStream(streamId: string): void {
+  controllers.delete(streamId);
+}
+
+/**
+ * Abort a stream by id. Aborts locally if this process owns it, then
+ * publishes on the stop channel so other instances can abort their copy.
+ */
+export async function stopStream(
+  streamId: string,
+  reason = "user_stopped",
+): Promise<void> {
+  abortLocal(streamId, reason);
+  try {
+    await getRedisConnection().publish(
+      STOP_CHANNEL,
+      JSON.stringify({ streamId, reason }),
+    );
+  } catch (err) {
+    logger.warn("[stream-registry] failed to publish stop", {
+      streamId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/webapp/app/services/conversation.server.ts
+++ b/apps/webapp/app/services/conversation.server.ts
@@ -145,7 +145,13 @@ export async function readConversation(conversationId: string) {
 
 export async function updateConversationStatus(
   conversationId: string,
-  status: "pending" | "running" | "completed" | "failed" | "need_attention",
+  status:
+    | "pending"
+    | "running"
+    | "completed"
+    | "failed"
+    | "cancelled"
+    | "need_attention",
 ) {
   return prisma.conversation.update({
     where: { id: conversationId },

--- a/apps/webapp/prisma/schema.prisma
+++ b/apps/webapp/prisma/schema.prisma
@@ -101,7 +101,7 @@ model Conversation {
   workspace   Workspace? @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   workspaceId String?
 
-  status         String  @default("pending") // Can be "pending", "running", "completed", "failed", "need_attention"
+  status         String  @default("pending") // Can be "pending", "running", "completed", "failed", "cancelled", "need_attention"
   activeStreamId String? // Set while background stream is active; cleared on completion
 
   ConversationHistory ConversationHistory[]

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -101,7 +101,7 @@ model Conversation {
   workspace   Workspace? @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   workspaceId String?
 
-  status         String  @default("pending") // Can be "pending", "running", "completed", "failed", "need_attention"
+  status         String  @default("pending") // Can be "pending", "running", "completed", "failed", "cancelled", "need_attention"
   activeStreamId String? // Set while background stream is active; cleared on completion
 
   ConversationHistory ConversationHistory[]


### PR DESCRIPTION
## Summary

Make the conversation chat stream resumable, add explicit stop, and tighten the conversation list UX.

Before this PR, the agent stream was tied to the lifetime of the HTTP request — closing the tab aborted the run, and there was no way for a second tab (or a reload) to re-attach to an in-progress reply. Stop and tab-close were indistinguishable.

After: runs survive client disconnects (buffered to Redis via \`resumable-stream\`), multiple tabs can watch the same live stream, and a dedicated stop endpoint cleanly cancels the actual agent run.

## Architecture

**Producer (\`app/routes/api.v1.conversation._index.tsx\` + \`app/services/agent/mastra-stream.server.ts\`):**
- Each turn gets a fresh \`streamId\` stored on \`Conversation.activeStreamId\`.
- \`createResumableUIResponse\` wraps the Mastra agent stream with \`createNewResumableStream(streamId, …)\` so every chunk is mirrored to Redis regardless of whether a client is reading.
- A detached \`start(controller)\` pump decides the terminal status: \`completed\` on clean finish (message already persisted by \`messageHistoryProcessor\`), \`cancelled\` on abort, \`failed\` otherwise. Cancelled runs leave **no partial assistant message** in history.
- The approval-resume branch uses the same wrap so tool-approval continuations are resumable too, with their own \`streamId\` + abort controller.

**Stop path (\`app/services/agent/stream-registry.server.ts\` + \`api.v1.conversation.\$conversationId.stop.tsx\`):**
- Process-local \`Map<streamId, AbortController>\` registers each live run.
- \`stopStream()\` aborts locally **and** publishes to a Redis \`conversation:stream:stop\` channel so other app instances that own the run can abort their copy.
- Stop endpoint marks status \`cancelled\` and clears \`activeStreamId\`.

**Resume (client):**
- \`useChat\`'s \`prepareReconnectToStreamRequest\` points at \`GET /api/v1/conversation/:id/stream\`, which replays the Redis buffer via \`resumeExistingStream(activeStreamId)\`.
- \`ConversationView\` is now keyed by \`conversationId\` so switching between conversations fully remounts and re-triggers \`resume: true\`.

## UX

- Stop button: \`Chat\` → \`Stop\` (while running) → spinner + \`Stopping\` (until server ack) → back to \`Chat\`. Button no longer disabled mid-run.
- \`ThinkingIndicator\` shows on open whenever the DB says \`status = running\`, not just when the local useChat is streaming — covers the "I opened a conversation that's already running in the background" case.
- New \`Conversation.status\` value \`cancelled\`; schema comment updated in both \`apps/webapp\` and \`packages/database\` Prisma schemas.

## Conversation list

- Hide \`task\` / \`scheduled-task\` / \`daily\` source folders.
- Per-conversation running spinner when \`status = running\`.
- Poll page 1 every 3s while any loaded conversation is running; merge updates by id so pagination/scroll state is preserved. Interval self-cleans once nothing is running.

## Non-goals

- Background-queue runs (reminders, scheduled tasks, integrations via \`no-stream-process.ts\`) are intentionally not resumable — they write their final message via \`upsertConversationHistory\` and rely on list polling + next page load to surface completion.

## Test plan

- [ ] Send a message, close the tab mid-stream, reopen the conversation — run resumes and completes.
- [ ] Open the same running conversation in two tabs — both see live chunks.
- [ ] Click Stop mid-stream — button shows \`Stopping\` until the POST acks, status becomes \`cancelled\`, no partial assistant message saved, other tabs stop too.
- [ ] Approve a tool mid-run, close the tab during the post-approval stream — resumes on return.
- [ ] Navigate A → B → A while A is running — live stream still visible on A.
- [ ] Trigger a background run (reminder/scheduled task) — list sidebar polling flips the spinner off within ~3s of completion.
- [ ] Conversation list no longer shows \`task\`/\`scheduled-task\`/\`daily\` folders.