### PR TITLE
feat: add send initial prompt checkbox to new coding session dialog

### DIFF
--- a/apps/webapp/app/components/coding/gateway-terminal.tsx
+++ b/apps/webapp/app/components/coding/gateway-terminal.tsx
@@ -11,6 +11,8 @@ interface Props {
    *  externalSessionId and proxies the WS. */
   codingSessionId: string;
   onNewSession?: () => void;
+  /** If set, this text is typed into the terminal once on first connect. */
+  initialPrompt?: string;
 }
 
 function useHtmlTheme(): "dark" | "light" {
@@ -41,7 +43,7 @@ function buildXtermUrl(codingSessionId: string): string {
   )}/xterm`;
 }
 
-export function GatewayTerminal({ codingSessionId, onNewSession }: Props) {
+export function GatewayTerminal({ codingSessionId, onNewSession, initialPrompt }: Props) {
   const theme = useHtmlTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
@@ -139,6 +141,17 @@ export function GatewayTerminal({ codingSessionId, onNewSession }: Props) {
             rows: term.rows,
           }),
         );
+        // Auto-type the initial prompt once per session (guarded by localStorage).
+        if (initialPrompt) {
+          const sentKey = `coding-session-prompt-sent-${codingSessionId}`;
+          if (!localStorage.getItem(sentKey)) {
+            localStorage.setItem(sentKey, "1");
+            setTimeout(() => {
+              if (!mounted || ws.readyState !== WebSocket.OPEN) return;
+              ws.send(JSON.stringify({ kind: "input", data: initialPrompt + "\r" }));
+            }, 1000);
+          }
+        }
       };
 
       ws.onmessage = (ev) => {

--- a/apps/webapp/app/components/coding/new-session-dialog.tsx
+++ b/apps/webapp/app/components/coding/new-session-dialog.tsx
@@ -16,6 +16,9 @@ import {
   SelectValue,
 } from "~/components/ui/select";
 import { cn } from "~/lib/utils";
+import { Checkbox } from "~/components/ui/checkbox";
+import { Textarea } from "~/components/ui/textarea";
+import { Label } from "~/components/ui/label";
 
 interface GatewayListItem {
   id: string;
@@ -43,12 +46,15 @@ interface Props {
   open: boolean;
   onOpenChange: (v: boolean) => void;
   taskId: string;
+  taskTitle?: string;
+  taskDescription?: string | null;
   onCreated: (args: {
     id: string;
     agent: string;
     dir: string;
     gatewayId: string;
     externalSessionId: string | null;
+    prompt: string | null;
   }) => void;
 }
 
@@ -56,6 +62,8 @@ export function NewSessionDialog({
   open,
   onOpenChange,
   taskId,
+  taskTitle,
+  taskDescription,
   onCreated,
 }: Props) {
   const [gateways, setGateways] = useState<GatewayListItem[] | null>(null);
@@ -72,6 +80,9 @@ export function NewSessionDialog({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  const [sendInitialPrompt, setSendInitialPrompt] = useState(false);
+  const [initialPrompt, setInitialPrompt] = useState("");
+
   // Reset when the dialog opens; load gateways.
   useEffect(() => {
     if (!open) return;
@@ -83,6 +94,8 @@ export function NewSessionDialog({
     setSubmitError(null);
     setGateways(null);
     setGatewaysError(null);
+    setSendInitialPrompt(false);
+    setInitialPrompt("");
 
     (async () => {
       try {
@@ -149,10 +162,20 @@ export function NewSessionDialog({
     Boolean(selectedAgent) &&
     Boolean(dirToSubmit);
 
+  const handleSendInitialPromptChange = (checked: boolean) => {
+    setSendInitialPrompt(checked);
+    if (checked && !initialPrompt) {
+      const parts = [taskTitle, taskDescription].filter(Boolean);
+      setInitialPrompt(parts.join("\n\n"));
+    }
+  };
+
   const handleSubmit = async () => {
     if (!canSubmit) return;
     setSubmitting(true);
     setSubmitError(null);
+    const prompt =
+      sendInitialPrompt && initialPrompt.trim() ? initialPrompt.trim() : null;
     try {
       const res = await fetch(`/api/v1/tasks/${taskId}/coding-sessions`, {
         method: "POST",
@@ -161,6 +184,7 @@ export function NewSessionDialog({
           agent: selectedAgent,
           dir: dirToSubmit,
           gatewayId: selectedGatewayId,
+          ...(prompt ? { prompt } : {}),
         }),
       });
       if (!res.ok) {
@@ -181,6 +205,7 @@ export function NewSessionDialog({
         dir: dirToSubmit,
         gatewayId: selectedGatewayId,
         externalSessionId: data.externalSessionId ?? null,
+        prompt,
       });
       onOpenChange(false);
     } catch (err) {
@@ -326,6 +351,34 @@ export function NewSessionDialog({
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          {/* Initial prompt */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="send-initial-prompt"
+                checked={sendInitialPrompt}
+                onCheckedChange={(checked) =>
+                  handleSendInitialPromptChange(checked === true)
+                }
+              />
+              <Label
+                htmlFor="send-initial-prompt"
+                className="cursor-pointer text-sm font-medium"
+              >
+                Send initial prompt
+              </Label>
+            </div>
+            {sendInitialPrompt && (
+              <Textarea
+                placeholder="Enter a prompt to send when the session starts…"
+                value={initialPrompt}
+                onChange={(e) => setInitialPrompt(e.target.value)}
+                rows={3}
+                className="resize-none text-sm"
+              />
+            )}
           </div>
 
           {submitError ? (

--- a/apps/webapp/app/routes/api.v1.tasks.$taskId.coding-sessions.tsx
+++ b/apps/webapp/app/routes/api.v1.tasks.$taskId.coding-sessions.tsx
@@ -10,6 +10,7 @@ const CreateSchema = z.object({
   agent: z.string().min(1),
   dir: z.string().min(1),
   gatewayId: z.string().optional(),
+  prompt: z.string().optional(),
 });
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -70,6 +71,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     dir: parsed.data.dir,
     gatewayId: parsed.data.gatewayId,
     externalSessionId,
+    prompt: parsed.data.prompt,
   });
 
   return json(

--- a/apps/webapp/app/routes/home.tasks.$taskId.coding.$sessionId.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.coding.$sessionId.tsx
@@ -237,6 +237,7 @@ export default function CodingSessionRoute() {
         key={session.id}
         codingSessionId={session.id}
         onNewSession={openNewSession}
+        initialPrompt={session.prompt ?? undefined}
       />
     );
   }

--- a/apps/webapp/app/routes/home.tasks.$taskId.coding.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.coding.tsx
@@ -19,6 +19,7 @@ import { useTauri } from "~/hooks/use-tauri";
 import { NewSessionDialog } from "~/components/coding/new-session-dialog";
 import { useSetCodingActions } from "~/components/coding/coding-actions-context";
 import { useSidebar } from "~/components/ui/sidebar";
+import { prisma } from "~/db.server";
 
 export type CodingOutletContext = {
   sessions: CodingSessionListItem[];
@@ -38,12 +39,27 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const { taskId } = params;
   if (!taskId) return redirect("/home/tasks");
 
-  const sessions = await getCodingSessionsForTask(taskId, workspaceId);
-  return typedjson({ sessions });
+  const [sessions, task] = await Promise.all([
+    getCodingSessionsForTask(taskId, workspaceId),
+    prisma.task.findUnique({
+      where: { id: taskId, workspaceId },
+      select: { title: true, description: true },
+    }),
+  ]);
+
+  return typedjson({
+    sessions,
+    taskTitle: task?.title ?? "",
+    taskDescription: task?.description ?? null,
+  });
 }
 
 function CodingLayout() {
-  const { sessions: initialSessions } = useTypedLoaderData<typeof loader>();
+  const {
+    sessions: initialSessions,
+    taskTitle,
+    taskDescription,
+  } = useTypedLoaderData<typeof loader>();
   const { taskId, sessionId } = useParams<{
     taskId: string;
     sessionId?: string;
@@ -89,6 +105,7 @@ function CodingLayout() {
     dir: string;
     gatewayId: string;
     externalSessionId: string | null;
+    prompt: string | null;
   }) => {
     // Optimistic insert so the new session is in the popover immediately and
     // the session route doesn't bounce back (it looks up by id in this list).
@@ -100,7 +117,7 @@ function CodingLayout() {
       dir: args.dir,
       createdAt: new Date(),
       updatedAt: new Date(),
-      prompt: null,
+      prompt: args.prompt,
       externalSessionId: args.externalSessionId,
       conversationId: null,
       gatewayId: args.gatewayId,
@@ -182,6 +199,8 @@ function CodingLayout() {
           open={newSessionOpen}
           onOpenChange={setNewSessionOpen}
           taskId={taskId!}
+          taskTitle={taskTitle}
+          taskDescription={taskDescription}
           onCreated={handleNewSessionCreated}
         />
       </>
@@ -205,6 +224,8 @@ function CodingLayout() {
         open={newSessionOpen}
         onOpenChange={setNewSessionOpen}
         taskId={taskId!}
+        taskTitle={taskTitle}
+        taskDescription={taskDescription}
         onCreated={handleNewSessionCreated}
       />
     </>


### PR DESCRIPTION
When enabled, pre-fills with task title + description and auto-types the prompt into the terminal once on first connect (localStorage-guarded).