### PR TITLE
docs(gateway): add agent-friendly setup runbook and clarify webapp paste step

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -287,7 +287,7 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["gateway/overview"]
+            "pages": ["gateway/overview", "gateway/setup"]
           },
           {
             "group": "Capabilities",

--- a/docs/gateway/overview.mdx
+++ b/docs/gateway/overview.mdx
@@ -5,49 +5,69 @@ description: "Run a local agent on your machine that connects CORE to your devel
 
 ## What is the Gateway?
 
-The Gateway is a local service that runs on your machine — or on a Docker host you control — and exposes your browser, coding agents, shell, and a registered set of folders to CORE over an authenticated HTTP + WebSocket API. CORE never touches your machine directly; it always goes through this gateway.
+The Gateway is a local Fastify HTTP server (default port `7787`) bundled into the `@redplanethq/corebrain` CLI. It runs on your laptop, on a Docker host you control, or on Railway, and exposes your **browser**, **coding agents**, **shell**, and a registered set of **folders** to CORE over an authenticated HTTP + WebSocket API.
 
-Think of it as the bridge between CORE's cloud intelligence and your local environment.
+CORE never touches your machine directly. Every action CORE takes on your environment, opening a tab, running a test, editing a file, spawning Claude Code, goes through this gateway. It's the bridge between CORE's cloud intelligence and your local environment.
+
+> **Looking for the runbook?** See [Gateway Setup](/gateway/setup) for a linear, copy-pasteable guide. This page is the conceptual overview.
 
 ---
 
-## Why Use It?
+## Why connect a Gateway?
 
-<CardGroup cols={3}>
-  <Card title="Browser Automation" icon="browser">
-    Drive Playwright Chromium with persistent profiles for authenticated automation
+Without a gateway, CORE is a memory and reasoning layer in the cloud. With one, CORE can act on your actual machine and accounts. Concrete examples:
+
+<CardGroup cols={2}>
+  <Card title="Remote coding from your phone" icon="mobile">
+    Message CORE on WhatsApp, "Fix the auth timeout in the API." CORE spawns Claude Code on your gateway, pulls context from memory, and works on the bug while you're on the train.
   </Card>
 
-  <Card title="Coding Agents" icon="code">
-    Spawn and resume Claude Code or Codex CLI sessions from anywhere
+  <Card title="Authenticated browser automation" icon="browser">
+    Log in to LinkedIn once on your `personal` Playwright profile. CORE can research leads, scrape your dashboards, or drive a checkout flow without you re-authenticating.
   </Card>
 
-  <Card title="Shell + Files" icon="terminal">
-    Run commands and read/write files inside scoped folders, with allow/deny patterns
+  <Card title="Live terminal in the webapp" icon="terminal">
+    Watch a coding session stream into the webapp's terminal pane in real time, attach, type, and resize, with a Chrome DevTools-style live view of the browser running alongside.
+  </Card>
+
+  <Card title="Scheduled local actions" icon="clock">
+    "Every morning at 9am, run the test suite and summarize failures." A reminder fires `exec_command` against your repo and posts the result back to your channel of choice.
   </Card>
 </CardGroup>
 
+The gateway is what turns CORE from "an LLM that remembers" into "an assistant that gets things done on your stack."
+
 ---
 
-## How It Works
+## What does it expose?
 
-The gateway is a Fastify HTTP server (default port `7787`) bundled into the `@redplanethq/corebrain` CLI. It boots from on-disk preferences (`~/.corebrain`) and serves:
+The gateway advertises a **manifest** of capability slots. Each slot can be turned off in `corebrain gateway config`; disabled slots aren't just hidden, their HTTP routes are not registered.
 
-- `GET /manifest` — full capability manifest the webapp reads on every poll.
-- `POST /api/<group>/<tool>` — one route per advertised tool.
-- `WS /api/coding/coding_xterm_session` — terminal stream for coding sessions and the per-gateway shell.
-- `WS /api/browser/cdp/:session` — Chrome DevTools Protocol proxy for the live browser viewer.
-- `/api/folders`, `/api/shell` — folder management and a general-purpose PTY.
+| Slot | Tools exposed | Use this for |
+| ---- | ------------- | ------------ |
+| **Browser** | `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_fill`, `browser_type`, `browser_press_key`, `browser_select_option`, `browser_screenshot`, `browser_scroll`, `browser_go_back`, `browser_go_forward`, `browser_wait_for`, `browser_evaluate`, `browser_create_session`, `browser_list_sessions`, `browser_delete_session`, `browser_close_session`, `browser_close_all` | Authenticated scraping, form automation, dashboard reads, live browser viewing in the webapp |
+| **Coding** | `coding_ask`, `coding_read_session`, `coding_list_sessions`, `coding_search_sessions`, `coding_list_agents`, `coding_close_session`, `coding_close_all` | Spawn or resume Claude Code / Codex sessions remotely; isolated git worktrees for autonomous work |
+| **Exec** | `exec_command` | Shell commands gated by allow/deny patterns and folder scopes |
+| **Files** | `files_read`, `files_write`, `files_edit`, `files_glob`, `files_grep` | File reads, edits, glob, ripgrep, all scoped to registered folders |
+| **Utils** (always on) | `sleep` | Pause between polling tool calls |
 
-Every request requires `Authorization: Bearer gwk_<key>`. There is no localhost bypass — the same flow applies whether the gateway is on `127.0.0.1`, behind a tunnel, or on a public Docker host.
+In addition the gateway exposes a few HTTP routes the webapp uses directly:
+
+- `GET /manifest`: full capability manifest the webapp reads on every poll.
+- `WS /api/coding/coding_xterm_session`: terminal stream for coding sessions and the per-gateway shell.
+- `WS /api/browser/cdp/:session`: Chrome DevTools Protocol proxy for the live browser viewer.
+- `POST /api/folders/local`, `POST /api/folders/git`, `DELETE /api/folders/:idOrName`: folder management.
+- `POST /api/shell/spawn`: general-purpose PTY for the shell tab.
+
+Every request requires `Authorization: Bearer gwk_<key>`. There is no localhost bypass, the same flow applies whether the gateway is on `127.0.0.1`, behind a tunnel, or on a public Docker host.
 
 For the protocol details and a route-by-route reference, see [`packages/gateway-protocol/README.md`](https://github.com/RedPlanetHQ/core/blob/main/packages/gateway-protocol/README.md).
 
 ---
 
-## Install
+## Install (quick path)
 
-`corebrain gateway setup` is the unified entry point — pick where the gateway should run and the wizard handles the rest (config, security key, public URL via Tailscale or Railway, registration with CORE).
+For the full step-by-step including Tailscale / ngrok install, see [Gateway Setup](/gateway/setup).
 
 <Steps>
   <Step title="Install the CLI">
@@ -57,18 +77,41 @@ For the protocol details and a route-by-route reference, see [`packages/gateway-
     ```
   </Step>
 
-  <Step title="Run setup">
+  <Step title="Run the wizard">
     ```bash
     corebrain gateway setup
     ```
 
-    The wizard asks where the gateway should run:
+    Pick where the gateway should run:
 
-    - **Native** — this machine. Installs a launchd (macOS) / systemd (Linux) service, generates a security key, and registers with CORE. Full access to local browser, shells, and folders.
-    - **Docker** — local or remote Docker host. Drops `docker-compose.yaml` + `.env` into `~/.corebrain/gateways/<name>/` (templates fetched from `main` so they stay in sync), runs `docker compose up -d`, optionally exposes via [Tailscale funnel](/gateway/tunnels), and registers with CORE.
-    - **Railway** — managed cloud. Detects (or installs) the Railway CLI, runs `railway init` + `railway deploy -t core-gateway`, provisions a public domain, and registers with CORE.
+    - **Native**: this machine. Installs a launchd (macOS) / systemd (Linux) service and gives full access to local browser, shells, and folders. Native gateways listen on `127.0.0.1` and need a tunnel (Tailscale or ngrok) before CORE's cloud can reach them. See [Tunnels](/gateway/tunnels) or the [Setup runbook](/gateway/setup) for the tunnel install steps you must run first.
+    - **Docker**: local or remote Docker host. Drops `docker-compose.yaml` + `.env` into `~/.corebrain/gateways/<name>/` (templates fetched from `main` so they stay in sync), runs `docker compose up -d`, and optionally exposes via [Tailscale Funnel](/gateway/tunnels).
+    - **Railway**: managed cloud. Detects (or installs) the Railway CLI, runs `railway init` + `railway deploy -t core-gateway`, and provisions a public domain.
 
     For docker / railway the wizard also prompts (optional) for `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`, and `GITHUB_TOKEN` so the coding + git slots work out of the box.
+  </Step>
+
+  <Step title="Register the gateway with a tunnel">
+    Native installs need a tunnel before the cloud can reach them:
+
+    ```bash
+    corebrain gateway register --tunnel tailscale
+    # or
+    corebrain gateway register --tunnel ngrok
+    # or, bring your own URL:
+    corebrain gateway register --tunnel none --baseUrl https://gateway.example.com
+    ```
+
+    The CLI prints a `baseUrl` and a `securityKey` (`gwk_...`). **The raw key is shown exactly once.**
+  </Step>
+
+  <Step title="Paste URL + key into the CORE app">
+    This is the step that links the gateway to your workspace. Without it, the gateway is reachable but CORE doesn't know it exists.
+
+    1. Open [https://app.getcore.me](https://app.getcore.me) (or your self-hosted instance).
+    2. **Sidebar → Gateways → + New gateway**.
+    3. Paste the **Base URL** and the **Security key** from the CLI output.
+    4. Click **Submit**. The gateway should show **Connected** within a few seconds.
   </Step>
 
   <Step title="Verify">
@@ -86,70 +129,89 @@ For the protocol details and a route-by-route reference, see [`packages/gateway-
 
 ### One-click Railway deploy
 
-Prefer to skip the CLI entirely for a Railway gateway? Click below — Railway prompts for the env vars, provisions the service + public domain, and you paste the URL + security key into the webapp's **Register gateway** dialog.
-
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/core-gateway)
 
-The required env vars are:
+Railway prompts for the env vars, provisions the service + public domain, and the security key appears in the deploy logs on first boot. You still need to paste the URL + key into **Sidebar → Gateways** in the CORE app (Step 4 above).
 
-- `COREBRAIN_API_URL` — your CORE instance URL (e.g. `https://app.getcore.me`)
-- `COREBRAIN_API_KEY` — a Personal Access Token from the webapp
-- `COREBRAIN_GATEWAY_NAME` — name shown in the webapp
-- `COREBRAIN_GATEWAY_SECURITY_KEY` — *(optional)* leave empty and Railway will auto-generate one (find it in the deploy logs on first boot)
+The required env vars:
+
+- `COREBRAIN_API_URL`: your CORE instance URL (e.g. `https://app.getcore.me`)
+- `COREBRAIN_API_KEY`: a Personal Access Token from the webapp
+- `COREBRAIN_GATEWAY_NAME`: name shown in the webapp
+- `COREBRAIN_GATEWAY_SECURITY_KEY`: *(optional)* leave empty and Railway will auto-generate one
 
 ---
 
 ## Gateway Commands
 
-| Command                                | Description                                                              |
-| -------------------------------------- | ------------------------------------------------------------------------ |
-| `corebrain gateway setup`              | Wizard: pick native / docker / railway, configure, and register with CORE |
-| `corebrain gateway list`               | List every gateway registered with your CORE workspace                   |
-| `corebrain gateway status [id]`        | Show local-native status (no id), or any gateway's manifest (with id)    |
-| `corebrain gateway config`             | Reconfigure the native gateway on this machine (slots, folders, exec patterns) |
-| `corebrain gateway start`              | Install + start the native gateway as a system service                   |
-| `corebrain gateway start --foreground` | Run attached to the current terminal (Docker / ad-hoc)                   |
-| `corebrain gateway stop`               | Stop and uninstall the native service                                    |
-| `corebrain gateway restart`            | Restart the native service                                               |
-| `corebrain gateway register`           | Generate / rotate the security key for the native gateway                |
+### Top-level (work on any gateway)
 
-The `folder`, `browser`, `coding`, and `exec` command groups configure the native gateway's slots and only run when one is set up on this machine — they print a redirect to `corebrain gateway setup` otherwise.
+| Command | Use this when |
+| ------- | ------------- |
+| `corebrain login` | First-time setup, or after rotating your Personal Access Token. |
+| `corebrain gateway setup` | Spinning up a new gateway from scratch (interactive wizard). |
+| `corebrain gateway setup --kind native\|docker\|railway` | Headless install / CI / scripted setup. |
+| `corebrain gateway list` | Checking which gateways your CORE workspace knows about, across all your machines. |
+| `corebrain gateway status` | Quick health check of the native gateway running on this machine. |
+| `corebrain gateway status <id>` | Inspecting any gateway's manifest, slot config, and tunnel state by id. |
 
-| Command                       | Description                                            |
-| ----------------------------- | ------------------------------------------------------ |
-| `corebrain folder add <path>` | Register a path with `files,coding,exec` scopes        |
-| `corebrain folder list`       | List registered folders                                |
-| `corebrain browser status`    | Inspect the gateway's browser config + sessions        |
-| `corebrain coding setup`      | Configure a coding agent (claude-code, codex)          |
-| `corebrain exec config`       | Set the exec slot's allow / deny patterns              |
+### Native gateway lifecycle (this machine only)
+
+| Command | Use this when |
+| ------- | ------------- |
+| `corebrain gateway register` | After `setup`, to generate the URL + security key and (optionally) start a tunnel. Also used to **rotate** the key if it leaks or is lost. |
+| `corebrain gateway register --tunnel tailscale\|ngrok\|none` | Picking how the gateway is exposed. `none` means you supply your own URL. |
+| `corebrain gateway start` | Installing the gateway as a system service so it boots with the machine. |
+| `corebrain gateway start --foreground` | Debugging the gateway attached to your terminal (Docker / ad-hoc). |
+| `corebrain gateway stop` | Shutting the service down and tearing down the managed tunnel. |
+| `corebrain gateway restart` | Picking up a config change or recovering from a hung process. |
+| `corebrain gateway config` | Toggling slots (browser / coding / exec / files), changing exec patterns, registering folders. |
+
+The `folder`, `browser`, `coding`, and `exec` command groups configure the native gateway's slots and only run when one is set up on this machine. They print a redirect to `corebrain gateway setup` otherwise.
+
+### Folders and scopes
+
+| Command | Use this when |
+| ------- | ------------- |
+| `corebrain folder add <path>` | Granting the gateway access to a directory. Scopes default to `files,coding,exec`. |
+| `corebrain folder add <path> --scopes coding,exec` | Pinning narrower scopes (e.g. read-only, or coding-only). |
+| `corebrain folder list` | Auditing what the gateway is allowed to touch. |
+
+### Browser (Playwright)
+
+| Command | Use this when |
+| ------- | ------------- |
+| `corebrain browser install` | First-time install of the Playwright Chromium binary (or refreshing it). |
+| `corebrain browser create-profile <name>` | Creating a new persistent identity (cookies, localStorage). Max 5 profiles. |
+| `corebrain browser create-session <name> --profile <profile>` | Binding a named task (e.g. `linkedin`) to a profile. Max 10 sessions. |
+| `corebrain browser open <session> --headed` | Logging in manually so the profile captures auth state. |
+| `corebrain browser set-browser brave\|chrome\|default\|custom` | Switching the executable used by Playwright. |
+| `corebrain browser status` | Inspecting session list and current browser binary. |
+
+See [Browser](/gateway/browser) for the full reference.
+
+### Coding (Claude Code, Codex)
+
+| Command | Use this when |
+| ------- | ------------- |
+| `corebrain coding setup` | Adding a coding agent (claude-code or codex-cli) and logging it in. |
+| `corebrain coding setup --default claude-code` | Setting which agent runs when callers don't specify one. |
+
+See [Coding](/gateway/coding) for the full reference and the `coding_ask` payload shape.
+
+### Exec (shell)
+
+| Command | Use this when |
+| ------- | ------------- |
+| `corebrain exec config` | Editing the allow / deny pattern list (e.g. `Bash(git *)`, `Bash(npm run *)`). |
+
+See [Exec](/gateway/exec) for the security model.
 
 ---
 
-## Capabilities
+## Folders and scopes
 
-The manifest advertises a set of tools grouped by capability slot. Slots can be turned off in `corebrain gateway config` — a disabled slot hides both its tools and its routes.
-
-<CardGroup cols={3}>
-  <Card title="Browser" icon="browser" href="/gateway/browser">
-    Headless / headed Playwright with profile-backed sessions
-  </Card>
-
-  <Card title="Coding" icon="code" href="/gateway/coding">
-    Spawn, read, search, and resume coding agent sessions
-  </Card>
-
-  <Card title="Exec" icon="terminal" href="/gateway/exec">
-    Run shell commands with allow/deny patterns and folder scopes
-  </Card>
-</CardGroup>
-
-The `files` slot exposes `files_read`, `files_write`, `files_edit`, `files_glob`, and `files_grep` — also gated by registered folders. The always-on `utils` slot exposes a `sleep` tool useful between polling calls.
-
----
-
-## Folders & Scopes
-
-Folders are registered paths the gateway is allowed to touch. Each folder carries one or more **scopes**:
+Folders are registered paths the gateway is allowed to touch. Each folder carries one or more scopes:
 
 | Scope    | Allows                                                              |
 | -------- | ------------------------------------------------------------------- |
@@ -174,25 +236,16 @@ curl -X POST $GATEWAY/api/folders/git \
 
 ---
 
-## Use Cases
-
-**Remote development:** You're on your phone, a bug comes in. Message CORE on WhatsApp: "Fix the auth timeout issue in the API." CORE spawns Claude Code on your gateway, pulls context from memory, and starts working.
-
-**Authenticated browsing:** CORE opens your `linkedin` profile-backed browser session, runs lead research, returns highlights — without you re-authenticating.
-
-**Daily workflows:** "Every morning at 9am, check my GitHub notifications and summarize what needs attention." The reminder fires `exec_command` against your repos folder.
-
----
-
 ## Security
 
 - **Bearer-only auth.** The gateway stores `sha256(securityKey)` on disk; the webapp encrypts the raw key at rest. Constant-time comparison; no localhost bypass.
-- **Slot toggles.** Disabled slots are not just hidden — their HTTP routes are not registered, so a leaked key still cannot hit them.
+- **Slot toggles.** Disabled slots are not just hidden, their HTTP routes are not registered, so a leaked key still cannot hit them.
 - **Folder scopes.** Coding / exec / files tools are pinned to registered folders with the matching scope.
 - **Exec patterns.** `exec_command` validates each command against allow / deny globs (`Bash(<glob>)`) plus a built-in deny list for unsafe primitives.
 - **Browser profiles.** Stored locally; auth state never leaves your machine.
+- **Tunnels for native gateways.** Native installs always need HTTPS to be reachable from CORE's cloud. Use Tailscale Funnel, ngrok, or your own reverse proxy. See [Tunnels](/gateway/tunnels).
 
-All traffic between CORE and the gateway is authenticated; use HTTPS or a tunnel (Tailscale / ngrok / Cloudflare) for non-loopback deployments. See [Tunnels](/gateway/tunnels) for the Tailscale Funnel and ngrok setup walkthroughs.
+All traffic between CORE and the gateway is authenticated; use HTTPS or a tunnel for non-loopback deployments.
 
 ---
 
@@ -209,9 +262,18 @@ When running without an interactive `corebrain login` flow, the gateway reads:
 | `COREBRAIN_GATEWAY_SECURITY_KEY`  | Bearer key. Auto-generated and printed once if absent.               |
 | `COREBRAIN_GATEWAY_HTTP_PORT`     | Port to listen on (default `7787`)                                   |
 | `COREBRAIN_DEFAULT_WORKSPACE`     | Auto-registered as a folder with `files,coding,exec` scopes          |
-| `COREBRAIN_DEPLOY_MODE`           | `native` or `docker` — surfaces in the manifest for UI gating        |
+| `COREBRAIN_DEPLOY_MODE`           | `native` or `docker`, surfaces in the manifest for UI gating         |
 | `ANTHROPIC_API_KEY`               | Lets `claude-code` skip OAuth                                        |
 | `OPENAI_API_KEY`                  | Lets `codex-cli` skip OAuth                                          |
 | `GITHUB_TOKEN`                    | Used by `POST /api/folders/git` to clone private repos               |
 
-Bootstrap is idempotent — values you set manually inside the container are never overwritten.
+Bootstrap is idempotent. Values you set manually inside the container are never overwritten.
+
+---
+
+## Where next?
+
+- [Gateway Setup runbook](/gateway/setup): linear copy-paste guide from zero to connected.
+- [Tunnels](/gateway/tunnels): Tailscale Funnel and ngrok deep-dive.
+- [Browser](/gateway/browser), [Coding](/gateway/coding), [Exec](/gateway/exec): per-capability references.
+- [Gateway protocol README](https://github.com/RedPlanetHQ/core/blob/main/packages/gateway-protocol/README.md): full HTTP / WebSocket reference.

--- a/docs/gateway/setup.mdx
+++ b/docs/gateway/setup.mdx
@@ -1,0 +1,295 @@
+---
+title: "Gateway Setup"
+description: "Step-by-step runbook to install, register, and connect a Gateway to CORE"
+---
+
+<Note>
+**For agents reading this page:** Execute every fenced bash block in order for the path the user picks (Native + Tailscale, Native + ngrok, Docker, or Railway). After Step 6, prompt the user to complete the browser-side paste in Step 7. Do not skip Step 7: nothing works until the gateway is linked in the CORE app.
+</Note>
+
+This is the linear runbook. For the conceptual overview of what the Gateway is and what it can do, see [Gateway Overview](/gateway/overview). For tunnel-only details (Tailscale, ngrok, custom URLs), see [Tunnels](/gateway/tunnels).
+
+---
+
+## Step 1. Install the CLI and log in
+
+Works on macOS, Linux, and WSL. Node 20+ required.
+
+```bash
+npm install -g @redplanethq/corebrain
+corebrain login
+```
+
+`corebrain login` opens your browser, authenticates against your CORE workspace, and stores a Personal Access Token in `~/.corebrain/preferences.json`. Every later command needs this token.
+
+---
+
+## Step 2. Pick where the gateway will run
+
+| Choice | Pick this when |
+| ------ | -------------- |
+| **Native** | The gateway should run on your laptop or workstation. Full local access to browsers, shells, and folders. Needs a tunnel (Tailscale or ngrok) so CORE's cloud can reach `127.0.0.1`. |
+| **Docker** | You have a server, VPS, or always-on Docker host. Public URL via Tailscale Funnel or your own reverse proxy. |
+| **Railway** | You want a managed cloud gateway with no infra. Railway provisions the URL and runs the container for you. |
+
+Once you've picked, jump to the matching path: [3A Native + Tailscale](#step-3a-native-tailscale), [3B Native + ngrok](#step-3b-native-ngrok), [3C Docker](#step-3c-docker), or [3D Railway](#step-3d-railway).
+
+---
+
+## Step 3A. Native + Tailscale
+
+Pick this if you want a stable URL tied to your tailnet (good for days/weeks of uptime).
+
+### Install Tailscale
+
+If you don't already have it, install from [https://tailscale.com/download](https://tailscale.com/download) or run:
+
+```bash
+# macOS
+brew install --cask tailscale
+
+# Linux
+curl -fsSL https://tailscale.com/install.sh | sh
+```
+
+Verify:
+
+```bash
+tailscale version
+```
+
+### Bring Tailscale up
+
+```bash
+sudo tailscale up
+```
+
+This authenticates the device with your tailnet. Confirm before moving on:
+
+```bash
+tailscale status
+```
+
+The current device should show as `active`.
+
+### Enable Funnel for this device
+
+Funnel is the Tailscale feature that exposes a tailnet device to the public internet over HTTPS. Open the [Tailscale admin console](https://login.tailscale.com/admin/acls), then:
+
+1. **DNS → HTTPS Certificates:** turn on.
+2. **Access Controls:** add a Funnel grant.
+
+```hujson
+"nodeAttrs": [
+  { "target": ["autogroup:member"], "attr": ["funnel"] }
+]
+```
+
+Reference: [Tailscale Funnel docs](https://tailscale.com/kb/1223/funnel).
+
+### Run gateway setup
+
+```bash
+corebrain gateway setup --kind native
+```
+
+The wizard installs the gateway as a launchd (macOS) or systemd (Linux) service, configures slots and folders, and stops short of registering. Now register with the tunnel:
+
+```bash
+corebrain gateway register --tunnel tailscale
+```
+
+This runs `tailscale funnel --bg 7787` in the background, captures the public URL (`https://<device>.<tailnet>.ts.net`), generates a security key, and prints both. Skip ahead to [Step 4](#step-4-copy-the-url-and-security-key).
+
+---
+
+## Step 3B. Native + ngrok
+
+Pick this if you want the fastest possible setup (one auth token, public URL in seconds). Free-tier URLs change on every restart, so this path is best for short-lived sessions or paid ngrok accounts.
+
+### Install ngrok
+
+```bash
+# macOS
+brew install ngrok
+
+# Linux / Windows: see https://ngrok.com/download
+```
+
+Verify:
+
+```bash
+ngrok version
+```
+
+### Add your auth token
+
+Sign in at [https://dashboard.ngrok.com](https://dashboard.ngrok.com), copy the auth token, then:
+
+```bash
+ngrok config add-authtoken <YOUR_TOKEN>
+```
+
+Without this step ngrok starts but the public URL fails the TLS handshake (`ERR_NGROK_4018`).
+
+### Run gateway setup
+
+```bash
+corebrain gateway setup --kind native
+corebrain gateway register --tunnel ngrok
+```
+
+This runs `ngrok http 7787` in the background, captures the public HTTPS URL, generates a security key, and prints both. Skip ahead to [Step 4](#step-4-copy-the-url-and-security-key).
+
+---
+
+## Step 3C. Docker
+
+Pick this for an always-on gateway on a server you control.
+
+```bash
+corebrain gateway setup --kind docker
+```
+
+The wizard:
+
+1. Drops `docker-compose.yaml` and `.env` into `~/.corebrain/gateways/<name>/`.
+2. Optionally prompts for `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`, `GITHUB_TOKEN` so the coding and git slots work out of the box.
+3. Optionally exposes the host via Tailscale Funnel (re-uses any existing Tailscale install).
+4. Runs `docker compose up -d`.
+5. Prints the public URL and security key.
+
+If you'd rather use your own reverse proxy (Cloudflare, nginx, Caddy), pick "no tunnel" in the wizard and point your proxy at the host's port `7787`. Then jump to [Step 4](#step-4-copy-the-url-and-security-key).
+
+---
+
+## Step 3D. Railway
+
+Pick this for a fully managed cloud gateway.
+
+**Option 1: One-click deploy.** Click the button below. Railway prompts for env vars, provisions the service and a public domain, and the security key appears in the deploy logs on first boot.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/core-gateway)
+
+### Railway env vars: what to fill in
+
+| Variable | What to fill in | How to get it |
+| -------- | --------------- | ------------- |
+| `COREBRAIN_API_URL` | URL of your CORE instance, e.g. `https://app.getcore.me`. | Use the hosted instance URL, or your self-hosted domain. No trailing slash. |
+| `COREBRAIN_API_KEY` | A Personal Access Token (PAT) for your CORE workspace. | In the CORE webapp: avatar → **Settings → API keys → New token**. Copy the value once; it's not shown again. |
+| `COREBRAIN_GATEWAY_NAME` | Display name for this gateway, e.g. `railway-prod`. | Pick anything. Shows up in **Sidebar → Gateways** so you can tell multiple gateways apart. |
+| `COREBRAIN_GATEWAY_SECURITY_KEY` | *Leave blank.* | The gateway auto-generates one on first boot and prints it to the Railway deploy logs (look for the banner `CoreBrain Gateway, security key generated`). If you'd rather pin your own, generate with `echo "gwk_$(openssl rand -base64 32 \| tr -d '=' \| tr '/+' '_-')"` and paste the same value here and into the CORE app later. |
+| `GITHUB_TOKEN` | A GitHub Personal Access Token. | Required by the Railway template, but only used if the gateway will clone private repos or commit on your behalf. Create at [github.com/settings/tokens](https://github.com/settings/tokens) → classic, scopes `repo` + `read:user`. Fine-grained PATs also work (`Contents: Read & write` on the repos you want, plus `Account → Profile: Read-only`). If you don't need private-repo access, paste any valid PAT; the gateway boots either way. |
+| `ANTHROPIC_API_KEY` *(optional)* | API key for Anthropic. | Lets `claude-code` skip the OAuth login flow. Get it at [console.anthropic.com](https://console.anthropic.com). Skip if you'll log Claude Code in manually later. |
+| `OPENAI_API_KEY` *(optional)* | API key for OpenAI. | Lets `codex-cli` skip OAuth. Get it at [platform.openai.com/api-keys](https://platform.openai.com/api-keys). |
+| `CLAUDE_CODE_OAUTH_TOKEN` *(optional)* | OAuth token for Claude Code. | Alternative to `ANTHROPIC_API_KEY` if you already have an OAuth token from a prior `claude` login. |
+
+### After Railway deploys
+
+1. Open the service in Railway → **Deployments → View logs**.
+2. Find the banner that starts with `CoreBrain Gateway, security key generated`. Copy the `gwk_...` value.
+3. Copy the public domain Railway provisioned (under **Settings → Networking → Public Networking**).
+4. Skip ahead to [Step 5](#step-5-open-the-core-app) and paste both into **Sidebar → Gateways → New gateway**.
+
+**Option 2: CLI-driven.**
+
+```bash
+corebrain gateway setup --kind railway
+```
+
+The wizard detects (or installs) the Railway CLI, runs `railway init` and `railway deploy -t core-gateway`, provisions a public domain, and prints the URL + security key. Continue to [Step 4](#step-4-copy-the-url-and-security-key).
+
+---
+
+## Step 4. Copy the URL and security key
+
+After registration finishes, the CLI prints something like:
+
+```
+name:        my-laptop
+baseUrl:     https://my-laptop.tail-scale.ts.net
+securityKey: gwk_aBcDeFg...           ← only shown ONCE
+
+Paste baseUrl + securityKey into CORE → Sidebar → Gateways.
+```
+
+**The raw security key is shown exactly once.** The CLI stores only a SHA256 hash on disk. Copy both values now. If you lose the key, run `corebrain gateway register` again to generate a new one.
+
+---
+
+## Step 5. Open the CORE app
+
+Go to [https://app.getcore.me](https://app.getcore.me) (or your self-hosted instance) and sign in.
+
+---
+
+## Step 6. Paste the URL and key into the Register Gateway dialog
+
+1. In the left sidebar, click **Gateways**.
+2. Click **+ New gateway**.
+3. Pick the same deploy kind you chose in Step 2 (Native, Docker, Railway).
+4. Paste the **Base URL** into the URL field.
+5. Paste the **Security key** (`gwk_...`) into the security key field.
+6. Click **Submit**.
+
+The gateway should appear in the Gateways list with status **Connected** within a few seconds. If it shows **Unreachable**, verify the tunnel is up (`tailscale status` or `ngrok` dashboard) and that you copied both values without trailing whitespace.
+
+---
+
+## Step 7. Verify
+
+From the gateway machine:
+
+```bash
+corebrain gateway status        # native gateway on this machine
+corebrain gateway list          # every gateway your workspace knows about
+```
+
+`status` should show the gateway as running and the tunnel as active. `list` should show the gateway you just registered with the same name.
+
+In the CORE app, open any conversation and ask: *"List my gateways."* CORE should respond with the gateway you just registered.
+
+---
+
+## Step 8. Register a folder (recommended)
+
+Until you register at least one folder, the gateway runs in permissive first-run mode. Once you register one, scope is enforced everywhere.
+
+```bash
+# Register the current directory with all three scopes
+corebrain folder add . --scopes files,coding,exec
+
+# Or pin scopes
+corebrain folder add /Users/me/repos/api --scopes coding,exec
+```
+
+| Scope | What it allows |
+| ----- | -------------- |
+| `files` | `files_read`, `files_write`, `files_edit`, `files_glob`, `files_grep` and the file browser in the webapp |
+| `coding` | `coding_ask` and interactive coding sessions targeting paths inside this folder |
+| `exec` | `exec_command` working directories |
+
+---
+
+## Troubleshooting
+
+**`tailscale not found on PATH`**: install via `brew install --cask tailscale` (macOS) or the official installer (Linux). The Homebrew formula `brew install tailscale` only installs the daemon helper, not the CLI binary.
+
+**`tailscale funnel started but no public URL appeared within 5s`**: Funnel isn't yet enabled for this device. Re-check the admin console (HTTPS certs + Funnel grant) and try `corebrain gateway register --tunnel tailscale` again.
+
+**`ngrok did not expose a public URL within 15s`**: usually a missing auth token. Run `ngrok config add-authtoken <token>` and retry.
+
+**Gateway shows as Unreachable in the webapp**: confirm the tunnel is alive (`tailscale status` or check the ngrok dashboard), and that the URL in the webapp matches what `corebrain gateway status` prints. Re-register if needed: `corebrain gateway stop && corebrain gateway register --tunnel <kind>`, then update the webapp with the new URL + key.
+
+**Lost the security key**: run `corebrain gateway register` to generate a new one, then update **Sidebar → Gateways → Edit** in the webapp.
+
+For a deeper troubleshooting matrix, see [Tunnels](/gateway/tunnels).
+
+---
+
+## Next steps
+
+- [Capabilities: Browser](/gateway/browser), [Coding](/gateway/coding), [Exec](/gateway/exec)
+- [Folders and scopes](/gateway/overview#folders-and-scopes)
+- [Tunnels reference](/gateway/tunnels)
+- [Gateway protocol README](https://github.com/RedPlanetHQ/core/blob/main/packages/gateway-protocol/README.md)

--- a/docs/gateway/setup.mdx
+++ b/docs/gateway/setup.mdx
@@ -4,7 +4,7 @@ description: "Step-by-step runbook to install, register, and connect a Gateway t
 ---
 
 <Note>
-**For agents reading this page:** Execute every fenced bash block in order for the path the user picks (Native + Tailscale, Native + ngrok, Docker, or Railway). After Step 6, prompt the user to complete the browser-side paste in Step 7. Do not skip Step 7: nothing works until the gateway is linked in the CORE app.
+**For agents reading this page:** Execute every fenced bash block in order for the path the user picks (Native + Tailscale, Native + ngrok, Docker, or Railway), through Step 4. Surface the URL and security key from Step 4 to the user, then hand off and prompt them to complete Steps 5 and 6 in their browser. Do not claim success until the user confirms Step 6 is done: nothing works until the gateway is linked in the CORE app. After that, you can resume with Step 7 (Verify) and Step 8 (Register a folder).
 </Note>
 
 This is the linear runbook. For the conceptual overview of what the Gateway is and what it can do, see [Gateway Overview](/gateway/overview). For tunnel-only details (Tailscale, ngrok, custom URLs), see [Tunnels](/gateway/tunnels).

--- a/docs/gateway/tunnels.mdx
+++ b/docs/gateway/tunnels.mdx
@@ -31,7 +31,19 @@ Either way, traffic is HTTPS-terminated by the tunnel and the gateway still requ
 
 <Steps>
   <Step title="Install the Tailscale CLI">
-    Follow the install guide at <a href="https://tailscale.com/download">tailscale.com/download</a>. Verify with:
+    If you don't already have Tailscale, install from [tailscale.com/download](https://tailscale.com/download) or run:
+
+    ```bash
+    # macOS
+    brew install --cask tailscale
+
+    # Linux
+    curl -fsSL https://tailscale.com/install.sh | sh
+    ```
+
+    On macOS, `brew install tailscale` (no `--cask`) only installs the daemon helper. Use `--cask` or the App Store / `.pkg` build to get the CLI binary on `PATH`.
+
+    Verify:
 
     ```bash
     tailscale version
@@ -43,7 +55,13 @@ Either way, traffic is HTTPS-terminated by the tunnel and the gateway still requ
     sudo tailscale up
     ```
 
-    Funnel is a per-tailnet feature — your account needs to be the owner, or an admin must have enabled it for you.
+    Funnel is a per-tailnet feature; your account needs to be the owner, or an admin must have enabled it for you. Confirm the device is connected before moving on:
+
+    ```bash
+    tailscale status
+    ```
+
+    The current device should appear as `active`.
   </Step>
 
   <Step title="Enable Funnel for this device">
@@ -119,7 +137,7 @@ The CLI runs `ngrok http <port>` in the background and queries ngrok's local API
 
 ### Stable URLs
 
-Free-tier ngrok URLs change every restart, which means re-pasting the URL in **Settings → Gateways** every time you reboot. To avoid that:
+Free-tier ngrok URLs change every restart, which means re-pasting the URL in **Sidebar → Gateways** every time you reboot. To avoid that:
 
 - **Reserved domain (paid):** create one in the ngrok dashboard, then run ngrok manually with `ngrok http --domain=<your>.ngrok.app <port>` and register with `--tunnel none --baseUrl https://<your>.ngrok.app`.
 - **Static TCP / edge:** also supported via `--tunnel none` — anything that gives you a fixed `https://...` URL works.
@@ -144,6 +162,26 @@ No subprocess is started; the CLI just records the URL and prints the security k
 
 ---
 
+## After register: link the gateway in the CORE app
+
+Whichever tunnel you pick, the last step is the same. The CLI prints something like:
+
+```
+name:        my-laptop
+baseUrl:     https://my-laptop.tail-scale.ts.net
+securityKey: gwk_aBcDeFg...           ← only shown ONCE
+
+Paste baseUrl + securityKey into CORE → Sidebar → Gateways.
+```
+
+Open [https://app.getcore.me](https://app.getcore.me) (or your self-hosted instance), go to **Sidebar → Gateways → + New gateway**, and paste both values. The gateway should show **Connected** within a few seconds.
+
+If you ever rotate the tunnel or run `corebrain gateway register` again, the security key changes; update **Sidebar → Gateways → Edit** in the webapp with the new pair.
+
+For the full end-to-end runbook (CLI install, login, register, paste, verify, register folders), see [Gateway Setup](/gateway/setup).
+
+---
+
 ## Inspecting and stopping a tunnel
 
 ```bash
@@ -152,7 +190,7 @@ corebrain gateway stop        # stops the gateway and the tunnel
 corebrain gateway register    # re-run to swap to a different tunnel
 ```
 
-If you need to swap tunnels mid-session — say from ngrok to Tailscale — run `corebrain gateway stop`, then `corebrain gateway register --tunnel <new>`. The CLI generates a fresh security key on every register; paste the new pair into **Settings → Gateways → Edit** in the webapp.
+If you need to swap tunnels mid-session — say from ngrok to Tailscale — run `corebrain gateway stop`, then `corebrain gateway register --tunnel <new>`. The CLI generates a fresh security key on every register; paste the new pair into **Sidebar → Gateways → Edit** in the webapp.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `docs/gateway/setup.mdx`: linear, copy-pasteable runbook covering Native+Tailscale, Native+ngrok, Docker, and Railway paths. Each branch lists the prerequisite tunnel install commands (`brew install --cask tailscale`, `tailscale up`, `tailscale status`, `ngrok config add-authtoken`, etc.) so an AI agent can follow the page top-to-bottom without jumping between docs.
- Rewrite `docs/gateway/overview.mdx` to explain why the Gateway exists (concrete workflows pulled from the codebase), what tools each slot exposes (`browser_*`, `coding_*`, `exec_*`, `files_*`, `sleep`), and the purpose of every CLI command via a `Use this when` column on each table.
- Make the `paste URL + key into the CORE app` step explicit and non-skippable in all three docs. Was previously implied only for Railway. Step now lives in overview's install Steps and as Step 6 of the new setup runbook.
- Expand the Railway env-var section with how to source each value (PAT instructions, GitHub token scopes, security key auto-generation behaviour, where to find the deploy logs).
- Update `docs/gateway/tunnels.mdx`: per-OS Tailscale install commands, `tailscale status` verification step before register, and a new `After register: link the gateway in the CORE app` section.
- Update sidebar location references from `Settings -> Gateways` to the dedicated `Gateways` sidebar section throughout.
- Wire `gateway/setup` into `docs/docs.json` Gateway tab nav.

## Test plan
- [ ] `mintlify dev` renders the Gateway tab with Overview > Setup ordering and no broken anchors
- [ ] All cross-links between overview, setup, and tunnels resolve
- [ ] Run through the Native+Tailscale path on a fresh machine following only `gateway/setup.mdx`
- [ ] Run through the Railway path following only `gateway/setup.mdx` Step 3D

## Follow-up
The CLI banner in `packages/cli/src/utils/env-bootstrap.ts:211` and `packages/cli/src/commands/gateway/register.tsx:127` still prints `Settings -> Gateways -> New gateway`. That should be updated to `Sidebar -> Gateways -> New gateway` to match the docs and the actual app UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)