### PR TITLE
Fix: updates for #65

### DIFF
--- a/apps/webapp/app/components/browser/cdp-viewer.tsx
+++ b/apps/webapp/app/components/browser/cdp-viewer.tsx
@@ -15,7 +15,7 @@ import { useCdpScreencast } from "./use-cdp-screencast";
 interface Props {
   /** WebSocket URL pointing at the webapp's browser-CDP proxy. */
   wsUrl: string;
-  /** Format quality 0–100 (jpeg only — png ignores). */
+  /** JPEG quality 0–100. Lower = lower bandwidth. */
   quality?: number;
   /** Max frame width Chromium ships. Smaller = lower bandwidth. */
   maxWidth?: number;

--- a/apps/webapp/app/components/browser/use-cdp-screencast.ts
+++ b/apps/webapp/app/components/browser/use-cdp-screencast.ts
@@ -20,7 +20,9 @@ interface ScreencastFrameParams {
 
 interface Options {
   wsUrl: string;
-  /** Format quality 0-100 (only honored for `jpeg`). PNG ignores this. */
+  /** Format quality 0-100. JPEG only — the screencast is fixed to JPEG
+   *  because PNG ignores quality and produces 5–10x larger frames per tick,
+   *  which dominates bandwidth and decode cost on the screencast hot path. */
   quality?: number;
   /** Max frame width Chromium ships (lower = lower bandwidth). */
   maxWidth?: number;
@@ -193,17 +195,38 @@ export function useCdpScreencast({
 
           const canvas = canvasRef.current;
           if (!canvas) return;
-          const img = new Image();
-          img.onload = () => {
-            if (cancelled) return;
-            if (canvas.width !== img.width || canvas.height !== img.height) {
-              canvas.width = img.width;
-              canvas.height = img.height;
-            }
-            const ctx = canvas.getContext("2d");
-            if (ctx) ctx.drawImage(img, 0, 0);
-          };
-          img.src = `data:image/png;base64,${p.data}`;
+          // Decode off the main thread via createImageBitmap. The previous
+          // `new Image()` + base64 data URL forced a main-thread decode and
+          // a per-frame string allocation; with a busy screencast that adds
+          // up to visible jank. Skip the data-URL detour entirely by
+          // building a Blob from the base64 payload and handing it to the
+          // browser's image-bitmap pipeline.
+          const bin = atob(p.data);
+          const bytes = new Uint8Array(bin.length);
+          for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+          const blob = new Blob([bytes], { type: "image/jpeg" });
+          createImageBitmap(blob)
+            .then((bm) => {
+              if (cancelled) {
+                bm.close();
+                return;
+              }
+              const c = canvasRef.current;
+              if (!c) {
+                bm.close();
+                return;
+              }
+              if (c.width !== bm.width || c.height !== bm.height) {
+                c.width = bm.width;
+                c.height = bm.height;
+              }
+              const ctx = c.getContext("2d");
+              if (ctx) ctx.drawImage(bm, 0, 0);
+              bm.close();
+            })
+            .catch(() => {
+              /* swallow — corrupt frame; the next ack will pull a fresh one */
+            });
         });
 
         // Apply any viewport the consumer set before the connection was
@@ -226,11 +249,14 @@ export function useCdpScreencast({
         await cdp.send(
           "Page.startScreencast",
           {
-            format: "png",
+            format: "jpeg",
             quality,
             maxWidth: v ? Math.ceil(v.width * v.dpr) : maxWidth,
             maxHeight: v ? Math.ceil(v.height * v.dpr) : maxWidth * 2,
-            everyNthFrame: 1,
+            // Half the frames at the same perceived smoothness — eyes don't
+            // notice >30fps for screencast, but bandwidth and decode cost
+            // scale linearly. Keeps a busy page from saturating the WS.
+            everyNthFrame: 2,
           },
           sessionId,
         );
@@ -437,11 +463,11 @@ export function useCdpScreencast({
         .send(
           "Page.startScreencast",
           {
-            format: "png",
+            format: "jpeg",
             quality,
             maxWidth: Math.ceil(w * dprSafe),
             maxHeight: Math.ceil(h * dprSafe),
-            everyNthFrame: 1,
+            everyNthFrame: 2,
           },
           sid,
         )

--- a/apps/webapp/app/components/browser/use-cdp-screencast.ts
+++ b/apps/webapp/app/components/browser/use-cdp-screencast.ts
@@ -80,6 +80,54 @@ interface NavigationHistory {
   entries: NavigationHistoryEntry[];
 }
 
+interface KeyEventLike {
+  key: string;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * Map a keydown to Blink editor commands so Mac shortcuts (Cmd+Backspace,
+ * Alt+Left, etc.) work inside the screencast. AppKit normally translates
+ * these before the renderer sees them; under CDP we have to attach the
+ * commands explicitly. Names come from Blink's `EditorCommandNames`. The
+ * shift-modified variants extend the selection instead of moving the caret.
+ */
+function macEditorCommands(e: KeyEventLike): string[] {
+  const sel = e.shiftKey ? "AndModifySelection" : "";
+  if (e.metaKey && !e.ctrlKey && !e.altKey) {
+    switch (e.key) {
+      case "Backspace":
+        return ["DeleteToBeginningOfLine"];
+      case "Delete":
+        return ["DeleteToEndOfLine"];
+      case "ArrowLeft":
+        return [`MoveToBeginningOfLine${sel}`];
+      case "ArrowRight":
+        return [`MoveToEndOfLine${sel}`];
+      case "ArrowUp":
+        return [`MoveToBeginningOfDocument${sel}`];
+      case "ArrowDown":
+        return [`MoveToEndOfDocument${sel}`];
+    }
+  }
+  if (e.altKey && !e.ctrlKey && !e.metaKey) {
+    switch (e.key) {
+      case "Backspace":
+        return ["DeleteWordBackward"];
+      case "Delete":
+        return ["DeleteWordForward"];
+      case "ArrowLeft":
+        return [`MoveWordLeft${sel}`];
+      case "ArrowRight":
+        return [`MoveWordRight${sel}`];
+    }
+  }
+  return [];
+}
+
 /**
  * Connect to Chrome DevTools Protocol over the proxied WebSocket and stream
  * `Page.screencastFrame` images into a canvas. Also exposes mouse/keyboard
@@ -496,6 +544,16 @@ export function useCdpScreencast({
       modifiers: eventModifiers(e),
     };
     if (isPrintable) params.text = e.key;
+    // Mac editor shortcuts (Cmd+Backspace = delete-to-line-start, Alt+Left =
+    // word-left, etc.) are normally translated by AppKit before the renderer
+    // sees them. Headless Chromium gets only the raw key+modifiers, so the
+    // shortcut silently no-ops. CDP exposes a `commands` array on
+    // dispatchKeyEvent for exactly this — we map the key+modifier combo to
+    // Blink's editor command names and let the renderer execute them.
+    if (type === "keyDown") {
+      const commands = macEditorCommands(e);
+      if (commands.length > 0) params.commands = commands;
+    }
     cdp.send("Input.dispatchKeyEvent", params, sid).catch(() => {
       /* swallow */
     });

--- a/apps/webapp/app/services/gateway/browser-cdp-proxy.server.ts
+++ b/apps/webapp/app/services/gateway/browser-cdp-proxy.server.ts
@@ -58,7 +58,26 @@ async function resolveTarget(
 }
 
 function pipeFrames(client: WebSocket, upstream: WebSocket): void {
+  // Edge proxies (Railway / ALB / Cloudflare) drop WS connections after
+  // 30–60s of silence. CDP traffic is bursty — a static page emits no
+  // screencast frames once Chromium considers it visually stable — so
+  // long-idle sessions disconnect even though both ends are alive. Ping
+  // both hops on a 25s cadence to keep proxy state warm.
+  const heartbeat = setInterval(() => {
+    try {
+      if (client.readyState === client.OPEN) client.ping();
+    } catch {
+      /* swallow */
+    }
+    try {
+      if (upstream.readyState === upstream.OPEN) upstream.ping();
+    } catch {
+      /* swallow */
+    }
+  }, 25_000);
+
   const closeBoth = (code = 1000, reason = "") => {
+    clearInterval(heartbeat);
     if (client.readyState === client.OPEN) client.close(code, reason);
     if (upstream.readyState === upstream.OPEN) upstream.close(code, reason);
   };

--- a/apps/webapp/app/services/gateway/xterm-proxy.server.ts
+++ b/apps/webapp/app/services/gateway/xterm-proxy.server.ts
@@ -199,8 +199,13 @@ async function handleUpgrade(
   const upstreamUrl =
     resolved.baseUrl.replace(/^http/i, "ws").replace(/\/$/, "") +
     resolved.upstreamPath;
+  // permessage-deflate batches small frames before compressing, which adds
+  // perceptible latency to per-keystroke terminal traffic. Terminal output
+  // is already small and mostly ASCII — disabling deflate trades a bit of
+  // bandwidth for noticeably snappier typing in the Claude Code stream.
   const upstream = new WebSocket(upstreamUrl, {
     headers: { authorization: `Bearer ${securityKey}` },
+    perMessageDeflate: false,
   });
 
   // Buffer upstream frames that arrive before the client WS handshake

--- a/apps/webapp/app/services/gateway/xterm-proxy.server.ts
+++ b/apps/webapp/app/services/gateway/xterm-proxy.server.ts
@@ -93,7 +93,26 @@ function pipeFrames(client: WebSocket, upstream: WebSocket): void {
   const sanitizeCode = (code: number): number =>
     code === 1000 || (code >= 3000 && code <= 4999) ? code : 1000;
 
+  // Edge proxies (Railway / ALB / Cloudflare) drop WS connections after
+  // 30–60s of silence. A pause between keystrokes — or just thinking time
+  // mid-conversation — counts as idle, which manifests as the terminal
+  // randomly disconnecting while the user is typing. Pinging both hops on
+  // a 25s cadence keeps NAT and proxy state warm without touching payload.
+  const heartbeat = setInterval(() => {
+    try {
+      if (client.readyState === client.OPEN) client.ping();
+    } catch {
+      /* swallow — next interval will retry or close handler will clean up */
+    }
+    try {
+      if (upstream.readyState === upstream.OPEN) upstream.ping();
+    } catch {
+      /* swallow */
+    }
+  }, 25_000);
+
   const closeBoth = (code = 1000, reason = "") => {
+    clearInterval(heartbeat);
     const safe = sanitizeCode(code);
     try {
       if (client.readyState === client.OPEN) client.close(safe, reason);


### PR DESCRIPTION
## Context
Fixes #65: improve gateway reliability + deployment ergonomics, and document the new Scratchpad/Widgets surfaces.

## Changes
- **Gateway identity now syncs from manifest → DB on health refresh**
  - On every `refreshGatewayHealth`, the webapp best-effort updates the gateway **name + description** from the gateway manifest (handles unique name collisions by syncing description only).
- **Better gateway verification errors (typed result + actionable reasons)**
  - `verifyGateway()` now returns `{ ok: true ... } | { ok: false; reason }` (instead of null), with clearer messages for timeouts / 401 / non-JSON bodies / non-200 responses.
  - Registration + update routes surface these reasons directly.
- **Terminal reliability + UX**
  - Gateway shell becomes a singleton session that can be **resumed** by default; `fresh: true` forces a new session.
  - Webapp owns shell lifecycle at the gateway layout level so the **header “New shell”** button and terminal pane stay in sync.
  - Xterm proxy buffers early upstream frames so **scrollback replay (`attach.replayed`) isn’t dropped**, avoiding blank terminals on resume.
- **Railway/container deployment fixes**
  - Store folder paths as user-supplied (e.g. `/app`) instead of `realpath`, but still resolve symlink realpaths for security/path matching.
  - Clear stale Chromium `Singleton*` lockfiles at gateway boot to prevent Brave from refusing to launch after container restarts.
  - Ensure graceful shutdown closes browser sessions within a bounded timeout.
- **Redis streaming hardening**
  - Enable Redis `autoPipelining` to reduce ENOBUFS under bursty load.
  - Use dedicated pub/sub connections for resumable streaming + add error handlers for subscriber connections.
- **Docs**
  - Add: `docs/concepts/scratchpad.mdx`, `docs/concepts/widgets.mdx`, `docs/gateway/tunnels.mdx`
  - Wire pages into `docs/docs.json` and link tunnels from gateway overview.

## Testing
- Not specified in this PR.

## Notes
- This PR touches **webapp**, **CLI gateway daemon**, **gateway protocol**, and **docs**.
- If CI is available, it should be the main merge gate given the breadth (31 files, +1120/-485).