### PR TITLE
fix(api-keys): correctly delete selected API key

### DIFF
--- a/apps/webapp/app/components/api/columns.tsx
+++ b/apps/webapp/app/components/api/columns.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui";
 
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -12,7 +13,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "~/components/ui/dialog";
-import React from "react";
 import { Trash } from "lucide-react";
 
 export interface PersonalAccessToken {
@@ -25,11 +25,9 @@ export interface PersonalAccessToken {
 
 export const useTokensColumns = (): Array<ColumnDef<PersonalAccessToken>> => {
   const fetcher = useFetcher();
-  const [open, setOpen] = React.useState(false);
 
   const onDelete = (id: string) => {
     fetcher.submit({ id }, { method: "DELETE", action: "/settings/api" });
-    setOpen(false);
   };
 
   return [
@@ -81,7 +79,7 @@ export const useTokensColumns = (): Array<ColumnDef<PersonalAccessToken>> => {
       },
       cell: ({ row }) => {
         return (
-          <Dialog onOpenChange={setOpen} open={open}>
+          <Dialog>
             <DialogTrigger asChild>
               <Button variant="ghost">
                 <Trash size={14} />
@@ -96,20 +94,17 @@ export const useTokensColumns = (): Array<ColumnDef<PersonalAccessToken>> => {
                 </DialogDescription>
               </DialogHeader>
               <DialogFooter>
-                <Button
-                  variant="ghost"
-                  onClick={() => {
-                    setOpen(false);
-                  }}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive"
-                  onClick={() => onDelete(row.original.id)}
-                >
-                  Delete
-                </Button>
+                <DialogClose asChild>
+                  <Button variant="ghost">Cancel</Button>
+                </DialogClose>
+                <DialogClose asChild>
+                  <Button
+                    variant="destructive"
+                    onClick={() => onDelete(row.original.id)}
+                  >
+                    Delete
+                  </Button>
+                </DialogClose>
               </DialogFooter>
             </DialogContent>
           </Dialog>


### PR DESCRIPTION
## Summary

Fixes API key deletion incorrectly targeting the last key in the list instead of the selected key.

## Current Issue

In `useTokensColumns`, a shared `open` / `setOpen` state was declared at the hook level and reused across all row dialogs.

When the delete action was triggered for any API key, `setOpen(true)` caused every row dialog to open simultaneously. Due to dialog portal stacking behavior, only the last dialog instance remained visible, causing the delete confirmation to always submit the last token's ID regardless of which row was selected.

## Expected Behavior

Clicking delete on an API key should open a confirmation dialog only for the selected row, and confirming the action should delete only that specific key.

## Proposed Fix

* Removed the shared `open` / `setOpen` state from `useTokensColumns`
* Removed `open={open}` and `onOpenChange={setOpen}` from `<Dialog>`
* Allowed each dialog instance to manage its own visibility independently
* Replaced manual `setOpen(false)` calls with `DialogClose`

## Validation

* Reproduced the issue locally - deleting any key always removed the last key
* Verified each row dialog now opens independently
* Verified delete action correctly targets the selected API key
* Verified Cancel closes the dialog without triggering deletion

## Demo

https://github.com/user-attachments/assets/86a124a7-e740-44a2-bf9c-96e9aa9984e1

Fixes #389