### PR TITLE
refactor(agent): replace coding-session prompt injection with task-scoped tools

### DIFF
--- a/apps/webapp/app/services/agent/__tests__/session-tools.test.ts
+++ b/apps/webapp/app/services/agent/__tests__/session-tools.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/coding/coding-session.server", () => ({
+  getLastCodingSession: vi.fn(),
+  getCodingSessionsForTask: vi.fn(),
+}));
+vi.mock("~/services/browser/browser-session.server", () => ({
+  getBrowserSessionsForTask: vi.fn(),
+}));
+
+import { getSessionTools } from "~/services/agent/tools/session-tools";
+import {
+  getLastCodingSession,
+  getCodingSessionsForTask,
+} from "~/services/coding/coding-session.server";
+import { getBrowserSessionsForTask } from "~/services/browser/browser-session.server";
+
+const mockedGetLast = vi.mocked(getLastCodingSession);
+const mockedGetCodingList = vi.mocked(getCodingSessionsForTask);
+const mockedGetBrowserList = vi.mocked(getBrowserSessionsForTask);
+
+const WORKSPACE = "ws_1";
+const TASK = "task_1";
+
+// The tool() factory returns AI SDK tools whose execute signature is
+// (input, context) — we don't pass context in unit tests.
+type ExecutableTool = {
+  execute: (input: Record<string, unknown>) => Promise<unknown>;
+};
+
+function getTool(
+  tools: Record<string, unknown>,
+  name: string,
+): ExecutableTool {
+  return tools[name] as ExecutableTool;
+}
+
+describe("session-tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("get_task_coding_session", () => {
+    it("returns null when there is no session", async () => {
+      mockedGetLast.mockResolvedValueOnce(null);
+
+      const tools = getSessionTools({
+        workspaceId: WORKSPACE,
+        currentTaskId: TASK,
+      });
+      const result = await getTool(tools, "get_task_coding_session").execute(
+        {},
+      );
+
+      expect(mockedGetLast).toHaveBeenCalledWith(TASK, WORKSPACE);
+      expect(result).toEqual({ session: null });
+    });
+
+    it("returns ready when externalSessionId is set", async () => {
+      mockedGetLast.mockResolvedValueOnce({
+        externalSessionId: "sess_42",
+        agent: "claude-code",
+        dir: "/repo",
+        worktreePath: "/wt/repo",
+        worktreeBranch: "feature/x",
+        gateway: { id: "gw_1", name: "gw" },
+      } as Awaited<ReturnType<typeof getLastCodingSession>>);
+
+      const tools = getSessionTools({
+        workspaceId: WORKSPACE,
+        currentTaskId: TASK,
+      });
+      const result = (await getTool(tools, "get_task_coding_session").execute(
+        {},
+      )) as { session: { status: string; sessionId: string } };
+
+      expect(result.session.status).toBe("ready");
+      expect(result.session.sessionId).toBe("sess_42");
+    });
+
+    it("returns starting when externalSessionId is null", async () => {
+      mockedGetLast.mockResolvedValueOnce({
+        externalSessionId: null,
+        agent: "claude-code",
+        dir: "/repo",
+        worktreePath: null,
+        worktreeBranch: null,
+        gateway: { id: "gw_1", name: "gw" },
+      } as Awaited<ReturnType<typeof getLastCodingSession>>);
+
+      const tools = getSessionTools({
+        workspaceId: WORKSPACE,
+        currentTaskId: TASK,
+      });
+      const result = (await getTool(tools, "get_task_coding_session").execute(
+        {},
+      )) as { session: { status: string } };
+
+      expect(result.session.status).toBe("starting");
+    });
+
+    it("uses an explicit taskId argument over currentTaskId", async () => {
+      mockedGetLast.mockResolvedValueOnce(null);
+
+      const tools = getSessionTools({
+        workspaceId: WORKSPACE,
+        currentTaskId: TASK,
+      });
+      await getTool(tools, "get_task_coding_session").execute({
+        taskId: "task_other",
+      });
+
+      expect(mockedGetLast).toHaveBeenCalledWith("task_other", WORKSPACE);
+    });
+
+    it("errors when no taskId is available", async () => {
+      const tools = getSessionTools({
+        workspaceId: WORKSPACE,
+        currentTaskId: undefined,
+      });
+      const result = (await getTool(tools, "get_task_coding_session").execute(
+        {},
+      )) as { error?: string };
+
+      expect(result.error).toMatch(/no taskId/i);
+      expect(mockedGetLast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list_task_coding_sessions", () => {
+    it("returns mapped sessions", async () => {
+      const now = new Date("2026-01-01T00:00:00Z");
+      mockedGetCodingList.mockResolvedValueOnce([
+        {
+          id: "row_1",
+          createdAt: now,
+          updatedAt: now,
+          agent: "claude-code",
+          prompt: null,
+          dir: "/repo",
+          externalSessionId: "sess_a",
+          conversationId: null,
+          gatewayId: "gw_1",
+          worktreePath: null,
+          worktreeBranch: null,
+          gateway: { id: "gw_1", name: "gw" },
+        },
+      ] as Awaited<ReturnType<typeof getCodingSessionsForTask>>);
+
+      const tools = getSessionTools({
+        workspaceId: WORKSPACE,
+        currentTaskId: TASK,
+      });
+      const result = (await getTool(
+        tools,
+        "list_task_coding_sessions",
+      ).execute({})) as {
+        sessions: Array<{ sessionId: string | null; createdAt: string }>;
+      };
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0].sessionId).toBe("sess_a");
+      expect(result.sessions[0].createdAt).toBe(now.toISOString());
+    });
+  });
+
+  describe("list_task_browser_sessions", () => {
+    it("returns mapped browser sessions", async () => {
+      const now = new Date("2026-02-02T00:00:00Z");
+      mockedGetBrowserList.mockResolvedValueOnce([
+        {
+          id: "row_b",
+          createdAt: now,
+          updatedAt: now,
+          sessionName: "create_swiggy_order",
+          profileName: "personal",
+          taskId: TASK,
+          gatewayId: "gw_1",
+          gateway: { id: "gw_1", name: "gw" },
+        },
+      ] as Awaited<ReturnType<typeof getBrowserSessionsForTask>>);
+
+      const tools = getSessionTools({
+        workspaceId: WORKSPACE,
+        currentTaskId: TASK,
+      });
+      const result = (await getTool(
+        tools,
+        "list_task_browser_sessions",
+      ).execute({})) as {
+        sessions: Array<{ sessionName: string; profileName: string }>;
+      };
+
+      expect(result.sessions).toEqual([
+        expect.objectContaining({
+          sessionName: "create_swiggy_order",
+          profileName: "personal",
+          gatewayId: "gw_1",
+          gatewayName: "gw",
+        }),
+      ]);
+    });
+  });
+});

