### PR TITLE
fix(memory): add bounded broad-recall candidates to SearchV2

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -200,6 +200,14 @@ const EnvironmentSchema = z
     // Search-v2 label match tuning
     // Default keeps current behavior; lower for embedding providers with lower cosine ranges.
     SEARCH_LABEL_VECTOR_THRESHOLD: z.coerce.number().min(0).max(1).default(0.7),
+    // Optional Search-v2 broad recall backstop.
+    // When enabled, episode-returning handlers merge bounded raw-query recall
+    // candidates before existing reranking/compaction/token budgeting.
+    MEMORY_SEARCH_V2_BROAD_RECALL_BACKSTOP: z
+      .string()
+      .optional()
+      .default("false")
+      .transform((val) => val === "true" || val === "1"),
 
     // Provider configuration
     GRAPH_PROVIDER: z.enum(["neo4j", "falkordb", "helix"]).default("neo4j"),

--- a/apps/webapp/app/services/search-v2/handlers.ts
+++ b/apps/webapp/app/services/search-v2/handlers.ts
@@ -2,6 +2,8 @@ import { ProviderFactory, VECTOR_NAMESPACES } from "@core/providers";
 import { logger } from "~/services/logger.service";
 import { applyCohereEpisodeReranking } from "~/services/search/rerank";
 import { prisma } from "~/db.server";
