### PR TITLE
feat: direct browser↔gateway xterm via short-lived HMAC tickets

### DIFF
--- a/apps/webapp/app/components/coding/gateway-terminal.tsx
+++ b/apps/webapp/app/components/coding/gateway-terminal.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useRef, useState } from "react";
 import { Loader2, AlertCircle, CheckCircle2 } from "lucide-react";
 import { Button } from "~/components/ui/button";
+import { requestCodingSessionXtermWsUrl } from "~/lib/xterm-ws.client";
 import { terminalThemes } from "./terminal-themes";
 import "@xterm/xterm/css/xterm.css";
 
 type TerminalState = "connecting" | "running" | "ended" | "error";
 
 interface Props {
-  /** CodingSession.id in CORE's DB. The webapp resolves it to the gateway +
-   *  externalSessionId and proxies the WS. */
+  /** CodingSession.id in CORE's DB. The webapp's /xterm-ticket endpoint
+   *  resolves it to the gateway + externalSessionId and either signs a
+   *  direct-attach ticket or returns the proxy URL. */
   codingSessionId: string;
   onNewSession?: () => void;
   /** Resume the same session (re-spawns the agent with `--resume <id>` on the
@@ -38,13 +40,6 @@ function useHtmlTheme(): "dark" | "light" {
   }, []);
 
   return theme;
-}
-
-function buildXtermUrl(codingSessionId: string): string {
-  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${proto}//${window.location.host}/api/v1/coding-sessions/${encodeURIComponent(
-    codingSessionId,
-  )}/xterm`;
 }
 
 export function GatewayTerminal({
@@ -143,8 +138,23 @@ export function GatewayTerminal({
       term.focus();
       termRef.current = term;
 
-      // ── WebSocket to webapp proxy ─────────────────────────────────────
-      const ws = new WebSocket(buildXtermUrl(codingSessionId));
+      // Resolve the WS URL via /xterm-ticket. Capable gateways return a
+      // direct wss:// URL (browser → gateway, no webapp hop); older or
+      // http-only gateways return the existing webapp proxy path.
+      let wsUrl: string;
+      try {
+        wsUrl = await requestCodingSessionXtermWsUrl(codingSessionId);
+      } catch (err) {
+        if (!mounted) return;
+        setErrorMsg(
+          err instanceof Error ? err.message : "Failed to open terminal",
+        );
+        setStatusBoth("error");
+        return;
+      }
+      if (!mounted) return;
+
+      const ws = new WebSocket(wsUrl);
       localWs = ws;
       wsRef.current = ws;
 

--- a/apps/webapp/app/components/gateway/xterm-pane.tsx
+++ b/apps/webapp/app/components/gateway/xterm-pane.tsx
@@ -370,12 +370,3 @@ export function XtermPane({
   );
 }
 
-export function buildGatewayXtermUrl(
-  gatewayId: string,
-  externalSessionId: string,
-): string {
-  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${proto}//${window.location.host}/api/v1/gateways/${encodeURIComponent(
-    gatewayId,
-  )}/xterm?session_id=${encodeURIComponent(externalSessionId)}`;
-}

--- a/apps/webapp/app/lib/xterm-ws.client.ts
+++ b/apps/webapp/app/lib/xterm-ws.client.ts
@@ -1,0 +1,75 @@
+/**
+ * Browser-side helpers for resolving the xterm WebSocket URL via the
+ * `/xterm-ticket` endpoints. The response is one of:
+ *
+ *   { mode: "direct", wsUrl: "wss://gw.host/…?ticket=…", expiresAt }
+ *   { mode: "proxy",  wsUrl: "/api/v1/…/xterm…" }
+ *
+ * Direct URLs are already absolute; proxy URLs are relative paths and need
+ * the page's host + scheme prepended.
+ */
+
+interface TicketResponse {
+  mode: "direct" | "proxy";
+  wsUrl: string;
+  expiresAt?: number;
+}
+
+function resolveWsUrl(raw: string): string {
+  if (/^wss?:\/\//i.test(raw)) return raw;
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  // Tolerate a leading-slashless path just in case ("api/...").
+  const path = raw.startsWith("/") ? raw : `/${raw}`;
+  return `${proto}//${window.location.host}${path}`;
+}
+
+async function requestTicket(
+  endpoint: string,
+  body: Record<string, unknown>,
+): Promise<string> {
+  const res = await fetch(endpoint, {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `xterm-ticket ${res.status}: ${text || res.statusText}`.trim(),
+    );
+  }
+  const data = (await res.json()) as TicketResponse;
+  if (typeof data?.wsUrl !== "string" || !data.wsUrl) {
+    throw new Error("xterm-ticket: response missing wsUrl");
+  }
+  return resolveWsUrl(data.wsUrl);
+}
+
+/**
+ * Resolve a WebSocket URL for an xterm attach to a *gateway-direct* session
+ * (per-gateway Terminal tab, agent-login dialog). `sessionId` is the
+ * gateway's external session id (the one the PTY is keyed by).
+ */
+export function requestGatewayXtermWsUrl(
+  gatewayId: string,
+  sessionId: string,
+): Promise<string> {
+  return requestTicket(
+    `/api/v1/gateways/${encodeURIComponent(gatewayId)}/xterm-ticket`,
+    { session_id: sessionId },
+  );
+}
+
+/**
+ * Resolve a WebSocket URL for an xterm attach bound to a CodingSession row.
+ * The webapp looks up the row's gateway + externalSessionId server-side.
+ */
+export function requestCodingSessionXtermWsUrl(
+  codingSessionId: string,
+): Promise<string> {
+  return requestTicket(
+    `/api/v1/coding-sessions/${encodeURIComponent(codingSessionId)}/xterm-ticket`,
+    {},
+  );
+}

--- a/apps/webapp/app/routes/api.v1.coding-sessions.$codingSessionId.xterm-ticket.tsx
+++ b/apps/webapp/app/routes/api.v1.coding-sessions.$codingSessionId.xterm-ticket.tsx
@@ -1,0 +1,96 @@
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { createHash, createHmac } from "node:crypto";
+import { prisma } from "~/db.server";
+import { requireUser } from "~/services/session.server";
+import { readSecurityKey } from "~/services/gateway/secrets.server";
+import { fetchManifest } from "~/services/gateway/transport.server";
+
+/**
+ * POST /api/v1/coding-sessions/:codingSessionId/xterm-ticket
+ *
+ * CodingSession-bound twin of /api/v1/gateways/:gatewayId/xterm-ticket: the
+ * caller (the per-task coding UI) only knows the CodingSession.id; this
+ * endpoint resolves it to (gateway, externalSessionId), then either signs a
+ * direct-attach ticket or returns the existing webapp proxy URL.
+ *
+ * See the gateway-variant route for the ticket format and rationale.
+ */
+
+const TICKET_TTL_MS = 5 * 60 * 1000;
+
+interface ManifestCapabilities {
+  directXterm?: boolean;
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const { codingSessionId } = params;
+  if (!codingSessionId) {
+    return json({ error: "Missing codingSessionId" }, { status: 400 });
+  }
+
+  const user = await requireUser(request);
+
+  // Workspace membership check via the CodingSession relation — mirrors the
+  // resolveSession() logic in xterm-proxy.server.ts so a tenant can't issue
+  // tickets for a gateway they don't own.
+  const cs = await prisma.codingSession.findFirst({
+    where: {
+      id: codingSessionId,
+      workspace: { UserWorkspace: { some: { userId: user.id } } },
+    },
+    select: {
+      externalSessionId: true,
+      gateway: { select: { id: true, baseUrl: true } },
+    },
+  });
+  if (!cs) return json({ error: "Not found" }, { status: 404 });
+  if (!cs.externalSessionId) {
+    return json({ error: "Session has no externalSessionId" }, { status: 422 });
+  }
+  if (!cs.gateway?.baseUrl) {
+    return json({ error: "No gateway linked" }, { status: 422 });
+  }
+  const externalSessionId = cs.externalSessionId;
+  const gw = cs.gateway;
+
+  const fetched = await fetchManifest(gw.id, 5_000);
+  const caps = fetched?.manifest.capabilities as
+    | ManifestCapabilities
+    | undefined;
+  const supportsDirect = caps?.directXterm === true;
+  // Full `https://` prefix — `/^https:/i` would also match `https:foo`.
+  const baseUrlIsHttps = /^https:\/\//i.test(gw.baseUrl);
+
+  const proxyResponse = json({
+    mode: "proxy" as const,
+    wsUrl: `/api/v1/coding-sessions/${encodeURIComponent(codingSessionId)}/xterm`,
+  });
+  if (!supportsDirect || !baseUrlIsHttps) return proxyResponse;
+
+  // If the encrypted key is missing or corrupt we can't sign — fall back
+  // to the proxy path instead of 500'ing the terminal open.
+  let securityKey: string;
+  try {
+    securityKey = await readSecurityKey(gw.id);
+  } catch {
+    return proxyResponse;
+  }
+  const hmacKey = createHash("sha256").update(securityKey).digest("hex");
+  const exp = Date.now() + TICKET_TTL_MS;
+  const payload = Buffer.from(
+    JSON.stringify({ sid: externalSessionId, exp }),
+    "utf8",
+  ).toString("base64url");
+  const sig = createHmac("sha256", hmacKey).update(payload).digest("base64url");
+  const ticket = `${payload}.${sig}`;
+
+  const wsBase = gw.baseUrl.replace(/^http/i, "ws").replace(/\/$/, "");
+  const wsUrl = `${wsBase}/api/coding/coding_xterm_session?session_id=${encodeURIComponent(
+    externalSessionId,
+  )}&ticket=${encodeURIComponent(ticket)}`;
+
+  return json({ mode: "direct" as const, wsUrl, expiresAt: exp });
+}

--- a/apps/webapp/app/routes/api.v1.gateways.$gatewayId.xterm-ticket.tsx
+++ b/apps/webapp/app/routes/api.v1.gateways.$gatewayId.xterm-ticket.tsx
@@ -1,0 +1,112 @@
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { createHash, createHmac } from "node:crypto";
+import { z } from "zod";
+import { prisma } from "~/db.server";
+import { requireUser, getWorkspaceId } from "~/services/session.server";
+import { readSecurityKey } from "~/services/gateway/secrets.server";
+import { fetchManifest } from "~/services/gateway/transport.server";
+
+/**
+ * POST /api/v1/gateways/:gatewayId/xterm-ticket
+ * body: { session_id }
+ *
+ * Returns a WebSocket URL the browser should connect to in order to attach
+ * to the gateway's xterm PTY for `session_id`.
+ *
+ *   { mode: "direct", wsUrl: "wss://<gw.baseUrl>/…?ticket=…", expiresAt }
+ *   { mode: "proxy",  wsUrl: "/api/v1/gateways/<id>/xterm?session_id=…" }
+ *
+ * Direct mode is offered only when the gateway advertises
+ * `capabilities.directXterm` in its manifest (i.e. it's running a CLI
+ * version that knows how to verify HMAC tickets). Older gateways and
+ * gateways with the coding slot disabled fall back to the proxy path the
+ * webapp has always supported — same wire protocol, just one extra hop.
+ *
+ * The ticket is HMAC-SHA256(sha256(rawSecurityKey), payload) where
+ * payload = base64url(JSON({sid, exp})). The gateway holds
+ * sha256(rawSecurityKey) on disk (`securityKeyHash`), so both sides arrive
+ * at the same MAC key without sharing a separate secret. TTL is 5 minutes
+ * — enough time for the browser to actually open the WS but short enough
+ * that a leaked URL is uninteresting.
+ */
+
+const Body = z.object({
+  session_id: z.string().min(1),
+});
+
+const TICKET_TTL_MS = 5 * 60 * 1000;
+
+interface ManifestCapabilities {
+  directXterm?: boolean;
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const { gatewayId } = params;
+  if (!gatewayId) return json({ error: "Missing gatewayId" }, { status: 400 });
+
+  const user = await requireUser(request);
+  const workspaceId = (await getWorkspaceId(
+    request,
+    user.id,
+    user.workspaceId,
+  )) as string;
+
+  const gw = await prisma.gateway.findFirst({
+    where: { id: gatewayId, workspaceId },
+    select: { id: true, baseUrl: true },
+  });
+  if (!gw) return json({ error: "Gateway not found" }, { status: 404 });
+
+  const raw = await request.json().catch(() => ({}));
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return json({ error: parsed.error.message }, { status: 400 });
+  }
+  const sessionId = parsed.data.session_id;
+
+  const fetched = await fetchManifest(gw.id, 5_000);
+  const caps = fetched?.manifest.capabilities as
+    | ManifestCapabilities
+    | undefined;
+  const supportsDirect = caps?.directXterm === true;
+
+  // Browser can't open `ws://` from an `https://` page (mixed content).
+  // If the gateway is plain http, fall back to the proxy even if the
+  // gateway itself supports tickets — the webapp's WS endpoint inherits
+  // the page's TLS context. Match the full `https://` prefix so a
+  // malformed `https:foo` doesn't slip past.
+  const baseUrlIsHttps = /^https:\/\//i.test(gw.baseUrl);
+
+  const proxyResponse = json({
+    mode: "proxy" as const,
+    wsUrl: `/api/v1/gateways/${gw.id}/xterm?session_id=${encodeURIComponent(sessionId)}`,
+  });
+  if (!supportsDirect || !baseUrlIsHttps) return proxyResponse;
+
+  // If the encrypted key is missing or corrupt we can't sign — fall back
+  // to the proxy path instead of 500'ing the terminal open.
+  let securityKey: string;
+  try {
+    securityKey = await readSecurityKey(gw.id);
+  } catch {
+    return proxyResponse;
+  }
+  const hmacKey = createHash("sha256").update(securityKey).digest("hex");
+  const exp = Date.now() + TICKET_TTL_MS;
+  const payload = Buffer.from(
+    JSON.stringify({ sid: sessionId, exp }),
+    "utf8",
+  ).toString("base64url");
+  const sig = createHmac("sha256", hmacKey).update(payload).digest("base64url");
+  const ticket = `${payload}.${sig}`;
+
+  const wsBase = gw.baseUrl.replace(/^http/i, "ws").replace(/\/$/, "");
+  const wsUrl = `${wsBase}/api/coding/coding_xterm_session?session_id=${encodeURIComponent(
+    sessionId,
+  )}&ticket=${encodeURIComponent(ticket)}`;
+
+  return json({ mode: "direct" as const, wsUrl, expiresAt: exp });
+}

--- a/apps/webapp/app/routes/home.gateways.$gatewayId.terminal.tsx
+++ b/apps/webapp/app/routes/home.gateways.$gatewayId.terminal.tsx
@@ -1,9 +1,8 @@
+import { useEffect, useState } from "react";
 import { Loader2, RefreshCcw } from "lucide-react";
 import { Button } from "~/components/ui/button";
-import {
-  XtermPane,
-  buildGatewayXtermUrl,
-} from "~/components/gateway/xterm-pane";
+import { XtermPane } from "~/components/gateway/xterm-pane";
+import { requestGatewayXtermWsUrl } from "~/lib/xterm-ws.client";
 import {
   useGateway,
   useGatewayShell,
@@ -16,10 +15,41 @@ import {
  * and back) comes from the gateway's `ptyManager`: the PTY stays alive
  * while the gateway process runs, and `attach()` replays its 256 KB
  * scrollback on every WS reconnect (see `coding_xterm_session.ts`).
+ *
+ * The WS URL is fetched via /xterm-ticket so capable gateways get a direct
+ * browser↔gateway connection; older/http gateways transparently fall back
+ * to the webapp proxy path.
  */
 export default function GatewayTerminalTab() {
   const ctx = useGateway();
   const { sessionId, loading, error, openShell } = useGatewayShell();
+
+  const [wsUrl, setWsUrl] = useState<string | null>(null);
+  const [wsError, setWsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setWsUrl(null);
+      setWsError(null);
+      return;
+    }
+    let cancelled = false;
+    setWsUrl(null);
+    setWsError(null);
+    requestGatewayXtermWsUrl(ctx.id, sessionId)
+      .then((url) => {
+        if (!cancelled) setWsUrl(url);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setWsError(
+          err instanceof Error ? err.message : "Failed to open terminal",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ctx.id, sessionId]);
 
   if (loading && !sessionId) {
     return (
@@ -30,10 +60,12 @@ export default function GatewayTerminalTab() {
     );
   }
 
-  if (error) {
+  if (error || wsError) {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-3 text-sm">
-        <p className="text-destructive max-w-md text-center">{error}</p>
+        <p className="text-destructive max-w-md text-center">
+          {error ?? wsError}
+        </p>
         <Button
           variant="secondary"
           size="sm"
@@ -47,13 +79,20 @@ export default function GatewayTerminalTab() {
     );
   }
 
-  if (!sessionId) return null;
+  if (!sessionId || !wsUrl) {
+    return (
+      <div className="text-muted-foreground flex h-full w-full items-center justify-center gap-2 text-sm">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Opening terminal…
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full w-full flex-1 overflow-hidden">
       <XtermPane
         key={sessionId}
-        wsUrl={buildGatewayXtermUrl(ctx.id, sessionId)}
+        wsUrl={wsUrl}
         endedAction={{
           label: "Start new shell",
           onClick: () => openShell(true),

--- a/packages/cli/src/server/api/auth.ts
+++ b/packages/cli/src/server/api/auth.ts
@@ -1,4 +1,4 @@
-import {createHash, timingSafeEqual, randomBytes} from 'node:crypto';
+import {createHash, createHmac, timingSafeEqual, randomBytes} from 'node:crypto';
 import type {FastifyRequest, FastifyReply} from 'fastify';
 import {getPreferences} from '@/config/preferences';
 
@@ -31,13 +31,96 @@ export function extractBearer(header: string | undefined): string | null {
 }
 
 /**
+ * Verify a short-lived xterm WS ticket. Ticket format:
+ *
+ *   base64url(JSON({sid, exp})) "." base64url(HMAC-SHA256(hmacKey, payload))
+ *
+ * `hmacKey` is the gateway's stored `securityKeyHash` (hex string of
+ * sha256(rawKey)) — the webapp recomputes the same value from the raw key it
+ * decrypted from its DB, so both sides arrive at the same MAC key without
+ * having to share a separate secret.
+ *
+ * The ticket is bound to a single PTY: the caller must pass the `session_id`
+ * the WS is attaching to so we can reject tickets minted for a different
+ * session. Expiry is checked with a small (+5s) skew tolerance.
+ */
+export function verifyTicket(
+	rawTicket: string | undefined,
+	sessionId: string,
+): boolean {
+	if (!rawTicket || !sessionId) return false;
+	const hmacKey = getPreferences().gateway?.securityKeyHash;
+	if (!hmacKey) return false;
+
+	const dot = rawTicket.indexOf('.');
+	if (dot <= 0 || dot === rawTicket.length - 1) return false;
+	const payloadB64 = rawTicket.slice(0, dot);
+	const sigB64 = rawTicket.slice(dot + 1);
+
+	const expected = createHmac('sha256', hmacKey).update(payloadB64).digest();
+	let provided: Buffer;
+	try {
+		provided = Buffer.from(sigB64, 'base64url');
+	} catch {
+		return false;
+	}
+	if (provided.length !== expected.length) return false;
+	if (!timingSafeEqual(provided, expected)) return false;
+
+	let payload: {sid?: unknown; exp?: unknown};
+	try {
+		payload = JSON.parse(
+			Buffer.from(payloadB64, 'base64url').toString('utf8'),
+		) as typeof payload;
+	} catch {
+		return false;
+	}
+	if (typeof payload.sid !== 'string' || typeof payload.exp !== 'number') {
+		return false;
+	}
+	if (payload.sid !== sessionId) return false;
+	// 5s skew tolerance for clock drift between webapp and gateway hosts.
+	if (payload.exp + 5_000 < Date.now()) return false;
+
+	return true;
+}
+
+/**
+ * Paths where `?ticket=…` is accepted in lieu of `Authorization: Bearer`.
+ * Kept tiny and explicit — the ticket auth path is only for browser-direct
+ * WebSocket attaches; every other route still requires the full security key.
+ */
+const TICKET_PATHS: ReadonlySet<string> = new Set([
+	'/api/coding/coding_xterm_session',
+]);
+
+/**
  * Fastify onRequest hook. Skips authentication for paths in `skip`
- * (e.g. `/healthz/public`). Every other request must present a valid Bearer
- * securityKey — there is no loopback bypass.
+ * (e.g. `/healthz/public`). On `TICKET_PATHS` requests may authenticate
+ * via `?ticket=…&session_id=…`; every other request must present a valid
+ * Bearer securityKey — there is no loopback bypass.
  */
 export function makeAuthHook(skip: string[] = ['/healthz/public']) {
 	return async function authHook(req: FastifyRequest, reply: FastifyReply) {
 		if (skip.some((s) => req.url === s || req.url.startsWith(s + '?'))) return;
+
+		// Ticket auth for the browser-direct xterm WS. A request that targets
+		// a TICKET_PATH and supplies `?ticket=…` is verified via HMAC instead
+		// of Bearer — the browser never sees the gateway's raw securityKey.
+		const pathOnly = req.url.split('?')[0] ?? req.url;
+		if (TICKET_PATHS.has(pathOnly)) {
+			const q = req.query as {ticket?: string; session_id?: string} | undefined;
+			if (q?.ticket) {
+				if (verifyTicket(q.ticket, q.session_id ?? '')) return;
+				reply.code(401).send({
+					ok: false,
+					error: {code: 'UNAUTHORIZED', message: 'invalid or expired ticket'},
+				});
+				return;
+			}
+			// no ticket present → fall through to Bearer (legacy webapp proxy path)
+		}
+
 		const token = extractBearer(req.headers['authorization']);
 		if (!verifySecurityKey(token ?? undefined)) {
 			reply.code(401).send({ok: false, error: {code: 'UNAUTHORIZED', message: 'invalid or missing security key'}});

--- a/packages/cli/src/server/api/manifest-builder.ts
+++ b/packages/cli/src/server/api/manifest-builder.ts
@@ -191,6 +191,10 @@ export function buildManifest(): {manifest: Manifest; etag: string} {
 				enabled: isSlotEnabled(slots, 'browser'),
 				engines: ['chromium'],
 			},
+			// Browser-direct xterm via HMAC tickets is available whenever the
+			// coding slot is on (that's where the xterm WS route lives). When
+			// off, the webapp falls back to its proxy path.
+			directXterm: isSlotEnabled(slots, 'coding'),
 		},
 		folders: listFolders(),
 		tools,

--- a/packages/gateway-protocol/src/manifest.ts
+++ b/packages/gateway-protocol/src/manifest.ts
@@ -44,6 +44,13 @@ export const Manifest = z.object({
   }),
   capabilities: z.object({
     browser: z.object({ enabled: z.boolean(), engines: z.array(z.string()).optional() }),
+    /**
+     * Whether the gateway accepts short-lived HMAC tickets on its xterm
+     * WebSocket so the browser can connect directly without proxying through
+     * the webapp. Omitted on older gateways — webapp must fall back to the
+     * proxy path in that case.
+     */
+    directXterm: z.boolean().optional(),
   }),
   folders: z.array(Folder),
   tools: z.array(GatewayTool),


### PR DESCRIPTION
## Summary

- Browser opens the xterm WebSocket directly to the gateway when supported, skipping the webapp WS proxy hop and reducing latency.
- Webapp signs a 5-minute HMAC ticket scoped to one PTY (key = `sha256(rawSecurityKey)` = the gateway's existing `securityKeyHash`); gateway verifies on the WS upgrade. No new secret introduced, no new on-disk state.
- Older gateways (no `directXterm` capability in manifest) and http-only `baseUrl`s transparently fall back to the existing proxy path. No coordinated rollout needed.

## How it works

```
Browser flow:
  browser → webapp /xterm-ticket   (cookie auth)
         ← { wsUrl }                # direct: wss://gw/…?ticket=…
                                    # proxy:  /api/v1/.../xterm
  browser → wsUrl                   # direct: gateway verifies ticket
                                    # proxy:  webapp proxies as before

CLI / programmatic flow:
  client → gateway WS               # Bearer auth, unchanged
```

Two ticket-issuing endpoints, one per existing proxy path:

| Endpoint | Caller has | Body |
|---|---|---|
| `POST /api/v1/gateways/:gatewayId/xterm-ticket` | `gatewayId` + a `session_id` (gateway PTY id) | `{ session_id }` |
| `POST /api/v1/coding-sessions/:codingSessionId/xterm-ticket` | only a CORE DB row id | `{}` (webapp resolves) |

Both return either `{ mode: "direct", wsUrl, expiresAt }` or `{ mode: "proxy", wsUrl }`.

## Why this design

- No replay-prevention (no `jti` dedup map). Matches what code-server / ttyd / Cloud Shell do: a replayed ticket only re-attaches to a PTY the attacker would already need the `session_id` for. Key rotation is the escape hatch.
- Gateway never gets a URL-issuing endpoint — only the webapp has the raw key needed to sign. Keeps the "hash-only on disk" property of the gateway.
- Ticket-auth is only accepted on `/api/coding/coding_xterm_session`; every other gateway route still requires `Authorization: Bearer`.

## Files

**Gateway (`packages/`)**
- `gateway-protocol/src/manifest.ts` — adds `capabilities.directXterm?: boolean`
- `cli/src/server/api/auth.ts` — `verifyTicket()` + ticket-eligible path whitelist in the auth hook
- `cli/src/server/api/manifest-builder.ts` — advertises `directXterm` when coding slot is on

**Webapp (`apps/webapp/`)**
- `app/routes/api.v1.gateways.$gatewayId.xterm-ticket.tsx` — gateway-direct ticket
- `app/routes/api.v1.coding-sessions.$codingSessionId.xterm-ticket.tsx` — CodingSession-bound ticket
- `app/lib/xterm-ws.client.ts` — browser helper that calls the ticket endpoint and resolves relative proxy URLs to `wss://${location.host}…`
- `app/components/coding/gateway-terminal.tsx`, `app/components/gateway/xterm-pane.tsx`, `app/routes/home.gateways.$gatewayId.terminal.tsx` — wire UI to the new helper

## Test plan

- [ ] **New webapp + new gateway over HTTPS** → terminal opens with direct WS (DevTools network: WS connects to gateway host, not webapp host); xterm input/output round-trips correctly.
- [ ] **New webapp + new gateway over plain HTTP** → falls back to proxy (no mixed-content errors); terminal still works.
- [ ] **New webapp + old gateway (no `directXterm` capability in manifest)** → falls back to proxy path; terminal still works.
- [ ] **CLI / programmatic clients hitting `/api/coding/coding_xterm_session` with `Authorization: Bearer …`** → still authenticated as before.
- [ ] **Per-gateway Terminal tab** (`/home/gateways/:id/terminal`) — open, type, exit; "Start new shell" reopens cleanly.
- [ ] **Per-task coding session** (`/home/tasks/:id/coding/:sessionId`) — open, resume session, new session.
- [ ] **Ticket TTL** — leave the page idle for >5 min then reopen; new ticket is fetched on remount.
- [ ] **Invalid ticket** (e.g. tamper with `?ticket=` query) → gateway returns 401 on WS upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)