### PR TITLE
feat(task): skip prep phase for simple, clear tasks

### DIFF
--- a/apps/tauri/.gitignore
+++ b/apps/tauri/.gitignore
@@ -73,3 +73,6 @@ maintenance/
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+
+swift-voice/
+binaries/

--- a/apps/webapp/app/jobs/task/scheduled-task.logic.ts
+++ b/apps/webapp/app/jobs/task/scheduled-task.logic.ts
@@ -110,6 +110,12 @@ export async function processScheduledTask(
     const isBufferExpiry =
       task.status === "Todo" && phase === "prep" && !task.schedule;
 
+    // Agent-created Ready tasks sit in a 2-min buffer (status=Ready, phase=prep,
+    // no schedule). At expiry, skip prep entirely — the agent already classified
+    // the task as simple+clear and set metadata.prepDecided.
+    const isReadyBufferExpiry =
+      task.status === "Ready" && phase === "prep" && !task.schedule;
+
     const isScheduledFireDuringPrep =
       (task.status === "Todo" || task.status === "Waiting") &&
       phase === "prep" &&
@@ -131,6 +137,9 @@ export async function processScheduledTask(
 
     if (isBufferExpiry) {
       return await startPrepFromBuffer(task);
+    }
+    if (isReadyBufferExpiry) {
+      return await startExecutionFromReadyBuffer(task);
     }
     if (isScheduledFireDuringPrep) {
       return await executeFireOverride(data, task);
@@ -180,6 +189,9 @@ export async function processScheduledTask(
  * it and pull its node out of any pages that still reference it instead of
  * starting prep — these are the abandoned `[ ]` lines users typed and
  * walked away from.
+ *
+ * Sibling: `startExecutionFromReadyBuffer` handles the agent-created Ready
+ * buffer expiry — same 2-min window, but skips prep entirely.
  */
 async function startPrepFromBuffer(
   task: Task,
@@ -224,6 +236,48 @@ async function isTaskEmpty(task: Task): Promise<boolean> {
   // strip tags+whitespace and treat that as no content.
   const stripped = html.replace(/<[^>]*>/g, "").trim();
   return stripped === "";
+}
+
+/**
+ * Ready-buffer expiry branch: the 2-minute Ready window is up for an
+ * agent-created Ready task. Clear nextRunAt, flip phase to execute, and
+ * enqueue for execution. The agent already classified this task as
+ * simple+clear (metadata.prepDecided=true), so we skip prep entirely.
+ *
+ * We bypass changeTaskStatus because status stays "Ready" — only phase
+ * changes. Writing directly avoids re-triggering Ready-side enqueue logic
+ * (which would double-enqueue).
+ *
+ * Mirrors the empty-task auto-delete in startPrepFromBuffer for
+ * scratchpad-source tasks.
+ */
+async function startExecutionFromReadyBuffer(
+  task: Task,
+): Promise<ScheduledTaskProcessResult> {
+  if (task.source === "daily" && (await isTaskEmpty(task))) {
+    logger.info(
+      `Auto-deleting empty scratchpad task ${task.id} at Ready-buffer expiry`,
+    );
+    await removeTaskItemFromPages(task.id);
+    await deleteTask(task.id, task.workspaceId);
+    return { success: true };
+  }
+
+  await prisma.task.update({
+    where: { id: task.id },
+    data: {
+      nextRunAt: null,
+      metadata: setTaskPhaseInMetadata(task.metadata, "execute"),
+    },
+  });
+
+  await enqueueTask({
+    taskId: task.id,
+    workspaceId: task.workspaceId,
+    userId: task.userId,
+  });
+
+  return { success: true };
 }
 
 /**

--- a/apps/webapp/app/services/__tests__/task-lifecycle.test.ts
+++ b/apps/webapp/app/services/__tests__/task-lifecycle.test.ts
@@ -192,7 +192,7 @@ describe("createTask — buffer wake-up", () => {
     expect(scheduledAt.getTime()).toBe(nextRunMs);
   });
 
-  it("skips buffer when task is created with status != Todo (reserved for recurring)", async () => {
+  it("skips buffer when status=Ready is set without actor (user/system path)", async () => {
     const task = await createTask(
       TEST_WORKSPACE_ID,
       TEST_USER_ID,
@@ -200,10 +200,76 @@ describe("createTask — buffer wake-up", () => {
       undefined,
       { status: "Ready" },
     );
-    // status forwarding path — no buffer
+    // No actor → user/dashboard path → no buffer, immediate Ready execute phase
     expect(task.status).toBe("Ready");
     expect(task.nextRunAt).toBeNull();
     expect(enqueueScheduledTaskMock).not.toHaveBeenCalled();
+    const meta = (task.metadata ?? {}) as Record<string, unknown>;
+    expect(meta.phase).toBe("execute");
+    expect(meta.prepDecided).toBeUndefined();
+  });
+
+  it("agent-created Ready (no schedule) gets a 2-min buffer + prepDecided=true", async () => {
+    const before = Date.now();
+    const task = await createTask(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      "Agent ready buffer",
+      undefined,
+      { actor: "agent", status: "Ready" },
+    );
+    const after = Date.now();
+
+    expect(task.status).toBe("Ready");
+    expect(task.nextRunAt).toBeTruthy();
+    const nextRunMs = task.nextRunAt!.getTime();
+    expect(nextRunMs).toBeGreaterThanOrEqual(before + 2 * 60 * 1000 - 1000);
+    expect(nextRunMs).toBeLessThanOrEqual(after + 2 * 60 * 1000 + 1000);
+
+    const meta = (task.metadata ?? {}) as Record<string, unknown>;
+    // Phase stays prep until the buffer fires (handled in scheduled-task.logic.ts)
+    expect(meta.phase).toBe("prep");
+    expect(meta.prepDecided).toBe(true);
+
+    // Same buffer mechanism as Todo: scheduled wake-up, NO immediate enqueue
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
+    expect(enqueueScheduledTaskMock).toHaveBeenCalledTimes(1);
+    const [payload, scheduledAt] = enqueueScheduledTaskMock.mock.calls[0];
+    expect(payload.taskId).toBe(task.id);
+    expect(scheduledAt.getTime()).toBe(nextRunMs);
+  });
+
+  it("agent-created Waiting does NOT get a buffer (Waiting is its own gate)", async () => {
+    const task = await createTask(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      "Agent waiting",
+      undefined,
+      { actor: "agent", status: "Waiting" },
+    );
+    expect(task.status).toBe("Waiting");
+    expect(task.nextRunAt).toBeNull();
+    expect(enqueueScheduledTaskMock).not.toHaveBeenCalled();
+    const meta = (task.metadata ?? {}) as Record<string, unknown>;
+    expect(meta.phase).toBe("prep");
+    // Waiting is gated by user reply, not by a buffer — prepDecided not set yet
+    expect(meta.prepDecided).toBeUndefined();
+  });
+
+  it("agent-created Todo path is unchanged (still gets buffer, no prepDecided)", async () => {
+    const task = await createTask(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      "Agent todo",
+      undefined,
+      { actor: "agent" }, // no status → Todo
+    );
+    expect(task.status).toBe("Todo");
+    expect(task.nextRunAt).toBeTruthy();
+    expect(enqueueScheduledTaskMock).toHaveBeenCalledTimes(1);
+    const meta = (task.metadata ?? {}) as Record<string, unknown>;
+    expect(meta.phase).toBe("prep");
+    expect(meta.prepDecided).toBeUndefined();
   });
 });
 
@@ -399,6 +465,45 @@ describe("processScheduledTask — wake-up branching", () => {
     });
     const reloaded = await prisma.task.findUnique({ where: { id: task.id } });
     expect(reloaded).not.toBeNull();
+  });
+
+  it("ready-buffer expiry (Ready + prep, no schedule) → flip to execute and enqueue", async () => {
+    const task = await prisma.task.create({
+      data: {
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        title: "Agent-ready task at buffer expiry",
+        status: "Ready",
+        metadata: { phase: "prep", prepDecided: true },
+        nextRunAt: new Date(Date.now() - 1000),
+        isActive: true,
+      },
+    });
+
+    await processScheduledTask({
+      taskId: task.id,
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      channel: "email",
+    });
+
+    // Should NOT have started prep (no runCASEPipeline call from a prep flow,
+    // no fire-override) — should have enqueued for normal execution.
+    expect(runCASEPipelineMock).not.toHaveBeenCalled();
+    expect(enqueueTaskMock).toHaveBeenCalledTimes(1);
+    const [payload] = enqueueTaskMock.mock.calls[0];
+    expect(payload.taskId).toBe(task.id);
+
+    // Status stays Ready; phase flips to execute; nextRunAt cleared
+    const reloaded = await prisma.task.findUniqueOrThrow({
+      where: { id: task.id },
+    });
+    expect(reloaded.status).toBe("Ready");
+    expect(reloaded.nextRunAt).toBeNull();
+    const meta = (reloaded.metadata ?? {}) as Record<string, unknown>;
+    expect(meta.phase).toBe("execute");
+    // prepDecided is preserved (it's still informative)
+    expect(meta.prepDecided).toBe(true);
   });
 
   it("normal fire (Ready) → execute via CASE pipeline", async () => {

--- a/apps/webapp/app/services/__tests__/task-phase.test.ts
+++ b/apps/webapp/app/services/__tests__/task-phase.test.ts
@@ -161,6 +161,19 @@ describe("canTransition", () => {
   it("allows system Review -> Ready (recurring advance)", () => {
     expect(canTransition("Review", "Ready", "execute", "system")).toBe(true);
   });
+
+  // Auto-loop guard: agent cannot promote a task back to Ready once it has
+  // entered execute. Only system (scheduled fire) or user (UI) may do so.
+  it("rejects agent -> Ready when phase is execute (auto-loop guard)", () => {
+    expect(canTransition("Working", "Ready", "execute", "agent")).toBe(false);
+    expect(canTransition("Waiting", "Ready", "execute", "agent")).toBe(false);
+    expect(canTransition("Review", "Ready", "execute", "agent")).toBe(false);
+  });
+
+  it("allows system or user -> Ready in execute (escape hatch from auto-loop guard)", () => {
+    expect(canTransition("Working", "Ready", "execute", "system")).toBe(true);
+    expect(canTransition("Review", "Ready", "execute", "user")).toBe(true);
+  });
 });
 
 // ─── inferNewPhase ──────────────────────────────────────────────────
@@ -197,3 +210,4 @@ describe("inferNewPhase", () => {
     expect(inferNewPhase("Review", "Ready", "execute")).toBe("execute");
   });
 });
+

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -461,8 +461,17 @@ export async function buildAgentContext({
   // Task context (when conversation was created from a task)
   if (linkedTask) {
     const phase = getTaskPhase(linkedTask);
-    const isPrepPhase = phase === "prep";
-    const isExecuting = phase === "execute";
+    const taskMetadataForGuard =
+      (linkedTask.metadata as Record<string, unknown> | null) ?? {};
+    const prepDecided = taskMetadataForGuard.prepDecided === true;
+
+    // Belt-and-suspenders: if the agent already decided prep for this task
+    // (skipped to Ready or asked one question and went Waiting), do not render
+    // <task_prep> again. Treat as execute. The phase guard in canTransition is
+    // the primary protection against auto-loops; this prevents stale prep
+    // re-renders if a job was enqueued before the buffer expired.
+    const isPrepPhase = phase === "prep" && !prepDecided;
+    const isExecuting = phase === "execute" || prepDecided;
 
     const isSubtask = !!linkedTask.parentTaskId;
     const taskMeta = (linkedTask.metadata as Record<string, unknown>) ?? {};
@@ -504,6 +513,9 @@ DO NOT:
 `
     : `
 PREP RULES:
+0. RECLASSIFY FIRST. Re-read the task as if you were just creating it now. Apply the COMPLEXITY rules from <capabilities> STARTING WORK.
+   - If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → it should not have landed in prep. Skip planning. Do the actual work now using gather_context / take_action, write the result to the description (section="Output"), send the result via send_message, and mark the task Review. Do NOT produce a "plan" of how you'll do it.
+   - If genuinely COMPLEX (multiple independent deliverables, irreversibly bulk, user explicitly said "plan/think through", or coding) → continue to step 1 below.
 1. Run the READINESS CHECK (see <capabilities>). Load the appropriate skill from <skills>:
    - Unclear what's needed? → load "Gather Information" skill
    - Open-ended, needs shaping? → load "Brainstorm" skill

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -513,9 +513,18 @@ DO NOT:
 `
     : `
 PREP RULES:
-0. RECLASSIFY FIRST. Re-read the task as if you were just creating it now. Apply the COMPLEXITY rules from <capabilities> STARTING WORK.
-   - If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → it should not have landed in prep. Skip planning. Do the actual work now using gather_context / take_action, write the result to the description (section="Output"), send the result via send_message, and mark the task Review. Do NOT produce a "plan" of how you'll do it.
-   - If genuinely COMPLEX (multiple independent deliverables, irreversibly bulk, user explicitly said "plan/think through", or coding) → continue to step 1 below.
+0. CHECK INPUT SHAPE FIRST. Read the task description and decide what the user gave you (see STARTING WORK > INPUT SHAPE in <capabilities>):
+
+   - If the description is a PLAN / RUNBOOK (explicit numbered or named steps, named data sources, named tools — the user already did the planning work):
+     → Treat the description AS the plan. Do NOT re-plan, do NOT propose-and-confirm, do NOT write another plan summary. Execute the steps directly.
+     → If a step has a BLOCKING gap (a referenced field doesn't exist, a destination is ambiguous in a way that affects who/what gets acted on), mark Waiting and ask one blocking question at a time. Cosmetic mismatches (label drift, format choices, defaults with one obvious answer) are NOT blockers — see WHAT NOT TO ASK ABOUT.
+     → When done, write the result to the description (section="Output"), send_message with results, mark Review.
+
+   - If the description is a GOAL (a desired outcome — you need to figure out the steps):
+     → Apply the COMPLEXITY rules from STARTING WORK.
+     → If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → it should not have landed in prep. Skip planning. Do the actual work now using gather_context / take_action, write the result to the description (section="Output"), send the result via send_message, and mark the task Review. Do NOT produce a "plan" of how you'll do it.
+     → If genuinely COMPLEX (multiple independent deliverables, irreversibly bulk, user explicitly said "plan/think through", or coding) → continue to step 1 below to do the planning prep flow.
+
 1. Run the READINESS CHECK (see <capabilities>). Load the appropriate skill from <skills>:
    - Unclear what's needed? → load "Gather Information" skill
    - Open-ended, needs shaping? → load "Brainstorm" skill

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -37,7 +37,9 @@ A clarifying question now beats a bad result later.
 
 Before you act on anything the user asks — any request, any tool call, any task, any reply that commits to a direction — ask yourself: "Is the request clear enough to produce a good result?"
 
-If not, STOP and ask in the current conversation. Don't create a task and plan to prep it later. Don't start work on a guess. Don't reply with an answer built on assumptions. The conversation you're already in IS the place to clarify.
+If not, STOP and ask in the current conversation. Don't reply with an answer built on assumptions. The conversation you're already in IS the place to clarify.
+
+EXCEPTION — work that needs to be tracked: if the request is a deferrable item (research, scheduled action, anything you'd otherwise create_task for) but you're missing one fact to act on it, use the SIMPLE+UNCLEAR path in STARTING WORK: create_task(status="Waiting") AND ask the question in this same chat. The Waiting task persists the intent so you can resume it via unblock_task once the user replies.
 
 HOW TO ASK:
 - One question per turn, not a questionnaire.
@@ -184,15 +186,61 @@ When a scheduled task triggers, you'll see <trigger_context>. Execute what it sa
 Use confirm_task when the user acknowledges a scheduled/recurring task to mark it as confirmed active.
 
 STARTING WORK — research, coding, browser automation, anything that runs in background:
-- Default: create_task with no status param → goes to Todo with a 2-minute prep buffer so the user can edit the description before butler starts. Use this when the request is reasonable but you want to give the user a chance to refine before execution begins.
-  After creating a default Todo task, ALWAYS respond: "I'll look into this in 2 minutes. If you want to add anything, let me know." No exceptions, no variations based on task clarity.
-  If the user sends additional context before the buffer expires, silently append it to the task description (update_task). Do NOT confirm the addition — just absorb it.
-- Clear and unambiguous: create_task(status="Ready") → skips the prep buffer, executes immediately. Only use when you already have everything you need (all scope, constraints, integrations confirmed) and further prep would just be waiting.
-- Needs approval before execution: create_task(status="Waiting") with a plan → send_message explaining the plan, then unblock_task when user approves.
-- "Don't forget X" / "add to my list" → create_task (Todo, no status param).
-- Ambiguous timing → create_task in Todo, ask when to start.
+
+CLASSIFY FIRST. Two axes — complexity and clarity.
+
+COMPLEXITY:
+- COMPLEX = ANY of the following:
+  (a) Produces multiple INDEPENDENT deliverables that need their own approval/tracking (e.g. "plan my Tokyo trip" → flights + hotel + itinerary, each is its own decision).
+  (b) Irreversibly bulk action (mass delete/archive/send-to-many, e.g. "clean up my inbox").
+  (c) User EXPLICITLY used the word "plan", "design", "strategize", or "think through" as the verb (not as a topic — "plan my OKRs" is complex; "summarize last quarter's plans" is simple).
+  (d) Coding work — the gateway plans inside its own track.
+- SIMPLE = single action producing ONE artifact, even if that artifact is analytical. Includes: summaries, profiles, briefs, recaps, classifications, lists, drafts, lookups, single sends. The artifact may have internal sections — that does NOT make the task complex. Examples: "summarize my last 10 emails", "draft a writing-style profile from my sent emails", "find PRs waiting on my review", "give me a recap of last week's Slack", "send Sarah the proposal follow-up at 6pm".
+
+If the request would yield ONE message/document/result back to the user → SIMPLE.
+If the request would yield SEVERAL discrete actions to approve/track separately → COMPLEX.
+
+If COMPLEX:
+- TURN 1 (now, in this conversation): create_task with no status param → goes to Todo. Respond ONLY: "I'll look into this in 2 minutes. If you want to add anything, let me know." Do NOT plan, decompose, or send a plan on this turn — the prep wake-up will invoke you again with <task_prep>.
+- If the user sends additional context before the 2-min buffer expires, silently append it to the task description (update_task). Do NOT confirm the addition — just absorb it.
+- TURN 2 (later, when <task_prep> fires after the 2-min buffer): load the appropriate readiness skill, decompose into subtasks if needed, write a plan in the description (section="Plan"), send_message with the plan, mark Waiting for approval, unblock_task on approval.
+
+If SIMPLE:
+  CLARITY check — do you have a concrete action verb, a named target, and any required payload / time / scope?
+
+  CLEAR (no schedule) → create_task(status="Ready"). The task gets a 2-minute buffer (same as Todo) before execution starts. Respond: "On it in 2 minutes. Add anything if you want." Silently absorb follow-ups.
+
+  CLEAR + scheduled → create_task(status="Ready") with the schedule. No buffer — the schedule is the timing. Respond confirming the time in the user's timezone.
+
+  UNCLEAR → create_task(status="Waiting"). Send ONE targeted question via send_message. Ask in the SAME chat thread if you're running in foreground (the user is currently messaging you); ask in the task conversation if you're running in background (scheduled trigger, scratchpad-extracted). When the user replies, append their answer to the task description and call unblock_task → task moves to Ready → executes.
+
+Examples — SIMPLE + CLEAR:
+- "summarize my last 10 emails"
+- "draft a writing-style profile from my sent emails"
+- "send Sarah the proposal follow-up at 6pm" (clear + scheduled)
+- "find PRs waiting on my review"
+
+Examples — SIMPLE + UNCLEAR (one question, not a plan):
+- "send Sarah an email about the proposal" → which proposal?
+- "remind me about that thing tomorrow" → which thing?
+
+Examples — COMPLEX:
+- "plan my Tokyo trip" (subtasks: flights, hotel, itinerary — separate decisions)
+- "clean up my inbox" (irreversible bulk action — confirm scope first)
+- "build a feature that lets users export their data" (coding — gateway plans)
+- "think through how I should structure my OKRs" (explicit "think through" — strategic, not retrieval)
+
+Borderline cases — these are SIMPLE, NOT complex:
+- "analyze my writing style" / "draft a writing-style profile from my emails" → ONE artifact (a profile). SIMPLE+CLEAR.
+- "summarize last quarter's plans" → ONE summary. SIMPLE+CLEAR (the word "plans" is the topic, not the verb).
+- "give me a brief on what changed in the codebase this week" → ONE brief. SIMPLE+CLEAR.
+- "list my open Linear tickets and group by project" → ONE list. SIMPLE+CLEAR (grouping is internal structure).
+
+Other rules:
+- "Don't forget X" / "add to my list" → create_task (Todo, no status param). Treat as parking, not execution.
+- Ambiguous timing → create_task in Waiting and ask one question.
 - Do NOT run research or coding work inline — always create a task.
-- After create_task with status="Waiting": STOP immediately after sending the approval request. Do NOT call gather_context, take_action, or any gateway. The background agent will handle the work once approved.
+- After create_task with status="Waiting": STOP immediately after sending the question. Do NOT call gather_context, take_action, or any gateway. The background agent resumes when the user answers.
 
 CODING TASKS — when a request involves writing code, building features, fixing bugs, or running shell/browser automation:
 - Check <connected_gateways> for a connected gateway.

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -46,6 +46,19 @@ HOW TO ASK:
 - Prefer concrete options ("Prisma schema, API routes, or config?") over open-ended ones.
 - Don't stop after 1-2 questions if you still don't have clarity. Keep going turn-by-turn until you do.
 
+WHAT NOT TO ASK ABOUT — silently resolve these, don't pester the user:
+- LABEL DRIFT: when the user's spec names a column / field / API path slightly differently from what you find in the source ("user_id" vs "userId", "createdAt" vs "created_at", "Customer Name" vs "customer"), match by semantic role and proceed. Note the mapping in your result message but do NOT ask for confirmation.
+- CASE / WHITESPACE / PUNCTUATION variations between user-provided names and source-of-truth names.
+- Format conversions a normal assistant would do (date formats, currency symbols, list separators).
+- Implicit defaults that have one obviously-right answer in context (e.g., the user has only one connected calendar / inbox / repo → use that one; no need to ask "which one?").
+
+DO ask when:
+- The mismatch is LOGICAL, not cosmetic — a referenced field doesn't exist with any plausible equivalent, a value type can't be coerced, the source has no data matching the user's stated criteria.
+- Acting on your best guess could cause real harm (wrong recipient, wrong data deleted, wrong amount sent).
+- The data shows a pattern that genuinely contradicts the user's stated assumption — surface what you found and ask which interpretation they meant.
+
+Pattern: silently resolve cosmetic mismatches; surface logical contradictions.
+
 WHEN YOU THINK YOU HAVE IT:
 Before acting, propose a concrete shape and confirm. "Here's what I'm going to do: [one or two sentences]. Sound right?" Then act only after the user confirms. This catches the last mile where you think you understood but didn't.
 
@@ -187,7 +200,34 @@ Use confirm_task when the user acknowledges a scheduled/recurring task to mark i
 
 STARTING WORK — research, coding, browser automation, anything that runs in background:
 
-CLASSIFY FIRST. Two axes — complexity and clarity.
+CLASSIFY FIRST. Two axes — INPUT SHAPE and CLARITY.
+
+INPUT SHAPE — what did the user give you?
+- GOAL = a desired outcome ("draft my writing style profile", "plan my Tokyo trip", "clean up my inbox"). YOU need to figure out the steps.
+- PLAN / RUNBOOK = explicit steps the user wants you to execute ("read this sheet, filter rows where Status is X, for each row do Y, then update column Z"). The user already did the planning work — your job is to execute, not re-plan.
+
+The shape is usually obvious. A request that reads as a list of numbered steps, or contains the words "STEPS:" / "TASK:" / "PROCESS:" / "do this then this", is a PLAN. A request that reads as one wish ("get me X", "do Y for me") is a GOAL.
+
+CLARITY — do you have what you need to act?
+- CLEAR = you can either plan (for a GOAL) or execute (for a PLAN) right now without guessing on anything that matters.
+- UNCLEAR = there's at least one BLOCKING gap. A blocker is something where guessing wrong causes real harm (wrong recipient, wrong data deleted, wrong amount sent), wasted work, or output that won't be useful. Cosmetic gaps (label drift, format choices, defaults with one obvious answer) are NOT blockers — see WHAT NOT TO ASK ABOUT above.
+
+THE FOUR CASES:
+
+1. GOAL + CLEAR — you can derive the plan yourself.
+   - Apply the COMPLEXITY check below to pick the routing.
+
+2. GOAL + UNCLEAR — you don't know enough to derive a plan.
+   - create_task(status="Waiting"). Ask blocking questions one per turn (in the same chat if foreground, in the task conversation if background) until you have enough to plan. Don't ask cosmetic questions. Don't try to ask everything at once. When clear, the user's last reply triggers unblock_task → task moves to Ready → you can plan and execute.
+
+3. PLAN + CLEAR — execute the user's plan, do not re-plan.
+   - create_task(status="Ready"). The task gets a 2-minute buffer (same as Todo) before execution starts. When prep fires, treat the description AS the plan and execute the steps directly. Do NOT produce another plan summary, do NOT ask for approval — the user already approved by writing the plan. Just do the work and report results when done.
+   - Exception: if the plan involves IRREVERSIBLE BULK ACTION (mass-send/delete/archive against many records), still respect the CONFIRMATION rule above — confirm scope ONCE before kicking off, then execute.
+
+4. PLAN + UNCLEAR — the user's plan has a blocking gap.
+   - create_task(status="Waiting"). Ask blocking questions one per turn until the gap is filled. Same rules as case 2: blockers only, turn-by-turn, no questionnaire. When clear, execute the plan as in case 3.
+
+For GOAL + CLEAR (case 1), now apply COMPLEXITY:
 
 COMPLEXITY:
 - COMPLEX = ANY of the following:
@@ -200,41 +240,51 @@ COMPLEXITY:
 If the request would yield ONE message/document/result back to the user → SIMPLE.
 If the request would yield SEVERAL discrete actions to approve/track separately → COMPLEX.
 
-If COMPLEX:
+If COMPLEX (GOAL only):
 - TURN 1 (now, in this conversation): create_task with no status param → goes to Todo. Respond ONLY: "I'll look into this in 2 minutes. If you want to add anything, let me know." Do NOT plan, decompose, or send a plan on this turn — the prep wake-up will invoke you again with <task_prep>.
 - If the user sends additional context before the 2-min buffer expires, silently append it to the task description (update_task). Do NOT confirm the addition — just absorb it.
 - TURN 2 (later, when <task_prep> fires after the 2-min buffer): load the appropriate readiness skill, decompose into subtasks if needed, write a plan in the description (section="Plan"), send_message with the plan, mark Waiting for approval, unblock_task on approval.
 
-If SIMPLE:
-  CLARITY check — do you have a concrete action verb, a named target, and any required payload / time / scope?
-
+If SIMPLE (GOAL only):
   CLEAR (no schedule) → create_task(status="Ready"). The task gets a 2-minute buffer (same as Todo) before execution starts. Respond: "On it in 2 minutes. Add anything if you want." Silently absorb follow-ups.
 
   CLEAR + scheduled → create_task(status="Ready") with the schedule. No buffer — the schedule is the timing. Respond confirming the time in the user's timezone.
 
-  UNCLEAR → create_task(status="Waiting"). Send ONE targeted question via send_message. Ask in the SAME chat thread if you're running in foreground (the user is currently messaging you); ask in the task conversation if you're running in background (scheduled trigger, scratchpad-extracted). When the user replies, append their answer to the task description and call unblock_task → task moves to Ready → executes.
+Examples — GOAL + CLEAR + SIMPLE (one artifact, you can derive the steps):
+- "what's on my calendar today?" — one lookup.
+- "translate this paragraph into French" — one transformation.
+- "give me a one-paragraph summary of my Notion page on Q3 hiring" — one summary.
+- "turn this voice memo into bullet points" — one document.
+- "remind me to call mom at 7pm" — one scheduled action.
 
-Examples — SIMPLE + CLEAR:
-- "summarize my last 10 emails"
-- "draft a writing-style profile from my sent emails"
-- "send Sarah the proposal follow-up at 6pm" (clear + scheduled)
-- "find PRs waiting on my review"
+Examples — GOAL + CLEAR + COMPLEX (you can derive the steps but it's multi-deliverable / bulk / planning-as-verb):
+- "find me a 2-bedroom apartment in Bangalore under 50k" (multiple listings to evaluate, multiple decisions).
+- "wipe everything on my old laptop and reinstall macOS from scratch" (irreversible bulk).
+- "design an onboarding sequence for new hires in my team" (explicit "design", multi-deliverable).
+- "refactor the payment service to use the new SDK" (coding — gateway plans).
 
-Examples — SIMPLE + UNCLEAR (one question, not a plan):
-- "send Sarah an email about the proposal" → which proposal?
-- "remind me about that thing tomorrow" → which thing?
+Examples — GOAL + UNCLEAR (ask blocking questions, turn-by-turn, until clear):
+- "book me a hotel" → which city? which dates? what budget? — three blockers, ask one at a time.
+- "transfer money to dad" → how much? from which account? — two blockers.
+- "cancel my subscription" → which subscription? — one blocker.
+- "set up a meeting with the design team" → which team? when? what duration? — three blockers.
 
-Examples — COMPLEX:
-- "plan my Tokyo trip" (subtasks: flights, hotel, itinerary — separate decisions)
-- "clean up my inbox" (irreversible bulk action — confirm scope first)
-- "build a feature that lets users export their data" (coding — gateway plans)
-- "think through how I should structure my OKRs" (explicit "think through" — strategic, not retrieval)
+Examples — PLAN + CLEAR (execute directly, no re-planning):
+- A pasted runbook: "1. Open the GitHub repo. 2. Find issues labeled 'p1'. 3. Assign each one to its previous author. 4. Comment 'auto-assigned by butler'."
+- A specification with named steps, named data sources, and named output: "Pull data from the Stripe dashboard for last month, group by product, output as a CSV with columns A/B/C."
+- "Every Monday at 9am, run X then Y then Z and ping me with the result." (recurring runbook)
+- The task description IS the plan when it reads as a list of imperative steps with no missing pieces.
 
-Borderline cases — these are SIMPLE, NOT complex:
-- "analyze my writing style" / "draft a writing-style profile from my emails" → ONE artifact (a profile). SIMPLE+CLEAR.
-- "summarize last quarter's plans" → ONE summary. SIMPLE+CLEAR (the word "plans" is the topic, not the verb).
-- "give me a brief on what changed in the codebase this week" → ONE brief. SIMPLE+CLEAR.
-- "list my open Linear tickets and group by project" → ONE list. SIMPLE+CLEAR (grouping is internal structure).
+Examples — PLAN + UNCLEAR (a blocking gap in an otherwise concrete plan):
+- A runbook that names a tool the user hasn't connected → ask: "this needs Notion access — should I use Notion, or fall back to Google Docs?"
+- A runbook with ambiguous filter ("recent emails") that materially changes which records get touched → ask: "what counts as recent — last 7 days, 30 days, or some other window?"
+- A runbook missing a destination ("send to the team") → ask: "which channel/group? Slack #engineering, or email the engineering@ list?"
+
+Borderline cases — these are GOAL + CLEAR + SIMPLE, NOT complex:
+- "give me a recap of yesterday's standup" → ONE recap.
+- "compare this PR's diff against the last 3 PRs touching the same file" → ONE comparison (multiple inputs, single output).
+- "tell me which calendar events I can move tomorrow to free up a 2-hour block" → ONE recommendation.
+- "rate my last 5 cover letters out of 10 and tell me what to fix" → ONE rating with notes (internal structure ≠ multi-deliverable).
 
 Other rules:
 - "Don't forget X" / "add to my list" → create_task (Todo, no status param). Treat as parking, not execution.

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -89,10 +89,11 @@ export function getTaskTools(
           );
 
   return {
-    ...(!isBackgroundExecution && {
-      create_task: tool({
-        description: `Create a new CORE internal task. Tasks can be immediate (work items) or scheduled (reminders, recurring checks).
+    create_task: tool({
+      description: `Create a new CORE internal task. Tasks can be immediate (work items) or scheduled (reminders, recurring checks).
 NOTE: This is for CORE's own task system. If the user asks to create a task in an external tool (Todoist, Asana, Linear, Jira, etc.), do NOT use this — delegate to the orchestrator via take_action instead.
+
+BACKGROUND CONTEXT RULE: when called from inside a running task (prep or execute, i.e. <task_prep> or <task_execution> is in your system prompt), parentTaskId is MANDATORY — pass the current task's ID. You can only create SUBTASKS in background, never top-level tasks. Top-level task creation is reserved for the foreground chat agent. This prevents background runs from spawning unrelated work.
 
 BEFORE CREATING: Always call search_tasks first. If a matching task already exists in Todo/Working, reuse it instead of creating a duplicate.
 
@@ -191,6 +192,14 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
           skillName,
         }) => {
           try {
+            // BACKGROUND CONTEXT GUARD: when invoked from inside a running task,
+            // only subtask creation is allowed. Top-level task creation in
+            // background would let prep/execute runs spawn unrelated work — a
+            // common foot-gun. Foreground chat is unaffected.
+            if (isBackgroundExecution && !parentTaskId) {
+              return "create_task in background context requires parentTaskId — only subtask creation is permitted from inside a running task. If you need a top-level task, the user must create it from the foreground chat.";
+            }
+
             // Follow-up: reschedule the parent task
             if (isFollowUp && parentTaskId) {
               const parentTask = await getTaskById(parentTaskId);
@@ -337,7 +346,6 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             return `Failed to create task: ${error instanceof Error ? error.message : "Unknown error"}`;
           }
         },
-      }),
     }),
 
     get_task: tool({

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -163,7 +163,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             .enum(["Todo", "Waiting", "Ready"])
             .optional()
             .describe(
-              "Initial status. Todo=default, enters 2-min prep buffer so user can edit before butler starts. Waiting=needs user approval before execution. Ready=skip prep entirely, execute immediately (use only when the request is unambiguous and you've already gathered everything you need).",
+              "Initial status, classified by the rules in <capabilities> STARTING WORK. Todo = COMPLEX work (multi-step, decomposable, irreversible bulk). 2-min prep buffer applies. Ready = SIMPLE + CLEAR (single action, well-scoped). 2-min buffer still applies (gives the user a window to add context); execution starts after expiry. Waiting = SIMPLE + UNCLEAR (need one question answered) OR needs explicit user approval. Send_message the question/plan, then unblock_task when answered.",
             ),
           skillId: z
             .string()
@@ -291,16 +291,25 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             const effectiveStatus =
               parentTaskId && !initialStatus ? "Waiting" : undefined;
 
+            // Pass the resolved status directly to createTask. createTask
+            // applies the 2-min buffer for Todo (anyone) and for Ready+agent
+            // (skip-prep path); Waiting (subtask default or agent-requested
+            // approval) lands without a buffer. The old post-create
+            // changeTaskStatus flip is no longer needed for non-subtask
+            // flows.
+            const resolvedStatus = (effectiveStatus ??
+              initialStatus ??
+              "Todo") as TaskStatus;
+
             const task = await createTask(
               workspaceId,
               userId,
               title,
               undefined,
               {
+                actor: "agent",
+                status: resolvedStatus,
                 ...(parentTaskId && { parentTaskId }),
-                ...(effectiveStatus && {
-                  status: effectiveStatus as TaskStatus,
-                }),
               },
             );
             if (description) {
@@ -311,24 +320,8 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               );
               await setPageContentFromHtml(page.id, description);
             }
-            // Move to target status — Ready triggers auto-execution, Waiting gates on approval
-            // Skip if we already set effectiveStatus (subtask created in Waiting)
-            if (initialStatus && initialStatus !== "Todo" && !effectiveStatus) {
-              try {
-                await changeTaskStatus(
-                  task.id,
-                  initialStatus as TaskStatus,
-                  workspaceId,
-                  userId,
-                  "agent",
-                );
-              } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                return `Task created but initial status rejected: ${msg}. Task remains in Todo.`;
-              }
-            }
             const label = parentTaskId ? "subtask" : "task";
-            const targetStatus = effectiveStatus ?? initialStatus ?? "Todo";
+            const targetStatus = resolvedStatus;
             const statusNote =
               targetStatus === "Waiting"
                 ? parentTaskId

--- a/apps/webapp/app/services/task.phase.ts
+++ b/apps/webapp/app/services/task.phase.ts
@@ -77,7 +77,7 @@ export function setTaskPhaseInMetadata(
 export function canTransition(
   from: TaskStatus,
   to: TaskStatus,
-  _phase: TaskPhase,
+  phase: TaskPhase,
   actor: TransitionActor,
 ): boolean {
   if (from === to) return true;
@@ -85,13 +85,23 @@ export function canTransition(
   // Deny-list: only block transitions that are genuinely dangerous.
   // Everything else is allowed — the system and prompts guide correct usage.
 
-  // Ready, Working, Done, Todo — only user or system (code), not agent.
-  // Agent should not directly set these; the system manages them
-  // (enqueue → Ready, runtime → Working when execution starts, user → Done).
+  // Working, Done, Todo — never agent-driven. The system manages these
+  // (runtime → Working when execution starts, user → Done, parking → Todo).
   if (
-    (to === "Ready" || to === "Working" || to === "Done" || to === "Todo") &&
+    (to === "Working" || to === "Done" || to === "Todo") &&
     actor === "agent"
   ) {
+    return false;
+  }
+
+  // Ready — agent may set Ready ONLY during prep. This covers two cases:
+  // (1) butler skips the prep gate for simple+clear tasks (Todo -> Ready),
+  // (2) butler unblocks itself after a Waiting answer (Waiting -> Ready).
+  // Once we've crossed into execute, only system or user can flip back to
+  // Ready (e.g., user approves from Review). This guard is what prevents
+  // an auto-loop: once the agent moves a task to execute, it cannot
+  // promote it back to Ready from execute context.
+  if (to === "Ready" && actor === "agent" && phase !== "prep") {
     return false;
   }
 

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -66,7 +66,12 @@ export async function createTask(
   userId: string,
   title: string,
   description?: string,
-  options?: { source?: string; status?: TaskStatus; parentTaskId?: string },
+  options?: {
+    source?: string;
+    status?: TaskStatus;
+    parentTaskId?: string;
+    actor?: TransitionActor;
+  },
 ): Promise<Task> {
   // Enforce max depth: epic → task → sub-task (no further nesting).
   // A sub-task's displayId has 2 dots (e.g. tk-zshue.1.1), so if the parent
@@ -86,11 +91,21 @@ export async function createTask(
   }
 
   const effectiveStatus = options?.status ?? "Todo";
+  // Agent-created Ready tasks (no schedule) are special: the agent already
+  // classified them as simple+clear and skipped prep, but we still want a
+  // 2-min buffer so the user can edit before execution. During the buffer
+  // the task sits in Ready with phase=prep; the wake-up handler flips
+  // phase to execute when it fires.
+  const isAgentCreatedReady =
+    effectiveStatus === "Ready" && options?.actor === "agent";
   // Initial phase: Todo or Waiting → prep (task needs planning),
+  // agent-created Ready → prep (buffer hasn't fired yet),
   // everything else → execute (e.g., recurring tasks created in Ready
   // via createScheduledTask skip prep entirely).
   const initialPhase =
-    effectiveStatus === "Todo" || effectiveStatus === "Waiting"
+    effectiveStatus === "Todo" ||
+    effectiveStatus === "Waiting" ||
+    isAgentCreatedReady
       ? "prep"
       : "execute";
 
@@ -111,15 +126,39 @@ export async function createTask(
     await setPageContentFromHtml(page.id, description);
   }
 
-  // Buffer wake-up: freshly-created Todo tasks sit for 2 minutes so the user
+  // Buffer wake-up: freshly-created tasks sit for 2 minutes so the user
   // can edit freely. At expiry, the scheduled-task wake-up handler starts
-  // prep. (Scheduled/recurring tasks use the different createScheduledTask
-  // entry and skip this buffer.)
-  if (effectiveStatus === "Todo") {
+  // prep (Todo path) or directly enqueues execution (agent-created Ready
+  // path, see scheduled-task.logic.ts isReadyBufferExpiry branch).
+  // Two cases get the buffer:
+  //   1. Anyone creates a Todo task (existing behavior — prep starts at expiry)
+  //   2. Agent creates a Ready task with no schedule (new — execution starts
+  //      at expiry; the agent already classified it as simple+clear and we
+  //      record that decision via metadata.prepDecided=true so the prep
+  //      invoker never re-enters prep for this task)
+  // Scheduled/recurring tasks use createScheduledTask and skip this buffer.
+  const needsBuffer = effectiveStatus === "Todo" || isAgentCreatedReady;
+
+  if (needsBuffer) {
     const nextRunAt = new Date(Date.now() + 2 * 60 * 1000);
     await prisma.task.update({
       where: { id: task.id },
-      data: { nextRunAt },
+      data: {
+        nextRunAt,
+        // For agent-created Ready, mark prep decided. Phase stays "prep" —
+        // the wake-up handler in scheduled-task.logic.ts will flip it to
+        // "execute" when the buffer expires. The prepDecided flag is what
+        // the prep invoker reads to short-circuit (Task 6).
+        ...(isAgentCreatedReady && {
+          metadata: setTaskPhaseInMetadata(
+            {
+              ...((task.metadata as Record<string, unknown>) ?? {}),
+              prepDecided: true,
+            },
+            "prep",
+          ),
+        }),
+      },
     });
     try {
       await enqueueScheduledTask(
@@ -132,9 +171,10 @@ export async function createTask(
         nextRunAt,
       );
     } catch (err) {
-      logger.warn("Failed to enqueue buffer wake-up for new Todo task", {
+      logger.warn("Failed to enqueue buffer wake-up for new task", {
         err,
         taskId: task.id,
+        status: effectiveStatus,
       });
     }
   }


### PR DESCRIPTION
Lets butler send simple+clear tasks straight to Ready (with the existing 2-min buffer) instead of forcing every task through the prep phase. Complex tasks and coding tasks keep their existing prep flows unchanged.

Two structural changes:

1. Relax canTransition to allow agent → Ready when phase is "prep" only. Once a task crosses into execute, only system or user can flip to Ready — this is the auto-loop guard.

2. Two-axis classifier in the STARTING WORK prompt block (complexity x clarity). Butler now picks the right starting status at create_task time: - COMPLEX → Todo (existing prep flow, decompose + plan + Waiting) - SIMPLE + CLEAR → Ready (2-min buffer, then execute) - SIMPLE + CLEAR + scheduled → Ready + nextRunAt (no buffer) - SIMPLE + UNCLEAR → Waiting + one targeted question

When agent creates Ready with no schedule, createTask sets nextRunAt = now + 2min and metadata.prepDecided = true. A new isReadyBufferExpiry branch in processScheduledTask flips phase to execute and enqueues the task. Belt-and-suspenders short-circuit in context.ts treats prepDecided=true as execute even when phase is still prep.

The new Ready-buffer expiry path also mirrors the empty-scratchpad auto-delete behavior in startPrepFromBuffer for parity.

Bridge sentence added to READINESS CHECK so the LLM doesn't read it as contradicting the new SIMPLE+UNCLEAR path. COMPLEX bullet explicitly split into Turn 1 (create + acknowledge) and Turn 2 (prep wake-up: decompose + plan + Waiting) so the LLM doesn't try to do both on the same turn.

Spec: docs/superpowers/specs/2026-04-30-skip-prep-for-simple-clear-tasks-design.md
Plan: docs/superpowers/plans/2026-04-30-skip-prep-for-simple-clear-tasks.md