### PR TITLE
Auto-delete empty scratchpad-created tasks after 2 minutes

### DIFF
--- a/apps/webapp/app/jobs/task/scheduled-task.logic.ts
+++ b/apps/webapp/app/jobs/task/scheduled-task.logic.ts
@@ -19,6 +19,7 @@ import {
 import { logger } from "~/services/logger.service";
 import { getOrCreatePersonalAccessToken } from "~/services/personalAccessToken.server";
 import {
+  deleteTask,
   incrementTaskOccurrenceCount,
   incrementTaskUnrespondedCount,
   scheduleNextTaskOccurrence,
@@ -28,6 +29,7 @@ import { prisma } from "~/db.server";
 import { CoreClient } from "@redplanethq/sdk";
 import { HttpOrchestratorTools } from "~/services/agent/orchestrator-tools.http";
 import { getPageContentAsHtml } from "~/services/hocuspocus/content.server";
+import { removeTaskItemFromPages } from "~/services/hocuspocus/page-outlinks.server";
 import { enqueueTask } from "~/lib/queue-adapter.server";
 import {
   getTaskPhase,
@@ -171,10 +173,26 @@ export async function processScheduledTask(
  * Buffer-expiry branch: the 2-minute Todo window is up. Clear nextRunAt and
  * hand off to the normal task runner, which runs the agent in prep mode
  * (driven by phase=prep in context.ts).
+ *
+ * Parity with the client-side delete-on-removal in scratchpad-task-item.tsx:
+ * if a scratchpad-created task (`source === "daily"`) sits in the editor
+ * for the full 2 minutes without ever getting a title or description, drop
+ * it and pull its node out of any pages that still reference it instead of
+ * starting prep — these are the abandoned `[ ]` lines users typed and
+ * walked away from.
  */
 async function startPrepFromBuffer(
   task: Task,
 ): Promise<ScheduledTaskProcessResult> {
+  if (task.source === "daily" && (await isTaskEmpty(task))) {
+    logger.info(
+      `Auto-deleting empty scratchpad task ${task.id} at buffer expiry`,
+    );
+    await removeTaskItemFromPages(task.id);
+    await deleteTask(task.id, task.workspaceId);
+    return { success: true };
+  }
+
   await prisma.task.update({
     where: { id: task.id },
     data: { nextRunAt: null },
@@ -187,6 +205,25 @@ async function startPrepFromBuffer(
   });
 
   return { success: true };
+}
+
+/**
+ * Mirrors the client-side empty check in scratchpad-task-item.tsx: a task
+ * is "empty" if its title was never set past the placeholder and its page
+ * has no description content.
+ */
+async function isTaskEmpty(task: Task): Promise<boolean> {
+  const trimmedTitle = task.title?.trim() ?? "";
+  const isUntitled = trimmedTitle === "" || trimmedTitle === "Untitled task";
+  if (!isUntitled) return false;
+
+  if (!task.pageId) return true;
+  const html = await getPageContentAsHtml(task.pageId);
+  if (!html) return true;
+  // generateHTML wraps even an empty Tiptap doc in a single `<p></p>`;
+  // strip tags+whitespace and treat that as no content.
+  const stripped = html.replace(/<[^>]*>/g, "").trim();
+  return stripped === "";
 }
 
 /**

--- a/apps/webapp/app/services/__tests__/task-lifecycle.test.ts
+++ b/apps/webapp/app/services/__tests__/task-lifecycle.test.ts
@@ -57,13 +57,19 @@ vi.mock("~/services/agent/context/decision-context", () => ({
 vi.mock("~/models/workspace.server", () => ({
   getWorkspacePersona: vi.fn(async () => ({ content: "" })),
 }));
-vi.mock("~/services/hocuspocus/content.server", () => ({
+const contentMocks = vi.hoisted(() => ({
   getPageContentAsHtml: vi.fn(async () => ""),
   setPageContentFromHtml: vi.fn(),
 }));
-vi.mock("~/services/hocuspocus/page-outlinks.server", () => ({
+vi.mock("~/services/hocuspocus/content.server", () => contentMocks);
+const getPageContentAsHtmlMock = contentMocks.getPageContentAsHtml;
+
+const outlinksMocks = vi.hoisted(() => ({
   updateTaskTitleInPages: vi.fn(),
+  removeTaskItemFromPages: vi.fn(),
 }));
+vi.mock("~/services/hocuspocus/page-outlinks.server", () => outlinksMocks);
+const removeTaskItemFromPagesMock = outlinksMocks.removeTaskItemFromPages;
 vi.mock("~/services/page.server", () => ({
   findOrCreateTaskPage: vi.fn(async (_ws, _u, taskId) => ({
     id: `page-for-${taskId}`,
@@ -140,6 +146,10 @@ beforeEach(async () => {
   });
   hasCreditsMock.mockClear();
   hasCreditsMock.mockResolvedValue(true);
+  getPageContentAsHtmlMock.mockClear();
+  getPageContentAsHtmlMock.mockResolvedValue("");
+  removeTaskItemFromPagesMock.mockClear();
+  removeTaskItemFromPagesMock.mockResolvedValue(undefined);
   await ensureFixture();
   await cleanTasks();
 });
@@ -232,6 +242,163 @@ describe("processScheduledTask — wake-up branching", () => {
     });
     expect(reloaded.nextRunAt).toBeNull();
     expect(reloaded.status).toBe("Todo"); // prep starts in Todo, no status change yet
+  });
+
+  it("buffer expiry: empty scratchpad task (source=daily, Untitled, no description) → auto-deleted, scratchpad node pulled, no prep enqueued", async () => {
+    const page = await prisma.page.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        type: "Task",
+      },
+    });
+    const task = await prisma.task.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        title: "Untitled task",
+        status: "Todo",
+        source: "daily",
+        metadata: { phase: "prep" },
+        nextRunAt: new Date(Date.now() - 1000),
+        isActive: true,
+        pageId: page.id,
+      },
+    });
+    getPageContentAsHtmlMock.mockResolvedValueOnce("<p></p>");
+
+    const result = await processScheduledTask({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      channel: "email",
+    });
+
+    expect(result.success).toBe(true);
+    // Task is deleted and prep is NOT enqueued
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
+    expect(removeTaskItemFromPagesMock).toHaveBeenCalledWith(task.id);
+
+    const reloaded = await prisma.task.findUnique({ where: { id: task.id } });
+    expect(reloaded).toBeNull();
+  });
+
+  it("buffer expiry: scratchpad task with a real title → starts prep, NOT deleted", async () => {
+    const task = await prisma.task.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        title: "Buy oat milk",
+        status: "Todo",
+        source: "daily",
+        metadata: { phase: "prep" },
+        nextRunAt: new Date(Date.now() - 1000),
+        isActive: true,
+      },
+    });
+
+    await processScheduledTask({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      channel: "email",
+    });
+
+    expect(removeTaskItemFromPagesMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).toHaveBeenCalledWith({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+    });
+    const reloaded = await prisma.task.findUniqueOrThrow({
+      where: { id: task.id },
+    });
+    expect(reloaded.id).toBe(task.id);
+    expect(reloaded.nextRunAt).toBeNull();
+  });
+
+  it("buffer expiry: scratchpad task with description but Untitled title → starts prep, NOT deleted", async () => {
+    const page = await prisma.page.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        type: "Task",
+      },
+    });
+    const task = await prisma.task.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        title: "Untitled task",
+        status: "Todo",
+        source: "daily",
+        metadata: { phase: "prep" },
+        nextRunAt: new Date(Date.now() - 1000),
+        isActive: true,
+        pageId: page.id,
+      },
+    });
+    getPageContentAsHtmlMock.mockResolvedValueOnce(
+      "<p>some notes the user typed</p>",
+    );
+
+    await processScheduledTask({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      channel: "email",
+    });
+
+    expect(removeTaskItemFromPagesMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).toHaveBeenCalledWith({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+    });
+    const reloaded = await prisma.task.findUniqueOrThrow({
+      where: { id: task.id },
+    });
+    expect(reloaded.id).toBe(task.id);
+  });
+
+  it("buffer expiry: empty manual task (source=manual) is NOT auto-deleted", async () => {
+    const page = await prisma.page.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        type: "Task",
+      },
+    });
+    const task = await prisma.task.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        title: "Untitled task",
+        status: "Todo",
+        source: "manual",
+        metadata: { phase: "prep" },
+        nextRunAt: new Date(Date.now() - 1000),
+        isActive: true,
+        pageId: page.id,
+      },
+    });
+    getPageContentAsHtmlMock.mockResolvedValueOnce("<p></p>");
+
+    await processScheduledTask({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      channel: "email",
+    });
+
+    expect(removeTaskItemFromPagesMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).toHaveBeenCalledWith({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+    });
+    const reloaded = await prisma.task.findUnique({ where: { id: task.id } });
+    expect(reloaded).not.toBeNull();
   });
 
   it("normal fire (Ready) → execute via CASE pipeline", async () => {

--- a/apps/webapp/app/services/hocuspocus/page-outlinks.server.ts
+++ b/apps/webapp/app/services/hocuspocus/page-outlinks.server.ts
@@ -91,6 +91,69 @@ function updateTaskTitleInDoc(node: any, taskId: string, newTitle: string): bool
 }
 
 /**
+ * Recursively strip taskItem nodes that match taskId from the doc.
+ * Mutates `node.content` in place. Returns true if anything was removed.
+ */
+function removeTaskItemFromDoc(node: any, taskId: string): boolean {
+  let updated = false;
+
+  if (Array.isArray(node.content)) {
+    const filtered = node.content.filter(
+      (child: any) =>
+        !(child.type === "taskItem" && child.attrs?.id === taskId),
+    );
+    if (filtered.length !== node.content.length) {
+      node.content = filtered;
+      updated = true;
+    }
+    for (const child of node.content) {
+      if (removeTaskItemFromDoc(child, taskId)) updated = true;
+    }
+  }
+
+  return updated;
+}
+
+/**
+ * Remove every taskItem node referencing `taskId` from any page that
+ * outlinks to it. Persists via Hocuspocus so live clients see the removal
+ * in real-time.
+ *
+ * Used by the buffer-expiry auto-delete path: when the 2-minute window
+ * closes on an empty scratchpad-created task, we drop the task and pull
+ * its node out of the originating page so the user doesn't see a stub.
+ */
+export async function removeTaskItemFromPages(taskId: string): Promise<void> {
+  try {
+    const pages = await prisma.page.findMany({
+      where: {
+        outlinks: {
+          array_contains: [{ type: "Task", id: taskId }] as any,
+        },
+      },
+      select: { id: true, description: true },
+    });
+
+    for (const page of pages) {
+      if (!page.description) continue;
+
+      let doc: any;
+      try {
+        doc = JSON.parse(page.description);
+      } catch {
+        continue;
+      }
+
+      if (removeTaskItemFromDoc(doc, taskId)) {
+        await updateContentForDocument(page.id, doc);
+      }
+    }
+  } catch (err) {
+    console.error("[removeTaskItemFromPages] failed for task", taskId, err);
+  }
+}
+
+/**
  * When a task's title changes, find all pages that reference it via outlinks
  * and update the taskItem text in each page's stored JSON.
  * Persists via Hocuspocus so live clients get the update in real-time.


### PR DESCRIPTION
## Summary
Adds a safety cleanup at the 2-minute scratchpad buffer expiry: if a scratchpad-created task still has **empty title + empty description**, we **delete the task** and also **remove it from the scratchpad page**.

## Behavior
- Scratchpad creates a task with no title/description.
- If the user removes it immediately, existing behavior deletes it.
- If the user does not remove it, the butler/prep logic runs after ~2 minutes. At that point, if **title and description are still empty**, we now:
  1. Delete the task
  2. Remove the corresponding task item from pages (scratchpad) via `removeTaskItemFromPages`

## Implementation details
- Introduces `removeTaskItemFromPages` (mirrors `updateTaskTitleInPages`) to remove the `taskItem` node from any outlinking pages and persist via Hocuspocus.
- Updates `startPrepFromBuffer` to short-circuit: when `source === "daily"` and the task is empty, remove from pages + delete, then return (no prep starts).

## Tests
- Added/updated tests covering:
  - Empty scratchpad-created task is deleted at buffer expiry
  - Task is **not** deleted if title present
  - Task is **not** deleted if description present
  - Task is **not** deleted for non-`daily` source
