### PR TITLE
feat: channel picker in task detail view

### DIFF
--- a/apps/webapp/app/components/tasks/task-channel-picker.tsx
+++ b/apps/webapp/app/components/tasks/task-channel-picker.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import { Mail, MessageSquare, Send, Check } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+
+export interface ChannelOption {
+  id: string;
+  name: string;
+  type: string;
+  isDefault: boolean;
+}
+
+interface TaskChannelPickerProps {
+  channels: ChannelOption[];
+  selectedChannelId: string | null;
+  defaultChannelName: string | null;
+  onChange: (channelId: string | null) => void;
+}
+
+const CHANNEL_ICON: Record<string, React.ReactNode> = {
+  email: <Mail size={14} />,
+  slack: <MessageSquare size={14} />,
+  telegram: <Send size={14} />,
+  whatsapp: <MessageSquare size={14} />,
+};
+
+function channelIconFor(type: string | null | undefined): React.ReactNode {
+  if (!type) return <MessageSquare size={14} />;
+  return CHANNEL_ICON[type] ?? <MessageSquare size={14} />;
+}
+
+export function TaskChannelPicker({
+  channels,
+  selectedChannelId,
+  defaultChannelName,
+  onChange,
+}: TaskChannelPickerProps) {
+  const [open, setOpen] = useState(false);
+  if (channels.length === 0) return null;
+
+  const selected = selectedChannelId
+    ? (channels.find((c) => c.id === selectedChannelId) ?? null)
+    : null;
+
+  const label = selected
+    ? selected.name
+    : defaultChannelName
+      ? `${defaultChannelName} · default`
+      : "Default";
+  const iconType = selected?.type ?? channels.find((c) => c.isDefault)?.type;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="secondary" className="gap-1">
+          {channelIconFor(iconType)}
+          <span>{label}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-1" align="start">
+        <button
+          type="button"
+          onClick={() => {
+            onChange(null);
+            setOpen(false);
+          }}
+          className="hover:bg-grayAlpha-100 flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm"
+        >
+          <span className="text-muted-foreground flex w-4 shrink-0 justify-center">
+            {selectedChannelId === null ? <Check size={14} /> : null}
+          </span>
+          <span className="flex-1 truncate text-left">
+            Use default
+            {defaultChannelName && (
+              <span className="text-muted-foreground ml-1">
+                · {defaultChannelName}
+              </span>
+            )}
+          </span>
+        </button>
+        <div className="bg-border my-1 h-px" />
+        {channels.map((c) => (
+          <button
+            type="button"
+            key={c.id}
+            onClick={() => {
+              onChange(c.id);
+              setOpen(false);
+            }}
+            className="hover:bg-grayAlpha-100 flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm"
+          >
+            <span className="text-muted-foreground flex w-4 shrink-0 justify-center">
+              {selectedChannelId === c.id ? <Check size={14} /> : null}
+            </span>
+            <span className="text-muted-foreground shrink-0">
+              {channelIconFor(c.type)}
+            </span>
+            <span className="flex-1 truncate text-left">{c.name}</span>
+            {c.isDefault && (
+              <span className="text-muted-foreground shrink-0 text-xs">
+                default
+              </span>
+            )}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/webapp/app/components/tasks/task-detail-full.client.tsx
+++ b/apps/webapp/app/components/tasks/task-detail-full.client.tsx
@@ -21,6 +21,10 @@ import {
   TaskStatusDropdownVariant,
 } from "~/components/tasks/task-status-dropdown";
 import { TaskInlineForm } from "~/components/tasks/task-inline-form.client";
+import {
+  TaskChannelPicker,
+  type ChannelOption,
+} from "~/components/tasks/task-channel-picker";
 import type { TaskFull } from "~/services/task.server";
 import { cn } from "~/lib/utils";
 import type { TaskStatus } from "@core/database";
@@ -33,12 +37,15 @@ interface TaskDetailFullProps {
   taskPageId: string;
   collabToken: string;
   isSubmitting: boolean;
+  channels?: ChannelOption[];
+  defaultChannelName?: string | null;
   onSave: (title: string) => void;
   onStatusChange: (status: string) => void;
   onCreateSubtask: (title: string, status: string) => void;
   onSubtaskStatusChange: (subtaskId: string, status: string) => void;
   onSubtaskDelete: (subtaskId: string) => void;
   onSubtaskClick: (id: string) => void;
+  onChannelChange?: (channelId: string | null) => void;
 }
 
 function SubIssuesPopover({
@@ -155,12 +162,15 @@ export function TaskDetailFull({
   taskPageId,
   collabToken,
   isSubmitting,
+  channels = [],
+  defaultChannelName = null,
   onSave,
   onStatusChange,
   onCreateSubtask,
   onSubtaskStatusChange,
   onSubtaskDelete,
   onSubtaskClick,
+  onChannelChange,
 }: TaskDetailFullProps) {
   const [title, setTitle] = React.useState(task.title);
 
@@ -281,6 +291,15 @@ export function TaskDetailFull({
                   )}
               </span>
             </Button>
+
+            {onChannelChange && channels.length > 0 && (
+              <TaskChannelPicker
+                channels={channels}
+                selectedChannelId={task.channelId ?? null}
+                defaultChannelName={defaultChannelName}
+                onChange={onChannelChange}
+              />
+            )}
           </div>
 
           <div className="flex flex-col gap-1">

--- a/apps/webapp/app/routes/home.tasks.$taskId._index.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId._index.tsx
@@ -22,6 +22,8 @@ function TaskDetailInner() {
     widgetOptions,
     widgetPat,
     baseUrl,
+    channels,
+    defaultChannelName,
   } = data;
 
   const handleSave = (title: string) => {
@@ -59,6 +61,13 @@ function TaskDetailInner() {
     );
   };
 
+  const handleChannelChange = (channelId: string | null) => {
+    fetcher.submit(
+      { intent: "update", channelId: channelId ?? "" },
+      { method: "POST", action: `/home/tasks/${task.id}` },
+    );
+  };
+
   const widgetCtxValue = useMemo(
     () =>
       widgetPat && baseUrl
@@ -76,12 +85,15 @@ function TaskDetailInner() {
       taskPageId={taskPageId}
       collabToken={collabToken}
       isSubmitting={fetcher.state !== "idle"}
+      channels={channels}
+      defaultChannelName={defaultChannelName}
       onSave={handleSave}
       onStatusChange={handleStatusChange}
       onCreateSubtask={handleCreateSubtask}
       onSubtaskStatusChange={handleSubtaskStatusChange}
       onSubtaskDelete={handleSubtaskDelete}
       onSubtaskClick={(id) => navigate(`/home/tasks/${id}`)}
+      onChannelChange={handleChannelChange}
     />
   );
 

--- a/apps/webapp/app/routes/home.tasks.$taskId.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.tsx
@@ -42,6 +42,7 @@ import {
 } from "~/services/tasks/recurrence.server";
 import { getIntegrationAccounts } from "~/services/integrationAccount.server";
 import { hasCodingSessions } from "~/services/coding/coding-session.server";
+import { getChannels } from "~/services/channel.server";
 import {
   getWidgetOptions,
   getOrCreateWidgetPat,
@@ -87,6 +88,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     widgetOptions,
     widgetPat,
+    channels,
   ] = await Promise.all([
     getTaskFull(taskId, workspaceId),
     getIntegrationAccounts(user.id, workspaceId),
@@ -95,6 +97,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     getWidgetOptions(user.id, workspaceId),
     getOrCreateWidgetPat(workspaceId, user.id),
+    getChannels(workspaceId),
   ]);
 
   if (!task) return redirect("/home/tasks");
@@ -113,6 +116,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     }
   }
 
+  const defaultChannel =
+    channels.find((c) => c.isDefault) ?? channels[0] ?? null;
+
   return typedjson({
     task,
     integrationAccountMap,
@@ -125,6 +131,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     widgetOptions,
     widgetPat,
     baseUrl: new URL(request.url).origin,
+    channels: channels.map((c) => ({
+      id: c.id,
+      name: c.name,
+      type: c.type,
+      isDefault: c.isDefault,
+    })),
+    defaultChannelName: defaultChannel?.name ?? null,
   });
 }
 
@@ -133,8 +146,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 const ActionSchema = z.discriminatedUnion("intent", [
   z.object({
     intent: z.literal("update"),
-    title: z.string().min(1),
+    title: z.string().min(1).optional(),
     description: z.string().optional(),
+    channelId: z.string().optional(),
   }),
   z.object({
     intent: z.literal("update-status"),
@@ -199,18 +213,54 @@ export async function action({ request, params }: ActionFunctionArgs) {
     text: formData.get("text") ?? undefined,
     startTime: formData.get("startTime") ?? undefined,
     currentTime: formData.get("currentTime") ?? undefined,
+    channelId: formData.get("channelId") ?? undefined,
   });
 
   if (!parsed.success) return json({ error: "Invalid input" }, { status: 400 });
 
   if (parsed.data.intent === "update") {
+    let resolvedChannel: { channel: string | null; channelId: string | null } | undefined;
+    if (parsed.data.channelId !== undefined) {
+      if (parsed.data.channelId === "") {
+        resolvedChannel = { channel: null, channelId: null };
+      } else {
+        const channel = await prisma.channel.findFirst({
+          where: { id: parsed.data.channelId, workspaceId, isActive: true },
+        });
+        if (!channel) {
+          return json({ error: "Channel not found" }, { status: 404 });
+        }
+        resolvedChannel = { channel: channel.type, channelId: channel.id };
+      }
+    }
+
     const task = await updateTask(taskId, {
-      title: parsed.data.title,
+      ...(parsed.data.title !== undefined && { title: parsed.data.title }),
       ...(parsed.data.description !== undefined && {
         description: parsed.data.description,
       }),
+      ...(resolvedChannel !== undefined && {
+        channel: resolvedChannel.channel,
+        channelId: resolvedChannel.channelId,
+      }),
     });
-    detectAndApplyRecurrence(taskId, workspaceId, user.id, parsed.data.title);
+
+    if (resolvedChannel !== undefined && task.isActive && task.nextRunAt) {
+      await removeScheduledTask(taskId);
+      await enqueueScheduledTask(
+        {
+          taskId,
+          workspaceId,
+          userId: user.id,
+          channel: task.channel ?? "email",
+        },
+        task.nextRunAt,
+      );
+    }
+
+    if (parsed.data.title) {
+      detectAndApplyRecurrence(taskId, workspaceId, user.id, parsed.data.title);
+    }
     return json({ task });
   }
 

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -252,6 +252,8 @@ export async function updateTask(
     status?: TaskStatus;
     title?: string;
     description?: string;
+    channel?: string | null;
+    channelId?: string | null;
     /** Page the change originated from — excluded from title propagation. */
     sourcePageId?: string;
   },


### PR DESCRIPTION
## Summary
- Adds a per-task channel picker (`TaskChannelPicker`) next to the schedule pill in the single-task detail view, surfacing which channel a scheduled task's messages/notifications will go through.
- Picker defaults to "Use default · {workspace default channel}" when no per-task override is set; selecting a channel writes `task.channel` + `task.channelId`, selecting "Use default" clears them.
- Channel changes for an active scheduled task re-enqueue the wake-up job so the new channel string takes effect on the next run (the queue payload is set at enqueue time, not read live).
- Channel update is folded into the existing `update` intent (now also accepts an optional `channelId`); `updateTask` now accepts `channel`/`channelId` to keep a single update path.

## Test plan
- [ ] Open a task detail view with no per-task channel set → picker shows "{default} · default" with the default channel's icon.
- [ ] Pick a non-default channel → pill label updates to the channel's name; refreshing keeps the selection.
- [ ] Pick "Use default" on a task with a per-task channel → clears `channel`/`channelId`; pill returns to default label.
- [ ] On an active scheduled task, change channel → next scheduled run delivers via the newly chosen channel (queue payload re-enqueued).
- [ ] Workspace with no channels configured → picker is hidden (no channels to choose from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)