--- a/apps/webapp/app/services/agent/agents/core.ts
+++ b/apps/webapp/app/services/agent/agents/core.ts
@@ -12,7 +12,6 @@ import { type Tool, tool } from "ai";
 import { z } from "zod";
 import { Agent } from "@mastra/core/agent";
 import { createTool } from "@mastra/core/tools";
-import { createTool } from "@mastra/core/tools";
 
 import { type SkillRef } from "../types";
 import { type ModelConfig } from "~/services/llm-provider.server";
@@ -28,6 +27,7 @@ import {
 } from "../tools/skill-tools";
 import { getTaskTools } from "../tools/task-tools";
 import { getMessageTools } from "../tools/message-tools";
+import { getSessionTools } from "../tools/session-tools";
 import { getSleepTool } from "../tools/utils-tools";
 import { createOrchestratorAgent } from "./orchestrator";
 import { createGatewayAgents } from "./gateway";
@@ -198,7 +198,12 @@ export async function createCoreTools(
     tools["update_skill"] = updateSkillTool(workspaceId, userId);
   }
 
-  return { ...tools, ...taskTools, ...messageTools };
+  // Session lookup tools — replace the previous prompt-injection of last
+  // coding/browser session details. Available in every context (interactive
+  // chat too, for asking "what was the session for that task?").
+  const sessionTools = getSessionTools({ workspaceId, currentTaskId });
+
+  return { ...tools, ...taskTools, ...messageTools, ...sessionTools };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -40,7 +40,6 @@ import { getWorkspaceChannelContext } from "~/services/channel.server";
 import { type MessageListInput } from "@mastra/core/agent/message-list";
 import { type ModelConfig } from "~/services/llm-provider.server";
 import { getPageContentAsHtml } from "~/services/hocuspocus/content.server";
