### PR TITLE
fix(ghost): correctly create HTML posts using source=html

### DIFF
--- a/integrations/ghost/src/mcp/index.ts
+++ b/integrations/ghost/src/mcp/index.ts
@@ -264,7 +264,7 @@ export async function callTool(
         if (featured !== undefined) postData.featured = featured;
         if (custom_excerpt) postData.custom_excerpt = custom_excerpt;
 
-        const response = await ghostClient.post('/posts/', { posts: [postData] });
+        const response = await ghostClient.post('/posts/?source=html', { posts: [postData] });
         const p = response.data.posts[0];
 
         return {


### PR DESCRIPTION
## Summary

Fixes Ghost post creation for HTML-generated content by appending `?source=html` to the Ghost Admin API request.

## Current Issue

The Ghost integration currently generates post content in HTML format, but the Ghost Admin API expects HTML content requests to explicitly include the `source=html` query parameter.

Without this parameter, Ghost fails to correctly process the HTML content during post creation.

## Expected Behavior

HTML-generated content should be successfully created as Ghost posts when sent through the integration.

## Proposed Fix

Append `?source=html` to the Ghost Admin API post creation request whenever HTML content is generated.

## Validation

* Reproduced issue locally
* Verified failure without `?source=html`
* Verified successful post creation after applying fix
* Cross-checked with Ghost Admin API documentation

## Reference

https://docs.ghost.org/admin-api/posts/creating-a-post
<img width="803" height="529" alt="Screenshot 2026-05-15 at 6 26 25 PM" src="https://github.com/user-attachments/assets/04a6a043-ad6f-4457-8131-b298c8c00688" />

## Demo

https://github.com/user-attachments/assets/4c298d06-37f2-4060-a4a7-002ad2a8521a


Fixes #651