+import { env } from "~/env.server";
+import { SearchService } from "~/services/search.server";
 
 import type {
   HandlerContext,
@@ -30,6 +32,8 @@ import {
 type RankedEpisode = EpisodicNode & { relevanceScore?: number };
 import { CohereClientV2 } from "cohere-ai";
 import { getEmbedding } from "~/lib/model.server";
+
+const broadRecallSearchService = new SearchService();
 
 /**
  * Apply Cohere reranking to statements
@@ -1056,6 +1060,104 @@ async function normalizeToRecallResult(
   };
 }
 
+function shouldUseBroadRecallBackstop(ctx: HandlerContext): boolean {
+  return (
+    Boolean(ctx.options.query?.trim()) &&
+    (ctx.options.enableBroadRecallBackstop ??
+      env.MEMORY_SEARCH_V2_BROAD_RECALL_BACKSTOP)
+  );
+}
+
+async function getBroadRecallBackstopEpisodes(
+  ctx: HandlerContext,
+): Promise<EpisodicNode[]> {
+  if (!shouldUseBroadRecallBackstop(ctx)) {
+    return [];
+  }
+
+  const query = ctx.options.query?.trim();
+  if (!query) {
+    return [];
+  }
+
+  const startedAt = Date.now();
+  const limit = ctx.options.broadRecallBackstopLimit ?? 10;
+  const source = ctx.options.source
+    ? `${ctx.options.source}:search-v2-broad-recall-backstop`
+    : "search-v2-broad-recall-backstop";
+
+  try {
+    const result = await broadRecallSearchService.search(
+      query,
+      ctx.userId,
+      ctx.workspaceId,
+      {
+        structured: true,
+        limit,
+        skipEntityExpansion: true,
+        useLLMValidation: false,
+        skipRecallLog: true,
+        tokenBudget: ctx.options.tokenBudget,
+      },
+      source,
+    );
+
+    if (typeof result === "string") {
+      return [];
+    }
+
+    const episodes = result.episodes.map((episode) => ({
+      uuid: episode.uuid,
+      content: episode.content,
+      originalContent: episode.content,
+      metadata: {},
+      source,
+      createdAt: episode.createdAt,
+      validAt: episode.createdAt,
+      labelIds: episode.labelIds || [],
+      sessionId: episode.uuid,
+      type: episode.isDocument || episode.isCompact ? "DOCUMENT" : undefined,
+      userId: ctx.userId,
+      workspaceId: ctx.workspaceId,
+    })) as EpisodicNode[];
+
+    logger.info(
+      `[SearchV2:broad-recall-backstop] Found ${episodes.length} candidates in ${Date.now() - startedAt}ms`,
+    );
+    return episodes;
+  } catch (error) {
+    logger.warn(
+      `[SearchV2:broad-recall-backstop] Failed, continuing without backstop: ${error}`,
+    );
+    return [];
+  }
+}
+
+async function augmentEpisodesWithBroadRecallBackstop(
+  episodes: EpisodicNode[],
+  ctx: HandlerContext,
+): Promise<EpisodicNode[]> {
+  const backstopEpisodes = await getBroadRecallBackstopEpisodes(ctx);
+  if (backstopEpisodes.length === 0) {
+    return episodes;
+  }
+
+  const byUuid = new Map(episodes.map((episode) => [episode.uuid, episode]));
+  let added = 0;
+
+  for (const episode of backstopEpisodes) {
+    if (!byUuid.has(episode.uuid)) {
+      byUuid.set(episode.uuid, episode);
+      added += 1;
+    }
+  }
+
+  logger.info(
+    `[SearchV2:broad-recall-backstop] Added ${added}/${backstopEpisodes.length} candidates (${episodes.length} → ${byUuid.size})`,
+  );
+  return Array.from(byUuid.values());
+}
+
 /**
  * Handle temporal_facets - enumerate what exists in a time range without reading episode content
  * Runs topic, entity, and aspect queries in parallel based on requested facet dimensions
@@ -1327,8 +1429,12 @@ export async function routeToHandler(
       }
 
       // Broad mode - return episodes with entity
-      const rerankedEpisodes = await applyEpisodeReranking(
+      const augmentedEpisodes = await augmentEpisodesWithBroadRecallBackstop(
         result.episodes,
+        ctx,
+      );
+      const rerankedEpisodes = await applyEpisodeReranking(
+        augmentedEpisodes,
         ctx,
       );
       return await normalizeToRecallResult(
@@ -1347,7 +1453,12 @@ export async function routeToHandler(
         handleAspectQuery(ctx),
         searchVoiceAspectsForQuery(ctx),
       ]);
-      const rerankedEpisodes = await applyEpisodeReranking(episodes, ctx);
+      const augmentedEpisodes =
+        await augmentEpisodesWithBroadRecallBackstop(episodes, ctx);
+      const rerankedEpisodes = await applyEpisodeReranking(
+        augmentedEpisodes,
+        ctx,
+      );
       const result = await normalizeToRecallResult(
         { episodes: rerankedEpisodes },
         ctx,
@@ -1366,9 +1477,12 @@ export async function routeToHandler(
         ctx.routerOutput.entityHints.length > 0 ||
         ctx.routerOutput.selectedLabels.length > 0 ||
         ctx.routerOutput.aspects.length > 0;
+      const augmentedEpisodes = hasTopic
+        ? await augmentEpisodesWithBroadRecallBackstop(episodes, ctx)
+        : episodes;
       const rerankedEpisodes = hasTopic
-        ? await applyEpisodeReranking(episodes, ctx)
-        : episodes
+        ? await applyEpisodeReranking(augmentedEpisodes, ctx)
+        : augmentedEpisodes
             .sort(
               (a, b) =>
                 new Date(b.createdAt).getTime() -
@@ -1391,9 +1505,15 @@ export async function routeToHandler(
 
     case "exploratory": {
       const episodes = await handleExploratory(ctx);
-      const rerankedEpisodes = await applyEpisodeReranking(episodes, ctx, {
-        threshold: 0.2,
-      });
+      const augmentedEpisodes =
+        await augmentEpisodesWithBroadRecallBackstop(episodes, ctx);
+      const rerankedEpisodes = await applyEpisodeReranking(
+        augmentedEpisodes,
+        ctx,
+        {
+          threshold: 0.2,
+        },
+      );
       return await normalizeToRecallResult({ episodes: rerankedEpisodes }, ctx);
     }
 
@@ -1414,7 +1534,12 @@ export async function routeToHandler(
         handleAspectQuery(ctx),
         searchVoiceAspectsForQuery(ctx),
       ]);
-      const rerankedEpisodes = await applyEpisodeReranking(episodes, ctx);
+      const augmentedEpisodes =
+        await augmentEpisodesWithBroadRecallBackstop(episodes, ctx);
+      const rerankedEpisodes = await applyEpisodeReranking(
+        augmentedEpisodes,
+        ctx,
+      );
       const result = await normalizeToRecallResult(
         { episodes: rerankedEpisodes },
         ctx,

--- a/apps/webapp/app/services/search-v2/types.ts
+++ b/apps/webapp/app/services/search-v2/types.ts
@@ -323,6 +323,10 @@ export interface SearchV2Options {
   // Reranking
   enableReranking?: boolean;
 
+  // Candidate recall augmentation
+  enableBroadRecallBackstop?: boolean;
+  broadRecallBackstopLimit?: number;
+
   // Optional workspace override from caller context
   workspaceId?: string;
 

--- a/apps/webapp/app/services/search.server.ts
+++ b/apps/webapp/app/services/search.server.ts
@@ -85,11 +85,13 @@ export class SearchService {
       labelIds: options.labelIds || [],
       adaptiveFiltering: options.adaptiveFiltering || false,
       structured: options.structured || false,
-      useLLMValidation: options.useLLMValidation || true,
+      useLLMValidation: options.useLLMValidation ?? true,
       qualityThreshold: options.qualityThreshold || 0.3,
       maxEpisodesForLLM: options.maxEpisodesForLLM || 20,
       sortBy: options.sortBy || "relevance",
       tokenBudget: options.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+      skipEntityExpansion: options.skipEntityExpansion || false,
+      skipRecallLog: options.skipRecallLog || false,
     };
     // Enhance query with LLM to transform keyword soup into semantic query
 
@@ -98,10 +100,14 @@ export class SearchService {
     logger.info(`Query vectorization: ${vectorEndTime - startTime}ms`);
 
     // Note: We still need to extract entities from graph for Episode Graph search
-    // The LLM entities are just strings, we need EntityNode objects from the graph
-    const entities = await extractEntitiesFromQuery(query, userId, workspaceId, []);
+    // The LLM entities are just strings, we need EntityNode objects from the graph.
+    const entities = opts.skipEntityExpansion
+      ? []
+      : await extractEntitiesFromQuery(query, userId, workspaceId, []);
     logger.info(
-      `Extracted entities ${entities.map((e: EntityNode) => e.name).join(", ")}`,
+      opts.skipEntityExpansion
+        ? "Skipped entity extraction for broad recall search"
+        : `Extracted entities ${entities.map((e: EntityNode) => e.name).join(", ")}`,
     );
     const entityEndTime = Date.now();
     logger.info(`Entity extraction: ${entityEndTime - vectorEndTime}ms`);
@@ -133,20 +139,35 @@ export class SearchService {
         logger.debug(`Vector search completed in ${searchTimings.vector}ms`);
         return r;
       }),
-      performBfsSearch(query, queryVector, userId, workspaceId, entities, opts).then((r) => {
-        searchTimings.bfs = Date.now() - searchStartTime;
-        logger.debug(`BFS search completed in ${searchTimings.bfs}ms`);
-        return r;
-      }),
-      performEpisodeGraphSearch(entities, queryVector, userId, workspaceId, opts).then(
-        (r) => {
-          searchTimings.episodeGraph = Date.now() - searchStartTime;
-          logger.debug(
-            `Episode graph search completed in ${searchTimings.episodeGraph}ms`,
-          );
-          return r;
-        },
-      ),
+      opts.skipEntityExpansion
+        ? Promise.resolve([])
+        : performBfsSearch(
+            query,
+            queryVector,
+            userId,
+            workspaceId,
+            entities,
+            opts,
+          ).then((r) => {
+            searchTimings.bfs = Date.now() - searchStartTime;
+            logger.debug(`BFS search completed in ${searchTimings.bfs}ms`);
+            return r;
+          }),
+      opts.skipEntityExpansion
+        ? Promise.resolve([])
+        : performEpisodeGraphSearch(
+            entities,
+            queryVector,
+            userId,
+            workspaceId,
+            opts,
+          ).then((r) => {
+            searchTimings.episodeGraph = Date.now() - searchStartTime;
+            logger.debug(
+              `Episode graph search completed in ${searchTimings.episodeGraph}ms`,
+            );
+            return r;
+          }),
       performEpisodeVectorSearch(queryVector, userId, workspaceId, opts).then((r) => {
         searchTimings.episodeVector = Date.now() - searchStartTime;
         logger.debug(
@@ -385,18 +406,20 @@ export class SearchService {
       filteredResults.map((item) => item.statement),
     );
 
-    this.logRecallAsync(
-      query,
-      userId,
-      limitedEpisodes.length,
-      opts,
-      responseTime,
-      source,
-      tokenCount,
-      searchTimings,
-    ).catch((error) => {
-      logger.error("Failed to log recall event:", error);
-    });
+    if (!opts.skipRecallLog) {
+      this.logRecallAsync(
+        query,
+        userId,
+        limitedEpisodes.length,
+        opts,
+        responseTime,
+        source,
+        tokenCount,
+        searchTimings,
+      ).catch((error) => {
+        logger.error("Failed to log recall event:", error);
+      });
+    }
 
     // Return markdown by default, structured JSON if requested
     if (opts.structured) {

--- a/packages/types/src/search.ts
+++ b/packages/types/src/search.ts
@@ -22,6 +22,8 @@ export interface SearchOptions {
   maxEpisodesForLLM?: number; // Maximum episodes to send for LLM validation (default: 20)
   sortBy?: "relevance" | "recency"; // Sort results by relevance (default) or recency (newest first)
   tokenBudget?: number; // Token budget for recall output (default: 10000). Drops least relevant episodes from tail until total tokens <= budget
+  skipEntityExpansion?: boolean; // Skip entity extraction/BFS/graph fanout for bounded broad recall candidate searches
+  skipRecallLog?: boolean; // Skip writing recall log entries for internal candidate searches
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional bounded broad-recall backstop to SearchV2.

When enabled, episode-returning SearchV2 handlers merge a small set of raw-query recall candidates before the existing reranking, compaction, invalidation, and token-budget steps. SearchV2 still owns the final result shape; this only widens the candidate pool before ranking.

## Why

This keeps SearchV2 aligned with CORE’s hybrid recall goal: routed label/aspect retrieval remains the primary path, but bounded raw-query recall gives exact/semantic long-tail memories another way into the reranker before final filtering.

SearchV2’s label/aspect routing is useful, but it can become an exclusive candidate gate. A confident route can still miss older technical memories when the matched labels are adjacent-but-wrong, too narrow, or dominated by recent related work.

I tested this against a harder recall case: asking why Jina was chosen over Nomic for local embeddings. The target note was older and technical, with literal anchors like `Jina`, `Nomic`, and embedding evaluation details. SearchV2 repeatedly returned recent adjacent CORE/search/proxy memories instead of the older decision note.

Adding a bounded raw-query candidate pass let SearchV2 surface the missing target and recover the intended rationale: "Jina was a better operational fit for CORE’s bursty mixed-size workload, with faster local embedding times in that test, not a claim that Jina is universally semantically superior."

The goal is to preserve SearchV2’s structured routing and result shaping while avoiding premature candidate loss before reranking has a chance to work.

## Implementation

- Adds `MEMORY_SEARCH_V2_BROAD_RECALL_BACKSTOP`, default off.
- Adds `enableBroadRecallBackstop` and `broadRecallBackstopLimit` to SearchV2 options.
- Runs a bounded raw-query recall pass through `SearchService`.
- Skips entity expansion/BFS/episode graph traversal for that internal pass to keep it bounded.
- Skips recall-log writes for the internal candidate pass to avoid noisy duplicate logs.
- Merges backstop episodes by UUID before SearchV2 reranking.
- Leaves relationship/statement-only and temporal-facet paths unchanged.
- Fixes `useLLMValidation: false` being ignored by the previous `|| true` default.

## Notes

This is intentionally not a user-visible fallback and not a rewrite of SearchV2. It is a candidate-pool correction: label/aspect routing should prioritize recall, not be the only door through which older memories can enter the reranker.
