### PR TITLE
Fix Task Coding tab session switching

### DIFF
--- a/apps/webapp/app/routes/home.tasks.$taskId.coding.$sessionId.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.coding.$sessionId.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useOutletContext, useParams } from "@remix-run/react";
+import { useNavigate, useNavigation, useOutletContext, useParams } from "@remix-run/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { format } from "date-fns";
 import { Loader2, Copy, Check } from "lucide-react";
@@ -198,6 +198,7 @@ export default function CodingSessionRoute() {
     useOutletContext<CodingOutletContext>();
   const { sessionId } = useParams<{ sessionId: string }>();
   const navigate = useNavigate();
+  const navigation = useNavigation();
 
   const session = sessions.find((s) => s.id === sessionId) ?? null;
 
@@ -213,12 +214,14 @@ export default function CodingSessionRoute() {
   }, [sessionId, session, taskId]);
 
   // Stale URL (session deleted, or wrong taskId): bounce back to the index so
-  // it can pick a valid session.
+  // it can pick a valid session. Wait for any in-flight navigation to settle
+  // first — sessions may transiently lag the URL during a loading transition.
   useEffect(() => {
+    if (navigation.state !== "idle") return;
     if (sessionId && !session && sessions.length > 0) {
       navigate(`/home/tasks/${taskId}/coding`, { replace: true });
     }
-  }, [sessionId, session, sessions.length, navigate, taskId]);
+  }, [sessionId, session, sessions.length, navigate, taskId, navigation.state]);
 
   if (!session) {
     return (

--- a/apps/webapp/app/routes/home.tasks.$taskId.coding._index.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.coding._index.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useOutletContext } from "@remix-run/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { CodingOutletContext } from "./home.tasks.$taskId.coding";
 
 export function lastSessionStorageKey(taskId: string): string {
@@ -9,9 +9,13 @@ export function lastSessionStorageKey(taskId: string): string {
 export default function CodingIndex() {
   const { sessions, taskId } = useOutletContext<CodingOutletContext>();
   const navigate = useNavigate();
+  // Guard so we only navigate once per mount, even if sessions reference
+  // changes due to a loader revalidation while this index is still rendered.
+  const didNavigate = useRef(false);
 
   useEffect(() => {
-    if (sessions.length === 0) return;
+    if (didNavigate.current || sessions.length === 0) return;
+    didNavigate.current = true;
 
     const stored =
       typeof window !== "undefined"

--- a/apps/webapp/app/routes/home.tasks.$taskId.coding.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.coding.tsx
@@ -6,6 +6,7 @@ import {
   useParams,
   useRevalidator,
 } from "@remix-run/react";
+import type { ShouldRevalidateFunctionArgs } from "@remix-run/react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { ClientOnly } from "remix-utils/client-only";
 import { useCallback, useEffect, useState } from "react";
@@ -27,6 +28,27 @@ export type CodingOutletContext = {
   updateSessionExternalId: (sessionDbId: string, externalId: string) => void;
   openNewSession: () => void;
 };
+
+// Skip revalidating when the user is just switching between sessions within
+// the same task — the session list hasn't changed. Forced revalidations via
+// useRevalidator (same currentUrl === nextUrl) still pass through.
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+}: ShouldRevalidateFunctionArgs) {
+  const re = /\/home\/tasks\/([^/]+)\/coding/;
+  const cur = currentUrl.pathname.match(re);
+  const nxt = nextUrl.pathname.match(re);
+  if (
+    cur &&
+    nxt &&
+    cur[1] === nxt[1] &&
+    currentUrl.pathname !== nextUrl.pathname
+  ) {
+    return false;
+  }
+  return true;
+}
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const user = await requireUser(request);
@@ -82,10 +104,15 @@ function CodingLayout() {
     useState<CodingSessionListItem[]>(initialSessions);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
 
-  // Keep local sessions state in sync when the loader revalidates (e.g. when
-  // navigating back into this route after creating sessions elsewhere).
+  // Keep local sessions state in sync when the loader revalidates. Preserve
+  // any optimistic inserts (e.g. a just-created session) that haven't yet
+  // appeared in the server response.
   useEffect(() => {
-    setSessions(initialSessions);
+    setSessions((prev) => {
+      const serverIds = new Set(initialSessions.map((s) => s.id));
+      const optimistic = prev.filter((s) => !serverIds.has(s.id));
+      return [...optimistic, ...initialSessions];
+    });
   }, [initialSessions]);
 
   const updateSessionExternalId = useCallback(
@@ -137,7 +164,9 @@ function CodingLayout() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Register actions in the PageHeader
+  // Register actions in the PageHeader. The cleanup is intentionally split
+  // into a separate effect so that updating sessions or sessionId doesn't
+  // null out the context and unmount the Sessions popover mid-interaction.
   useEffect(() => {
     setCodingActions({
       onNewSession: () => setNewSessionOpen(true),
@@ -151,9 +180,13 @@ function CodingLayout() {
       selectedId: sessionId ?? null,
       onSelectSession: (id) => navigate(`/home/tasks/${taskId}/coding/${id}`),
     });
-    return () => setCodingActions(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessions, sessionId, taskId]);
+
+  // Clear context only when the coding layout fully unmounts.
+  useEffect(() => {
+    return () => setCodingActions(null);
+  }, []);
 
   if (isDesktop && corebrainError) {
     return (


### PR DESCRIPTION
## Summary

- **Bug**: Selecting an older session from the Sessions popover in the Task → Coding tab always opened the latest session instead.
- Three interacting root causes identified and fixed across the Remix route files.

## Root Causes & Fixes

### 1. `coding._index.tsx` — redirector fired multiple times per mount
The index route had `sessions` in its `useEffect` dep array. With `v3_singleFetch: true` and no `shouldRevalidate`, every navigation triggers a layout loader re-run producing a new `sessions` array reference → effect re-fired while the index was still mounted during the loading transition → navigated to `sessions[0]` (latest), overriding the user's selection.

**Fix**: `useRef` guard (`didNavigate`) ensures the navigation fires at most once per mount.

### 2. `coding.tsx` — Sessions popover unmounted on every data change
The `setCodingActions` effect cleanup (`return () => setCodingActions(null)`) fired on every `sessions`/`sessionId` change, setting context to null → `CodingSessionsPopover` unmounted entirely (resetting `open = false`) mid-interaction.

**Fix**: Split into two effects — one for updating the context on data changes (no cleanup), one empty-dep effect for unmount-only cleanup. Also adds `shouldRevalidate` to skip redundant loader re-runs on session switches, and preserves optimistic session inserts when syncing from server.

### 3. `coding.$sessionId.tsx` — stale URL bounce fired during loading transitions
The bounce (`session === null → navigate to /coding`) could fire before the sessions list was stable during a loading transition, redirecting to the index which then picked `sessions[0]`.

**Fix**: Guard with `navigation.state !== "idle"` so the bounce only triggers after navigation fully commits.

## Test plan

- [ ] Navigate to a task with multiple coding sessions
- [ ] Open the Sessions popover and click an older (non-latest) session — should open that session
- [ ] Navigate away and back to the Coding tab — should resume the last-viewed session
- [ ] Create a new session — should navigate directly to the new session without bouncing

## Notes on typecheck / tests

`tsc` and the test runner could not be executed in this environment — `node_modules` are not installed in the worktree. No existing tests cover Remix route hook behaviour (the project's vitest suite covers pure service logic with a `node` environment and no jsdom/React Testing Library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)