-import { getLastCodingSession } from "~/services/coding/coding-session.server";
 import { DirectOrchestratorTools } from "./executors";
 import { getTaskPhase } from "~/services/task.phase";
 import { fetchManifest } from "~/services/gateway/transport.server";
@@ -91,47 +90,6 @@ interface AgentContext {
   gatewayAgents: Agent[];
   /** True when running as a background task — ask_user should not be registered */
   isBackgroundExecution: boolean;
-}
-
-type CodingSessionHint = Awaited<ReturnType<typeof getLastCodingSession>>;
-
-/**
- * Render the coding-session resume hint that gets injected into <task_prep>
- * and <task_execution> system prompts. CodingSession is the source of truth —
- * the agent should read sessionId/dir/agent/branch from this hint, not from
- * the task description.
- *
- * Three cases:
- * - No row at all → return "" (agent will create the first session naturally).
- * - Row with externalSessionId → "resume it" with full details.
- * - Row with null externalSessionId → "starting up, wait via reschedule_self".
- */
-function renderCodingSessionHint(
-  session: CodingSessionHint,
-  mode: "prep" | "execute",
-): string {
-  if (!session) return "";
-
-  const dir = session.worktreePath ?? session.dir;
-  const dirPart = dir ? `, dir: ${dir}` : "";
-  const branchPart = session.worktreeBranch
-    ? `, branch: ${session.worktreeBranch}`
-    : "";
-
-  if (session.externalSessionId) {
-    if (mode === "prep") {
-      return `\n   A coding session already exists — resume it:\n   sessionId: ${session.externalSessionId}, agent: ${session.agent}${dirPart}${branchPart}`;
-    }
-    return `\n- A coding session already exists for this task — resume it with intent "execute the plan" to trigger Phase 3 execution:\n  sessionId: ${session.externalSessionId}, agent: ${session.agent}${dirPart}${branchPart}`;
-  }
-
-  // Row exists but externalSessionId not yet assigned (race window between
-  // createCodingSession and updateCodingSessionExternalId). Tell the agent to
-  // wait rather than start a duplicate.
-  if (mode === "prep") {
-    return `\n   A coding session is starting up for this task (agent: ${session.agent}${dirPart}) but its sessionId hasn't been assigned yet. Call reschedule_self(minutesFromNow=2) and try again. Do NOT start a new session.`;
-  }
-  return `\n- A coding session is starting up for this task (agent: ${session.agent}${dirPart}) but its sessionId hasn't been assigned yet. Call reschedule_self(minutesFromNow=2) and try again. Do NOT start a new session.`;
 }
 
 export async function buildAgentContext({
@@ -229,10 +187,6 @@ export async function buildAgentContext({
 
   const linkedTask = linkedTaskRecord
     ? { ...linkedTaskRecord, description: linkedTaskDescription }
-    : null;
-
-  const lastCodingSession = linkedTaskRecord
-    ? await getLastCodingSession(linkedTaskRecord.id, workspaceId)
     : null;
 
   const metadata = user?.metadata as Record<string, unknown> | null;
@@ -499,7 +453,7 @@ ${
 SUBTASK PREP RULES:
 1. You are prepping ONE CHUNK of a larger task. Read the parent task description and any prior sibling outputs for context.
 2. Self-resolve questions using available context (parent description, gather_context, code reading). ONLY move to Waiting and ask the user if you genuinely cannot proceed without their input.
-3. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent.${lastCodingSession?.externalSessionId ? `\n   A coding session already exists — resume it:\n   sessionId: ${lastCodingSession.externalSessionId}, agent: ${lastCodingSession.agent}${(lastCodingSession.worktreePath ?? lastCodingSession.dir) ? `, dir: ${lastCodingSession.worktreePath ?? lastCodingSession.dir}` : ""}${lastCodingSession.worktreeBranch ? `, branch: ${lastCodingSession.worktreeBranch}` : ""}` : ""}
+3. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent. Before delegating, call get_task_coding_session — if it returns a session, resume that one (pass its sessionId, dir, and worktreeBranch to the gateway). If status is "starting", call reschedule_self(minutesFromNow=2) and do NOT start a new session.
 4. For NON-CODING tasks: do the prep yourself using gather_context, take_action, and the readiness skills.
 5. Write your plan into the task description using update_task.
 6. When prep is complete, move to Review: update_task(taskId: "${linkedTask.id}", status: "Review"). Do NOT wait for user approval — subtasks auto-transition from prep to execute.
@@ -529,7 +483,7 @@ PREP RULES:
    - Unclear what's needed? → load "Gather Information" skill
    - Open-ended, needs shaping? → load "Brainstorm" skill
    - Multi-step, needs decomposition? → load "Plan" skill
-2. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent. Pass the task title and description. The gateway will return questions or a plan — do NOT tell it to execute.${renderCodingSessionHint(lastCodingSession, "prep")}
+2. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent. Pass the task title and description. The gateway will return questions or a plan — do NOT tell it to execute. Before delegating, call get_task_coding_session — if it returns a session with status "ready", resume that session (pass sessionId, dir, worktreeBranch to the gateway); if status is "starting", call reschedule_self(minutesFromNow=2) and do NOT start a new session.
 3. For NON-CODING tasks: do the prep yourself using gather_context, take_action, and the readiness skills.
 4. Write your findings/plan into the task description using update_task.
 5. When prep is complete, move to Review: update_task(taskId: "${linkedTask.id}", status: "Review")
@@ -575,7 +529,7 @@ THIS TASK IS WAITING. The user's message in this conversation is the reply that 
 
 RULES:
 - For integration work (emails, calendar, github, etc.): delegate to the orchestrator via gather_context / take_action
-- For coding, browser, shell: use gateway tools directly (coding_*, browser_*, exec_*) if connected${renderCodingSessionHint(lastCodingSession, "execute")}
+- For coding, browser, shell: use gateway tools directly (coding_*, browser_*, exec_*) if connected. Before delegating coding work, call get_task_coding_session — if it returns a session with status "ready", resume it via the gateway with sessionId/dir/worktreeBranch and the intent "execute the plan"; if status is "starting", call reschedule_self(minutesFromNow=2) instead of starting a new session.
 - If the user sends a message, treat it as additional direction for this task${
         isSubtask
           ? `
@@ -609,7 +563,7 @@ When you delegate a coding task to the gateway, it will return one of:
 
 When the user answers a question, resume the coding session with the answer. Do NOT write the answer into the task description.
 
-On re-execution after reschedule: the system prompt above already shows the latest coding session (sessionId, agent, dir, branch) — resume that session, do NOT start a new one. Delegate to gateway with the sessionId, dir, and intent "execute the plan" so the gateway enters Phase 3 (execution) rather than re-doing planning. If the prompt says the session is starting up and sessionId hasn't been assigned yet, call reschedule_self(minutesFromNow=2) and try again. Only pass user answers if the user has replied since the last run.
+On re-execution after reschedule: call get_task_coding_session to resolve the latest coding session for this task — resume that session, do NOT start a new one. Delegate to gateway with the returned sessionId, dir, and intent "execute the plan" so the gateway enters Phase 3 (execution) rather than re-doing planning. If get_task_coding_session returns status "starting" (sessionId hasn't been assigned yet), call reschedule_self(minutesFromNow=2) and try again. Only pass user answers if the user has replied since the last run.
 
 Do NOT sleep, poll coding_read_session, or create scheduled tasks yourself — the gateway handles that.
 </task_execution>`;

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -304,7 +304,7 @@ The gateway will return either questions, a plan (feature), or a root cause + pr
 **Common (both tracks):**
 - When the gateway returns questions → post them to the user via send_message (include sessionId), mark task Waiting. Do NOT write the questions into the task description — the conversation thread is the source of truth.
 - When re-enqueued after reschedule (no user reply) → pass the sessionId, dir, and tell the gateway you're checking on the status of a previously assigned task.
-- When re-enqueued after user replies → pass the user's answers to the gateway along with the sessionId and dir from the coding-session details in the system prompt.
+- When re-enqueued after user replies → call get_task_coding_session to resolve the sessionId and dir, then pass the user's answers to the gateway along with that sessionId and dir.
 - When execution/implementation completes → update task description with results. Then create a PR for the branch using the GitHub integration (gather_context/take_action). Include the PR URL in the Output section. After PR is created, mark task Review. The user will verify and move to Done.
 - STOP after marking Waiting or Review. Do not proceed further.
 

--- a/apps/webapp/app/services/agent/tools/session-tools.ts
+++ b/apps/webapp/app/services/agent/tools/session-tools.ts
@@ -1,0 +1,150 @@
+/**
+ * Session lookup tools.
+ *
+ * Replace the previous prompt-injection of `lastCodingSession` (sessionId, dir,
+ * branch, agent) with on-demand tool calls. The CodingSession / BrowserSession
+ * tables map workspace-side `taskId` → gateway-side session identifiers; the
+ * gateway itself has no notion of tasks, so this lookup must live in the
+ * webapp.
+ *
+ * The agent calls these only when it actually needs to resume or report on a
+ * task's session — most prompts no longer carry that data unconditionally.
+ */
+
+import { tool, type Tool } from "ai";
+import { z } from "zod";
+
+import {
+  getLastCodingSession,
+  getCodingSessionsForTask,
+} from "~/services/coding/coding-session.server";
+import { getBrowserSessionsForTask } from "~/services/browser/browser-session.server";
+
+interface GetSessionToolsParams {
+  workspaceId: string;
+  /** Defaults the optional `taskId` arg when the agent omits it. */
+  currentTaskId?: string;
+}
+
+function resolveTaskId(
+  argTaskId: string | undefined,
+  currentTaskId: string | undefined,
+): string | { error: string } {
+  const taskId = argTaskId ?? currentTaskId;
+  if (!taskId) {
+    return {
+      error:
+        "No taskId provided and no current task in context — pass taskId explicitly.",
+    };
+  }
+  return taskId;
+}
+
+export function getSessionTools(
+  params: GetSessionToolsParams,
+): Record<string, Tool> {
+  const { workspaceId, currentTaskId } = params;
+
+  return {
+    get_task_coding_session: tool({
+      description:
+        "Get the most recent coding session recorded for a task. Returns the gateway-side sessionId, agent name, working directory, worktree path and branch (when applicable), and gateway info. Call before delegating coding work to the gateway so you can resume an existing session instead of starting a new one. Returns null when the task has no coding session yet.",
+      inputSchema: z.object({
+        taskId: z
+          .string()
+          .optional()
+          .describe(
+            "Task ID to look up. Defaults to the current task in context when omitted.",
+          ),
+      }),
+      execute: async ({ taskId }) => {
+        const resolved = resolveTaskId(taskId, currentTaskId);
+        if (typeof resolved !== "string") return resolved;
+
+        const session = await getLastCodingSession(resolved, workspaceId);
+        if (!session) return { session: null };
+
+        return {
+          session: {
+            sessionId: session.externalSessionId,
+            agent: session.agent,
+            dir: session.dir,
+            worktreePath: session.worktreePath,
+            worktreeBranch: session.worktreeBranch,
+            gatewayId: session.gateway?.id ?? null,
+            gatewayName: session.gateway?.name ?? null,
+            // The CodingSession row exists but the gateway hasn't echoed back
+            // an externalSessionId yet — agent should wait, not start a new run.
+            status: session.externalSessionId ? "ready" : "starting",
+          },
+        };
+      },
+    }),
+
+    list_task_coding_sessions: tool({
+      description:
+        "List ALL coding sessions for a task in newest-first order. Use when you need history (multiple sessions across worktrees) rather than just the latest. Returns an empty array when none exist.",
+      inputSchema: z.object({
+        taskId: z
+          .string()
+          .optional()
+          .describe(
+            "Task ID to look up. Defaults to the current task in context when omitted.",
+          ),
+      }),
+      execute: async ({ taskId }) => {
+        const resolved = resolveTaskId(taskId, currentTaskId);
+        if (typeof resolved !== "string") return resolved;
+
+        const sessions = await getCodingSessionsForTask(resolved, workspaceId);
+        return {
+          sessions: sessions.map((s) => ({
+            id: s.id,
+            sessionId: s.externalSessionId,
+            agent: s.agent,
+            dir: s.dir,
+            worktreePath: s.worktreePath,
+            worktreeBranch: s.worktreeBranch,
+            gatewayId: s.gatewayId,
+            gatewayName: s.gateway?.name ?? null,
+            createdAt: s.createdAt.toISOString(),
+            updatedAt: s.updatedAt.toISOString(),
+          })),
+        };
+      },
+    }),
+
+    list_task_browser_sessions: tool({
+      description:
+        "List browser sessions a task has claimed on its gateways. Returns the session names and profile bindings — pass a returned `sessionName` to subsequent browser_* tool calls. Empty when the task has not opened any browser sessions yet.",
+      inputSchema: z.object({
+        taskId: z
+          .string()
+          .optional()
+          .describe(
+            "Task ID to look up. Defaults to the current task in context when omitted.",
+          ),
+      }),
+      execute: async ({ taskId }) => {
+        const resolved = resolveTaskId(taskId, currentTaskId);
+        if (typeof resolved !== "string") return resolved;
+
+        const sessions = await getBrowserSessionsForTask(
+          resolved,
+          workspaceId,
+        );
+        return {
+          sessions: sessions.map((s) => ({
+            id: s.id,
+            sessionName: s.sessionName,
+            profileName: s.profileName,
+            gatewayId: s.gatewayId,
+            gatewayName: s.gateway?.name ?? null,
+            createdAt: s.createdAt.toISOString(),
+            updatedAt: s.updatedAt.toISOString(),
+          })),
+        };
+      },
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- Remove the unconditional injection of last-coding-session details (sessionId, agent, dir, worktreePath, branch) from `<task_prep>`, `<task_execution>`, the subtask-prep inline string, and the capabilities prompt.
- Add three task-scoped AI SDK tools — `get_task_coding_session`, `list_task_coding_sessions`, `list_task_browser_sessions` — registered for every agent context via `createCoreTools`. Each accepts an optional `taskId` (defaulting to the current task) and is backed by the existing `CodingSession` / `BrowserSession` workspace tables.
- `get_task_coding_session` returns `status: "ready" | "starting"` so the agent can distinguish a session whose `externalSessionId` hasn't been echoed back yet from a usable one — preserving the prior "wait, do not start a duplicate" behavior the prompt injection encoded.
- Rewrite the three injection sites (and the trailing "system prompt above shows the latest session" guidance) to instruct the agent to call the new tool. No gateway-side changes were needed: `coding_list_sessions`, `coding_search_sessions`, `coding_read_session`, and `browser_list_sessions` already exist on the gateway, and the gateway agent prompt already routes through them — only the workspace-only task→session lookup needed a new home.
- Drive-by: collapse a duplicate `createTool` import in `agents/core.ts` that was a pre-existing TS error.

## Test plan
- [x] `pnpm vitest run app/services/agent/__tests__/` — 27/27 pass (7 new in `session-tools.test.ts`, 20 existing in `context-window.test.ts`).
- [x] `pnpm vitest run` (whole webapp) — 72/72 tests pass; 2 test files fail to load on missing `DATABASE_URL`, verified pre-existing on `main`.
- [x] `tsc --noEmit` — net **−2** errors (fixed the duplicate `createTool` import); zero new errors. The 3 remaining errors in touched files all pre-exist on `main`.
- [ ] Manual: trigger a coding task that previously relied on the prompt hint, confirm the agent now calls `get_task_coding_session` before delegating and resumes the existing session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
