### PR TITLE
fix: remove 50-transaction cap from YNAB list-transactions tools

### DIFF
--- a/integrations/ynab/package.json
+++ b/integrations/ynab/package.json
@@ -16,7 +16,9 @@
     "build": "rimraf bin && bun build src/index.ts --outfile dist/index.js --target node --minify",
     "lint": "eslint --ext js,ts,tsx src/ --fix",
     "prettier": "prettier --config .prettierrc --write .",
-    "register": "tsx scripts/register.ts"
+    "register": "tsx scripts/register.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "publishConfig": {
     "access": "public"
@@ -34,16 +36,15 @@
     ]
   },
   "dependencies": {
+    "@redplanethq/sdk": "0.1.9",
     "axios": "^1.7.9",
     "commander": "^12.0.0",
-    "@redplanethq/sdk": "0.1.9",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.1"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.26.0",
     "@types/node": "^18.0.20",
-    "pg": "^8.11.3",
     "@types/pg": "^8.10.9",
     "eslint": "^9.24.0",
     "eslint-config-prettier": "^10.1.2",
@@ -51,10 +52,12 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "pg": "^8.11.3",
     "prettier": "^3.4.2",
     "rimraf": "^3.0.2",
     "tslib": "^2.8.1",
     "tsx": "4.20.6",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.2",
+    "vitest": "^1.6.1"
   }
 }

--- a/integrations/ynab/src/mcp/__tests__/tools.test.ts
+++ b/integrations/ynab/src/mcp/__tests__/tools.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { callYnabTool } from '../tools';
+import type { AxiosInstance } from 'axios';
+
+function makeTransaction(i: number) {
+  return {
+    id: `tx-${i}`,
+    date: '2024-01-01',
+    amount: -10000 * i,
+    payee_name: `Payee ${i}`,
+    category_name: `Category ${i}`,
+    memo: `Memo ${i}`,
+    cleared: 'cleared',
+    approved: true,
+    account_name: 'Checking',
+  };
+}
+
+function makeMockClient(responseData: object): AxiosInstance {
+  return {
+    get: vi.fn().mockResolvedValue({ data: { data: responseData } }),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn(),
+  } as unknown as AxiosInstance;
+}
+
+describe('ynab_list_transactions - full pagination', () => {
+  it('returns all transactions when count exceeds 50', async () => {
+    const transactions = Array.from({ length: 100 }, (_, i) => makeTransaction(i + 1));
+    const client = makeMockClient({ transactions });
+
+    const result = await callYnabTool(
+      'ynab_list_transactions',
+      { budget_id: 'budget-1' },
+      client
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('Found 100 transactions');
+    expect(text).toContain('tx-100');
+    expect(text).not.toContain('showing up to 50');
+  });
+
+  it('returns all transactions when count is exactly 50', async () => {
+    const transactions = Array.from({ length: 50 }, (_, i) => makeTransaction(i + 1));
+    const client = makeMockClient({ transactions });
+
+    const result = await callYnabTool(
+      'ynab_list_transactions',
+      { budget_id: 'budget-1' },
+      client
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('tx-50');
+  });
+});
+
+describe('ynab_list_account_transactions - full pagination', () => {
+  it('returns all transactions when count exceeds 50', async () => {
+    const transactions = Array.from({ length: 75 }, (_, i) => makeTransaction(i + 1));
+    const client = makeMockClient({ transactions });
+
+    const result = await callYnabTool(
+      'ynab_list_account_transactions',
+      { budget_id: 'budget-1', account_id: 'account-1' },
+      client
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('Found 75 transactions');
+    expect(text).toContain('tx-75');
+  });
+});
+
+describe('ynab_list_category_transactions - full pagination', () => {
+  it('returns all transactions when count exceeds 50', async () => {
+    const transactions = Array.from({ length: 60 }, (_, i) => makeTransaction(i + 1));
+    const client = makeMockClient({ transactions });
+
+    const result = await callYnabTool(
+      'ynab_list_category_transactions',
+      { budget_id: 'budget-1', category_id: 'category-1' },
+      client
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('Found 60 transactions');
+    expect(text).toContain('tx-60');
+  });
+});
+
+describe('ynab_list_payee_transactions - full pagination', () => {
+  it('returns all transactions when count exceeds 50', async () => {
+    const transactions = Array.from({ length: 80 }, (_, i) => makeTransaction(i + 1));
+    const client = makeMockClient({ transactions });
+
+    const result = await callYnabTool(
+      'ynab_list_payee_transactions',
+      { budget_id: 'budget-1', payee_id: 'payee-1' },
+      client
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('Found 80 transactions');
+    expect(text).toContain('tx-80');
+  });
+});

--- a/integrations/ynab/src/mcp/tools.ts
+++ b/integrations/ynab/src/mcp/tools.ts
@@ -434,12 +434,11 @@ export async function callYnabTool(
         return { content: [{ type: 'text', text: 'No transactions found.' }] };
       }
       const list = transactions
-        .slice(0, 50)
         .map((t: any) => `ID: ${t.id} | Date: ${t.date} | Amount: ${formatMilliunits(t.amount)} | Payee: ${t.payee_name || 'N/A'} | Category: ${t.category_name || 'N/A'} | Memo: ${t.memo || ''}`)
         .join('\n');
       return {
         content: [
-          { type: 'text', text: `Found ${transactions.length} transactions (showing up to 50):\n\n${list}` },
+          { type: 'text', text: `Found ${transactions.length} transactions:\n\n${list}` },
         ],
       };
     }
@@ -496,7 +495,6 @@ export async function callYnabTool(
         return { content: [{ type: 'text', text: 'No transactions found for this account.' }] };
       }
       const list = transactions
-        .slice(0, 50)
         .map((t: any) => `ID: ${t.id} | Date: ${t.date} | Amount: ${formatMilliunits(t.amount)} | Payee: ${t.payee_name || 'N/A'} | Category: ${t.category_name || 'N/A'}`)
         .join('\n');
       return { content: [{ type: 'text', text: `Found ${transactions.length} transactions:\n\n${list}` }] };
@@ -512,7 +510,6 @@ export async function callYnabTool(
         return { content: [{ type: 'text', text: 'No transactions found for this category.' }] };
       }
       const list = transactions
-        .slice(0, 50)
         .map((t: any) => `ID: ${t.id} | Date: ${t.date} | Amount: ${formatMilliunits(t.amount)} | Payee: ${t.payee_name || 'N/A'}`)
         .join('\n');
       return { content: [{ type: 'text', text: `Found ${transactions.length} transactions:\n\n${list}` }] };
@@ -628,7 +625,6 @@ export async function callYnabTool(
         return { content: [{ type: 'text', text: 'No transactions found for this payee.' }] };
       }
       const list = transactions
-        .slice(0, 50)
         .map((t: any) => `ID: ${t.id} | Date: ${t.date} | Amount: ${formatMilliunits(t.amount)} | Category: ${t.category_name || 'N/A'} | Memo: ${t.memo || ''}`)
         .join('\n');
       return { content: [{ type: 'text', text: `Found ${transactions.length} transactions:\n\n${list}` }] };


### PR DESCRIPTION
## What
Removes the hard cap that truncated YNAB transaction listings to the first 50 results.

## Changes
- Removed `.slice(0, 50)` truncation from **4 YNAB MCP transaction listing tools**
- Added/updated Vitest coverage under `integrations/ynab/src/mcp/__tests__/tools.test.ts`

## Verification
- `npx vitest run`

## Notes
This ensures full transaction pagination is respected so downstream analyses are not silently incomplete.