### PR TITLE
docs: improve README clarity 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You decide where it acts on its own and where it waits for your call. Handle Sen
 
 A chatbot has one interface. An OS has many.
 
-**Voice.** Press Ctrl+Option on Mac and say what needs doing. CORE creates the task and starts running it in the background before you put your phone down.
+**Voice.** Press Ctrl+Option on Mac and say what needs doing. CORE runs it in the background without breaking your flow.
 
 **Scratchpad.** Open your daily page and write `[ ] Fix the auth bug from issue #47`. CORE picks it up within 3 minutes, loads context from your repo and memory, and drafts a plan.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 # Your personal AI OS.
 
-**Run Your OS.** Watches your work. Remembers what matters. Acts across your tools and agents. Open source, self-hosted, yours forever.
+Watches your work. Remembers what matters. Acts across your tools and agents — then brings you back only when judgment is needed. Open source, self-hosted, yours forever.
 
 <p align="center">
     <a href="https://getcore.me">
@@ -50,6 +50,12 @@
     <a href="https://github.com/RedPlanetHQ/core/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-AGPL%203.0-blue?style=for-the-badge" alt="License: AGPL 3.0" />
     </a>
+    <a href="https://news.ycombinator.com/item?id=43986085">
+        <img src="https://img.shields.io/badge/Y%20Combinator-S23-F26522?style=for-the-badge&logo=ycombinator&logoColor=white" alt="YC S23" />
+    </a>
+    <a href="https://github.com/RedPlanetHQ/core/stargazers">
+        <img src="https://img.shields.io/github/stars/RedPlanetHQ/core?style=for-the-badge&color=gold&logo=github" alt="GitHub Stars" />
+    </a>
 </p>
 </div>
 
@@ -57,7 +63,7 @@
 
 ## See it work
 
-Watch CORE handle two coding tasks end to end:
+Watch CORE take a plain-text task, gather context from GitHub and memory, plan the work, run a Claude Code session, and open a PR — without you touching anything:
 
 [![CORE Demo](https://img.youtube.com/vi/7y_kt_UTYQs/maxresdefault.jpg)](https://www.youtube.com/watch?v=7y_kt_UTYQs)
 
@@ -122,9 +128,23 @@ Create tasks from Slack, WhatsApp, Telegram, email, or web. The gateway keeps ru
 | **Tasks** | One-shot or recurring work units with your spec, CORE's plan, live state, and a dedicated chat thread. Each task can spawn coding or browser sessions. |
 | **Scratchpad** | A daily page for tasks, ideas, and work in progress. Type `[ ]` anywhere and CORE picks it up within 3 minutes. |
 | **Connectors** | 50+ apps through one MCP endpoint, plus webhook triggers for proactive automation. GitHub, Linear, Jira, Slack, Gmail, Calendar, Sentry, Granola, Todoist, and more. |
-| **Skills** | 100+ reusable instructions applied automatically based on context. Use built-in skills or write your own for repeatable workflows. |
+| **Skills** | Reusable instructions that fire automatically based on context. For example: "always pull related Linear issues before planning a fix," "run tests before opening a PR," or "post a Slack summary when a task completes." 100+ built-in, or write your own. |
 | **Gateway** | Runs Claude Code, Codex, browser agents, and local commands on your machine or in Docker / Railway, so CORE keeps working when your laptop is closed. |
 | **Model agnostic** | Bring your own provider: Anthropic, OpenAI, or open-weight models. Self-host the full stack for isolation. |
+
+---
+
+## How CORE compares
+
+| | CORE | Devin / Copilot Workspace | Zapier / n8n | Mem / Notion AI |
+|---|:---:|:---:|:---:|:---:|
+| Delegates full tasks to coding agents | ✅ | ✅ | ❌ | ❌ |
+| Persistent memory across tasks | ✅ | ❌ | ❌ | Partial |
+| 50+ app connectors | ✅ | ❌ | ✅ | ❌ |
+| Human-in-loop by default | ✅ | ❌ | ❌ | N/A |
+| Open source and self-hostable | ✅ | ❌ | Partial | ❌ |
+| Works from plain-language task descriptions | ✅ | Partial | ❌ | Partial |
+| Runs while your laptop is closed | ✅ | ✅ | ✅ | ❌ |
 
 ---
 
@@ -142,6 +162,14 @@ Create tasks from Slack, WhatsApp, Telegram, email, or web. The gateway keeps ru
 ## Quickstart
 
 Open source and self-hosted. Your data stays in your infrastructure.
+
+**Choose your path:**
+
+| I want to… | How |
+|---|---|
+| Try it on my machine | Run the one-step install below (requires Docker) |
+| Deploy on a server or VPS | One-click Railway deploy |
+| Use a Mac app | [Join the waitlist →](https://www.getcore.me/) |
 
 **Install and start CORE:**
 
@@ -168,13 +196,20 @@ corebrain gateway setup
 
 [Full self-hosting guide](https://docs.getcore.me/self-hosting/setup)
 
-> Want the Mac app? Join the waitlist at [getcore.me](https://www.getcore.me/).
+**Your first task (2 minutes after setup):**
+
+1. Open the **Scratchpad** — your daily page at `http://localhost:3033`
+2. Type `[ ] Summarize my open GitHub issues` — or any task you'd normally do yourself
+3. CORE picks it up within 3 minutes, gathers context from connected apps, and drafts a plan
+4. Approve the plan → CORE runs it and brings back the result
+
+[Connect your first app →](https://docs.getcore.me/connectors)
 
 ---
 
 ## Benchmark
 
-CORE achieves **88.24%** average accuracy on the [LoCoMo benchmark](https://github.com/RedPlanetHQ/core-benchmark) across single-hop, multi-hop, open-domain, and temporal reasoning.
+CORE achieves **88.24%** average accuracy on the [LoCoMo benchmark](https://github.com/RedPlanetHQ/core-benchmark) across single-hop, multi-hop, open-domain, and temporal reasoning. See the benchmark repo for full results and baseline comparisons.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,6 @@ CORE ships with five built-in personalities:
 
 Or write your own. The personality applies everywhere: every task it runs, every plan it drafts, every message it sends on your behalf.
 
-Then write the directives it follows across every session:
-
-- "Always check my calendar before scheduling anything."
-- "Never open a PR without my approval."
-- "Run the test suite before committing."
-- "Send me a morning brief at 8am."
-
 Choose its voice for spoken interactions. From then on, it sounds and behaves like the AI you configured, across every interface.
 
 ---

--- a/README.md
+++ b/README.md
@@ -102,17 +102,7 @@ One AI, four surfaces, the same memory and context behind all of them.
 
 Give it a name. Choose how it speaks. Set the rules it follows everywhere.
 
-CORE ships with five built-in personalities:
-
-| | |
-|---|---|
-| **TARS** | Dry wit, minimal, efficient. Like TARS from Interstellar. Built for Mars habitat management, now running your entire life. |
-| **Alfred** | Alfred Pennyworth. Formal, protective, decades of loyalty. Dry wit with genuine care underneath. Will tell you the hard truth with impeccable timing. |
-| **Hobson** | Sharp, acerbic, witty. Will say what no one else will. Loyalty disguised as sharpness. |
-| **Hudson** | Warm, practical, grounded. Common sense as a superpower. Gets things done without fuss. |
-| **Jeeves** | Quietly the most capable person in the room. Solves problems before you know you have them. |
-
-Or write your own. The personality applies everywhere: every task it runs, every plan it drafts, every message it sends on your behalf.
+Pick from five built-in personalities — TARS's dry efficiency, Alfred's loyal formality, Hudson's warm practicality — or write your own. The personality carries into every task it runs, every plan it drafts, every message it sends on your behalf.
 
 Choose its voice for spoken interactions. From then on, it sounds and behaves like the AI you configured, across every interface.
 

--- a/README.md
+++ b/README.md
@@ -68,20 +68,15 @@ Watch CORE take a plain-text task, gather context from GitHub and memory, plan t
 
 ## What makes it an OS
 
-Every chatbot, every agent tool, every AI assistant you use today has the same assumption baked in: you open it, you type, it responds, you close it. That is a chat interface. Not an OS.
+Most AI tools wait to be asked. CORE watches.
 
-Your Mac OS does not wait for you to open a window. It runs in the background, manages memory across every process, coordinates work across every app, and responds to keyboard, trackpad, and voice equally. You configure it once and it works your way everywhere.
+Connect it to your apps and it monitors activity across all of them. An email arrives from a client, a GitHub issue gets assigned, a Sentry alert fires, a meeting ends. CORE sees it, checks your memory and the skills you have set, and either handles it or surfaces it for your judgment. You do not trigger it. It notices on its own.
 
-CORE works the same way. It does not need a chat window. It is always on. It picks up work from wherever you give it. It has persistent memory across every tool, every session, every conversation. It coordinates coding agents, browser agents, and app actions. And you configure it once: name, personality, voice, directives.
+Install the CORE plugin in Claude Code, Codex, or Cursor and your agent conversations get watched too. Context discussed, decisions made, code written, all of it feeds the memory knowledge graph. The next task CORE picks up already knows what happened in your last session.
 
-Four things give it OS-level capability:
+When it acts, it acts directly. It can reply to emails, update Linear issues, file GitHub PRs, send Slack messages, run terminal commands, drive a browser, and spawn a Claude Code or Codex session from any interface. Send a WhatsApp message from the airport and CORE can have a coding session running and a PR open before you board.
 
-| | |
-|---|---|
-| **Memory** | A temporal knowledge graph of your preferences, decisions, goals, and history across every tool and conversation. Every task starts with full context already loaded. Not embedded chunks. What you decided, when, and why. |
-| **Tasks** | The process manager. CORE owns work end to end: reads the brief, drafts a plan, runs the agents, handles blockers, and brings back a result for your review. |
-| **Gateway** | The execution layer. Runs Claude Code, Codex, browser agents, and terminal commands on your machine or in Docker and Railway. Keeps running when your laptop is closed. |
-| **Toolkit** | The application layer. 1000+ actions across 50+ apps via MCP. GitHub, Linear, Slack, Gmail, Sentry, Notion, Jira, Calendar, and more. |
+You decide where it acts on its own and where it waits for your call. Handle Sentry alerts automatically but always ask before merging. Approve a plan before a coding session starts. Require confirmation before any email goes out. The level of autonomy is yours to set, per task, per app, per action.
 
 ---
 
@@ -103,18 +98,28 @@ No chat window required. One AI, four surfaces, the same memory and context behi
 
 ## Make it yours
 
-Every other AI assistant is built for everyone. That is why it feels like no one's.
+Give it a name. Choose how it speaks. Set the rules it follows everywhere.
 
-Give CORE a name. Set its personality: how formal it sounds, how much detail it gives, how it handles uncertainty. Choose its voice. Write the directives it follows everywhere:
+CORE ships with five built-in personalities:
+
+| | |
+|---|---|
+| **TARS** | Dry wit, minimal, efficient. Like TARS from Interstellar. Built for Mars habitat management, now running your entire life. |
+| **Alfred** | Alfred Pennyworth. Formal, protective, decades of loyalty. Dry wit with genuine care underneath. Will tell you the hard truth with impeccable timing. |
+| **Hobson** | Sharp, acerbic, witty. Will say what no one else will. Loyalty disguised as sharpness. |
+| **Hudson** | Warm, practical, grounded. Common sense as a superpower. Gets things done without fuss. |
+| **Jeeves** | Quietly the most capable person in the room. Solves problems before you know you have them. |
+
+Or write your own. The personality applies everywhere: every task it runs, every plan it drafts, every message it sends on your behalf.
+
+Then write the directives it follows across every session:
 
 - "Always check my calendar before scheduling anything."
 - "Never open a PR without my approval."
 - "Run the test suite before committing."
-- "Send me a morning brief at 8am with what needs attention."
+- "Send me a morning brief at 8am."
 
-These apply across every task, every session, every interface. CORE carries them into every Claude Code session it runs, every action it takes in your apps, every plan it drafts.
-
-This is not configuration. It is closer to training an AI that already knows your stack, your preferences, and your standards, and applies them without being reminded.
+Choose its voice for spoken interactions. From then on, whether you reach it by scratchpad, WhatsApp, or the Ctrl+Option voice shortcut, it sounds and behaves like the AI you configured.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ A chatbot has one interface. An OS has many.
 
 **Chat.** Open the dashboard and talk directly, like any assistant. When you want a back-and-forth before delegating.
 
-No chat window required. One AI, four surfaces, the same memory and context behind all of them.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@
 
 # Your personal AI OS.
 
-Not a chatbot you open. An operating layer that is always on. Name it, shape it, connect it to everything you use, and reach it however you work. Open source, self-hosted, yours forever.
+Not a chatbot you open. An AI that is always on, always watching.
+Name it. Shape it. Connect it to everything you use. Reach it however you work.
+Open source, self-hosted, yours forever.
 
 <p align="center">
     <a href="https://getcore.me">
@@ -66,7 +68,7 @@ Watch CORE take a plain-text task, gather context from GitHub and memory, plan t
 
 ---
 
-## What makes it an OS
+## Always watching. Always ready.
 
 Most AI tools wait to be asked. CORE watches.
 
@@ -119,7 +121,7 @@ Then write the directives it follows across every session:
 - "Run the test suite before committing."
 - "Send me a morning brief at 8am."
 
-Choose its voice for spoken interactions. From then on, whether you reach it by scratchpad, WhatsApp, or the Ctrl+Option voice shortcut, it sounds and behaves like the AI you configured.
+Choose its voice for spoken interactions. From then on, it sounds and behaves like the AI you configured, across every interface.
 
 ---
 
@@ -159,11 +161,9 @@ CORE already knows the branch, the context, and your preferences. It is running 
 |---|---|
 | **Memory** | Temporal knowledge graph across every tool and conversation. Preferences, decisions, goals, and directives, so every task starts with context loaded. |
 | **Tasks** | One-shot or recurring work units with your spec, CORE's plan, live state, and a dedicated chat thread. Each task can spawn coding, browser, or terminal sessions. |
-| **Scratchpad** | Your daily page for tasks, ideas, and work in progress. Type `[ ]` anywhere and CORE picks it up within 3 minutes. |
 | **Connectors** | 50+ apps through one MCP endpoint, plus webhook triggers for proactive automation. GitHub, Linear, Jira, Slack, Gmail, Calendar, Sentry, Notion, Todoist, and more. |
 | **Skills** | Reusable instructions that fire automatically based on context. For example: "always pull related Linear issues before planning a fix," "run tests before opening a PR," or "post a Slack summary when a task completes." 100+ built-in, or write your own. |
 | **Gateway** | Runs Claude Code, Codex, browser agents, and terminal commands on your machine or in Docker and Railway, so CORE keeps working when your laptop is closed. |
-| **Personalization** | Give your AI a name, a personality, a voice, and a set of directives it carries into every task and session. |
 | **Model agnostic** | Bring your own provider: Anthropic, OpenAI, or open-weight models. Self-host the full stack for full isolation. |
 
 ---
@@ -181,17 +181,6 @@ CORE already knows the branch, the context, and your preferences. It is running 
 | Terminal and browser access via gateway | ✅ | ✅ | ✅ | ✅ |
 | Human-in-loop by default | ✅ | ❌ | ❌ | ❌ |
 | Open source and self-hostable | ✅ | ✅ | ✅ | ❌ |
-
----
-
-## What CORE is not
-
-| | |
-|---|---|
-| **Not a RAG wrapper.** | Memory is not embedded chunks. It is a temporal knowledge graph that tracks what you decided, when, and why. |
-| **Not a workflow builder.** | No drag-and-drop DAGs. You write what needs doing. CORE figures out the steps and asks when it needs judgment. |
-| **Not another Devin.** | CORE proposes plans, you approve. CORE asks for unblocks, you decide. CORE brings back PRs, you review. Nothing merges on its own. |
-| **Not a closed cloud assistant.** | CORE is open source, self-hostable, model-agnostic, and designed around your infrastructure. |
 
 ---
 
@@ -243,12 +232,6 @@ corebrain gateway setup
 
 ---
 
-## Benchmark
-
-CORE achieves **88.24%** average accuracy on the [LoCoMo benchmark](https://github.com/RedPlanetHQ/core-benchmark) across single-hop, multi-hop, open-domain, and temporal reasoning. See the benchmark repo for full results and baseline comparisons.
-
----
-
 ## Docs
 
 - [**Memory**](https://docs.getcore.me/memory/overview) - Temporal knowledge graph, fact classification, intent-driven retrieval
@@ -260,6 +243,12 @@ CORE achieves **88.24%** average accuracy on the [LoCoMo benchmark](https://gith
 - [**Skills**](https://docs.getcore.me/skills/overview) - Reusable instructions for repeatable workflows
 - [**Self-hosting**](https://docs.getcore.me/self-hosting/setup) - Full deployment guide
 - [**Changelog**](https://docs.getcore.me/opensource/changelog) - What has shipped
+
+---
+
+## Benchmark
+
+CORE achieves **88.24%** average accuracy on the [LoCoMo benchmark](https://github.com/RedPlanetHQ/core-benchmark) across single-hop, multi-hop, open-domain, and temporal reasoning. See the benchmark repo for full results and baseline comparisons.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Open source, self-hosted, yours forever.
 
 ## See it work
 
-Watch CORE take a plain-text task, gather context from GitHub and memory, plan the work, run a Claude Code session, and open a PR, without you touching anything:
+Watch CORE take a plain-text task, gather context from GitHub and memory, plan the work, run a Claude Code session, and open a PR:
 
 [![CORE Demo](https://img.youtube.com/vi/7y_kt_UTYQs/maxresdefault.jpg)](https://www.youtube.com/watch?v=7y_kt_UTYQs)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 # Your personal AI OS.
 
-Watches your work. Remembers what matters. Acts across your tools and agents, then brings you back only when judgment is needed. Open source, self-hosted, yours forever.
+Not a chatbot you open. An operating layer that is always on. Name it, shape it, connect it to everything you use, and reach it however you work. Open source, self-hosted, yours forever.
 
 <p align="center">
     <a href="https://getcore.me">
@@ -66,82 +66,116 @@ Watch CORE take a plain-text task, gather context from GitHub and memory, plan t
 
 ---
 
-## What CORE is
+## What makes it an OS
 
-CORE is the open-source operating layer for AI-native work.
+Every chatbot, every agent tool, every AI assistant you use today has the same assumption baked in: you open it, you type, it responds, you close it. That is a chat interface. Not an OS.
 
-You write what needs doing in a scratchpad. CORE picks up the task, loads context from memory and connected apps, drafts a plan, runs the right agent through the gateway, handles blockers where it can, and comes back when human judgment is needed.
+Your Mac OS does not wait for you to open a window. It runs in the background, manages memory across every process, coordinates work across every app, and responds to keyboard, trackpad, and voice equally. You configure it once and it works your way everywhere.
 
-It is not a chatbot you keep prompting. It is the layer that remembers, coordinates, acts, and escalates.
+CORE works the same way. It does not need a chat window. It is always on. It picks up work from wherever you give it. It has persistent memory across every tool, every session, every conversation. It coordinates coding agents, browser agents, and app actions. And you configure it once: name, personality, voice, directives.
 
-### The architecture
+Four things give it OS-level capability:
 
 | | |
 |---|---|
-| **Watches** | Context from your AI conversations via MCP, 50+ connected apps, and on Mac, any app you explicitly grant access to. |
-| **Remembers** | A knowledge graph that tracks not just what you said, but what you decided, when, and why, across every tool and conversation. |
-| **Acts** | Takes direct actions in your connected apps, and delegates longer work to coding and browser agents via the gateway. |
-| **Policies** | Approval flows, escalation rules, plans, and audit logs so autonomy stays accountable. |
+| **Memory** | A temporal knowledge graph of your preferences, decisions, goals, and history across every tool and conversation. Every task starts with full context already loaded. Not embedded chunks. What you decided, when, and why. |
+| **Tasks** | The process manager. CORE owns work end to end: reads the brief, drafts a plan, runs the agents, handles blockers, and brings back a result for your review. |
+| **Gateway** | The execution layer. Runs Claude Code, Codex, browser agents, and terminal commands on your machine or in Docker and Railway. Keeps running when your laptop is closed. |
+| **Toolkit** | The application layer. 1000+ actions across 50+ apps via MCP. GitHub, Linear, Slack, Gmail, Sentry, Notion, Jira, Calendar, and more. |
 
-CORE decides what it can do safely, asks before sensitive actions, and leaves a trail you can review.
+---
+
+## Four ways to reach it
+
+A chatbot has one interface. An OS has many.
+
+**Voice.** Press Ctrl+Option on Mac and say what needs doing. CORE creates the task and starts running it in the background before you put your phone down.
+
+**Scratchpad.** Open your daily page and write `[ ] Fix the auth bug from issue #47`. CORE picks it up within 3 minutes, loads context from your repo and memory, and drafts a plan.
+
+**Messaging.** WhatsApp, Slack, Telegram. Send a task from the airport, from your phone, from bed. CORE has your full context regardless of where the message comes from.
+
+**Chat.** Open the dashboard and talk directly, like any assistant. When you want a back-and-forth before delegating.
+
+No chat window required. One AI, four surfaces, the same memory and context behind all of them.
+
+---
+
+## Make it yours
+
+Every other AI assistant is built for everyone. That is why it feels like no one's.
+
+Give CORE a name. Set its personality: how formal it sounds, how much detail it gives, how it handles uncertainty. Choose its voice. Write the directives it follows everywhere:
+
+- "Always check my calendar before scheduling anything."
+- "Never open a PR without my approval."
+- "Run the test suite before committing."
+- "Send me a morning brief at 8am with what needs attention."
+
+These apply across every task, every session, every interface. CORE carries them into every Claude Code session it runs, every action it takes in your apps, every plan it drafts.
+
+This is not configuration. It is closer to training an AI that already knows your stack, your preferences, and your standards, and applies them without being reminded.
 
 ---
 
 ## CORE in action
 
-### Delegate a coding task, come back to a PR.
+### Say it, come back to a PR.
 
-Tell CORE what needs doing. It gathers context from your repo, apps, and memory, drafts a plan, runs a Claude Code or Codex session, handles blockers where it can, and brings back a PR. You review when it is done.
+*Press Ctrl+Option, speak:* "Fix the race condition in the checkout flow from issue #312."
 
-`[ ] Fix the race condition in the checkout flow from issue #312`
+CORE loads the issue, pulls related commits and Slack threads, drafts a plan, and runs a Claude Code session. You come back to a diff. You were never at your desk.
 
-### Clear your backlog while you sleep.
+### Write it at night, review it in the morning.
 
-Set a recurring task to pull from your backlog at a set time. CORE works through it while you are offline. Smooth runs wait for review in the morning. Stuck sessions come back with a tight question, not a stalled tab.
+*Scratchpad:* `[ ] Work through tonight's backlog starting at 11pm`
 
-`[ ] Work through tonight's backlog starting at 11pm`
+CORE pulls from Linear, GitHub, and memory, prioritizes, and works through it while you sleep. Smooth runs are waiting for your review. Stuck sessions come back with one tight question, not a stalled tab.
 
-### Investigate alerts before they become interruptions.
+### Message it from anywhere.
 
-Set a recurring task to watch Sentry, logs, or any alert source. When something fires, CORE investigates, pulls related traces and prior incidents, and decides whether to handle it or escalate.
+*WhatsApp from the airport:* "Ship the auth refactor."
 
-A Sentry alert fires at 2am. CORE investigates, proposes a fix, and pings you on Slack for review.
+CORE already knows the branch, the context, and your preferences. It is running in Railway. It kicks off the session before you board.
 
-### Get a morning brief that knows your work.
+### Investigate alerts before they become incidents.
 
-Set a recurring task to pull from email, GitHub, Linear, and Slack every morning. CORE summarizes what needs attention, skips what doesn't, and turns follow-ups into tasks automatically.
+*Sentry fires at 2am.* CORE investigates, pulls related traces and prior incidents from memory, proposes a fix, and pings you on Slack: "Issue #847, fix proposed, awaiting your review." You approve from your phone.
 
-### Delegate from wherever you are.
+### Get a brief that already knows your week.
 
-Create tasks from Slack, WhatsApp, Telegram, email, or web. The gateway keeps running in Docker or Railway, so CORE can pick up work even when your laptop is closed.
+*Recurring task, every morning at 8am.* CORE pulls from email, GitHub, Linear, and Slack, surfaces what actually needs attention, skips what does not, and turns follow-ups into tasks automatically.
 
 ---
 
-## What's inside CORE
+## What is inside CORE
 
 | | |
 |---|---|
-| **Memory** | Tracks your preferences, decisions, goals, and directives across every tool and conversation, so every task starts with context loaded. |
-| **Tasks** | One-shot or recurring work units with your spec, CORE's plan, live state, and a dedicated chat thread. Each task can spawn coding or browser sessions. |
-| **Scratchpad** | A daily page for tasks, ideas, and work in progress. Type `[ ]` anywhere and CORE picks it up within 3 minutes. |
-| **Connectors** | 50+ apps through one MCP endpoint, plus webhook triggers for proactive automation. GitHub, Linear, Jira, Slack, Gmail, Calendar, Sentry, Granola, Todoist, and more. |
+| **Memory** | Temporal knowledge graph across every tool and conversation. Preferences, decisions, goals, and directives, so every task starts with context loaded. |
+| **Tasks** | One-shot or recurring work units with your spec, CORE's plan, live state, and a dedicated chat thread. Each task can spawn coding, browser, or terminal sessions. |
+| **Scratchpad** | Your daily page for tasks, ideas, and work in progress. Type `[ ]` anywhere and CORE picks it up within 3 minutes. |
+| **Connectors** | 50+ apps through one MCP endpoint, plus webhook triggers for proactive automation. GitHub, Linear, Jira, Slack, Gmail, Calendar, Sentry, Notion, Todoist, and more. |
 | **Skills** | Reusable instructions that fire automatically based on context. For example: "always pull related Linear issues before planning a fix," "run tests before opening a PR," or "post a Slack summary when a task completes." 100+ built-in, or write your own. |
-| **Gateway** | Runs Claude Code, Codex, browser agents, and local commands on your machine or in Docker / Railway, so CORE keeps working when your laptop is closed. |
-| **Model agnostic** | Bring your own provider: Anthropic, OpenAI, or open-weight models. Self-host the full stack for isolation. |
+| **Gateway** | Runs Claude Code, Codex, browser agents, and terminal commands on your machine or in Docker and Railway, so CORE keeps working when your laptop is closed. |
+| **Personalization** | Give your AI a name, a personality, a voice, and a set of directives it carries into every task and session. |
+| **Model agnostic** | Bring your own provider: Anthropic, OpenAI, or open-weight models. Self-host the full stack for full isolation. |
 
 ---
 
 ## How CORE compares
 
-| | CORE | Devin / Copilot Workspace | Zapier / n8n | Mem / Notion AI |
+| | CORE | OpenClaw | Hermes Agent | Devin / Copilot |
 |---|:---:|:---:|:---:|:---:|
-| Delegates full tasks to coding agents | ✅ | ✅ | ❌ | ❌ |
-| Persistent memory across tasks | ✅ | ❌ | ❌ | Partial |
-| 50+ app connectors | ✅ | ❌ | ✅ | ❌ |
-| Human-in-loop by default | ✅ | ❌ | ❌ | N/A |
-| Open source and self-hostable | ✅ | ❌ | Partial | ❌ |
-| Works from plain-language task descriptions | ✅ | Partial | ❌ | Partial |
-| Runs while your laptop is closed | ✅ | ✅ | ✅ | ❌ |
+| Multiple interfaces (voice, scratchpad, chat, messaging) | ✅ | Partial | ❌ | ❌ |
+| Persistent memory across tasks | ✅ | ❌ | ✅ | ❌ |
+| Delegates to coding agents (Claude Code, Codex) | ✅ | ❌ | ❌ | ✅ |
+| Structured task planning with human approval | ✅ | ❌ | ❌ | Partial |
+| Custom name, personality, and voice | ✅ | ❌ | ❌ | ❌ |
+| 50+ app connectors | ✅ | Partial | Partial | ❌ |
+| Terminal and browser access via gateway | ✅ | ✅ | ✅ | ✅ |
+| Human-in-loop by default | ✅ | ❌ | ❌ | ❌ |
+| Open source and self-hostable | ✅ | ✅ | ✅ | ❌ |
 
 ---
 
@@ -149,9 +183,9 @@ Create tasks from Slack, WhatsApp, Telegram, email, or web. The gateway keeps ru
 
 | | |
 |---|---|
-| **Not a RAG wrapper.** | Memory is not just embedded chunks. It is a knowledge graph that tracks what you decided, when, and why. |
-| **Not a workflow builder.** | No drag-and-drop DAGs. You write what needs doing. CORE figures out the workflow and asks when it needs judgment. |
-| **Not another Devin.** | CORE proposes plans, you approve. CORE asks for unblocks, you decide. CORE brings back PRs, you review. Agents do not merge on their own. |
+| **Not a RAG wrapper.** | Memory is not embedded chunks. It is a temporal knowledge graph that tracks what you decided, when, and why. |
+| **Not a workflow builder.** | No drag-and-drop DAGs. You write what needs doing. CORE figures out the steps and asks when it needs judgment. |
+| **Not another Devin.** | CORE proposes plans, you approve. CORE asks for unblocks, you decide. CORE brings back PRs, you review. Nothing merges on its own. |
 | **Not a closed cloud assistant.** | CORE is open source, self-hostable, model-agnostic, and designed around your infrastructure. |
 
 ---
@@ -162,11 +196,11 @@ Open source and self-hosted. Your data stays in your infrastructure.
 
 **Choose your path:**
 
-| I want to… | How |
+| I want to... | How |
 |---|---|
 | Try it on my machine | Run the one-step install below (requires Docker) |
 | Deploy on a server or VPS | One-click Railway deploy |
-| Use a Mac app | [Join the waitlist →](https://www.getcore.me/) |
+| Use the Mac app | [Join the waitlist](https://www.getcore.me/) |
 
 **Install and start CORE:**
 
@@ -182,7 +216,7 @@ Most local installs take a few minutes once Docker is running.
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.com/deploy/core)
 
-**Connect a gateway** so CORE can drive your browser, run coding agents, and access local folders:
+**Connect a gateway** so CORE can run coding agents, drive your browser, and access local folders:
 
 ```bash
 corebrain login
@@ -196,27 +230,17 @@ corebrain gateway setup
 **Your first task (2 minutes after setup):**
 
 1. Open the **Scratchpad** (your daily page at `http://localhost:3033`)
-2. Type `[ ] Summarize my open GitHub issues` or any task you'd normally do yourself
+2. Type `[ ] Summarize my open GitHub issues` or any task you would normally do yourself
 3. CORE picks it up within 3 minutes, gathers context from connected apps, and drafts a plan
-4. Approve the plan → CORE runs it and brings back the result
+4. Approve the plan and CORE runs it and brings back the result
 
-[Connect your first app →](https://docs.getcore.me/connectors)
+[Connect your first app](https://docs.getcore.me/connectors)
 
 ---
 
 ## Benchmark
 
 CORE achieves **88.24%** average accuracy on the [LoCoMo benchmark](https://github.com/RedPlanetHQ/core-benchmark) across single-hop, multi-hop, open-domain, and temporal reasoning. See the benchmark repo for full results and baseline comparisons.
-
----
-
-## What we believe
-
-- Chat is an interface. Not an OS.
-- Intelligence without memory is trivia.
-- Your AI should know you across every tool, not just the current tab.
-- Work should move from intent to action without you becoming the glue.
-- Automation without accountability is chaos.
 
 ---
 
@@ -248,9 +272,9 @@ CORE achieves **88.24%** average accuracy on the [LoCoMo benchmark](https://gith
 
 ## Community
 
-We're building CORE in public.
+We are building CORE in public.
 
-We share the roadmap and architectural decisions openly because the hardest problems in building a personal OS are best solved with the people using it. Star the repo, self-host it, share what you build, and open issues for what's broken or missing.
+We share the roadmap and architectural decisions openly because the hardest problems in building a personal OS are best solved with the people using it. Star the repo, self-host it, share what you build, and open issues for what is broken or missing.
 
 - [Discord](https://discord.gg/YGUZcvDjUa) - questions, ideas, show-and-tell
 - [Contributing docs](https://docs.getcore.me/opensource/contributing) - how to contribute to CORE

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 # Your personal AI OS.
 
-Watches your work. Remembers what matters. Acts across your tools and agents — then brings you back only when judgment is needed. Open source, self-hosted, yours forever.
+Watches your work. Remembers what matters. Acts across your tools and agents, then brings you back only when judgment is needed. Open source, self-hosted, yours forever.
 
 <p align="center">
     <a href="https://getcore.me">
@@ -50,9 +50,6 @@ Watches your work. Remembers what matters. Acts across your tools and agents —
     <a href="https://github.com/RedPlanetHQ/core/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-AGPL%203.0-blue?style=for-the-badge" alt="License: AGPL 3.0" />
     </a>
-    <a href="https://news.ycombinator.com/item?id=43986085">
-        <img src="https://img.shields.io/badge/Y%20Combinator-S23-F26522?style=for-the-badge&logo=ycombinator&logoColor=white" alt="YC S23" />
-    </a>
     <a href="https://github.com/RedPlanetHQ/core/stargazers">
         <img src="https://img.shields.io/github/stars/RedPlanetHQ/core?style=for-the-badge&color=gold&logo=github" alt="GitHub Stars" />
     </a>
@@ -63,7 +60,7 @@ Watches your work. Remembers what matters. Acts across your tools and agents —
 
 ## See it work
 
-Watch CORE take a plain-text task, gather context from GitHub and memory, plan the work, run a Claude Code session, and open a PR — without you touching anything:
+Watch CORE take a plain-text task, gather context from GitHub and memory, plan the work, run a Claude Code session, and open a PR, without you touching anything:
 
 [![CORE Demo](https://img.youtube.com/vi/7y_kt_UTYQs/maxresdefault.jpg)](https://www.youtube.com/watch?v=7y_kt_UTYQs)
 
@@ -198,8 +195,8 @@ corebrain gateway setup
 
 **Your first task (2 minutes after setup):**
 
-1. Open the **Scratchpad** — your daily page at `http://localhost:3033`
-2. Type `[ ] Summarize my open GitHub issues` — or any task you'd normally do yourself
+1. Open the **Scratchpad** (your daily page at `http://localhost:3033`)
+2. Type `[ ] Summarize my open GitHub issues` or any task you'd normally do yourself
 3. CORE picks it up within 3 minutes, gathers context from connected apps, and drafts a plan
 4. Approve the plan → CORE runs it and brings back the result
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A chatbot has one interface. An OS has many.
 
 **Chat.** Open the dashboard and talk directly, like any assistant. When you want a back-and-forth before delegating.
 
+One AI, four surfaces, the same memory and context behind all of them.
 
 ---
 


### PR DESCRIPTION
## Summary

README eval as a first-time user who knows nothing about CORE — rated 7/10, this PR closes the gaps.

**What was wrong:**
- "Run Your OS." tagline was redundant and awkward under "Your personal AI OS."
- Demo video had no caption — readers didn't know what they'd see before clicking
- Skills described as "100+ reusable instructions" with zero examples — meaningless
- Three install paths (npm, Railway, Mac waitlist) with no guidance on which to pick
- After \`corebrain setup\` opens localhost:3033 → total silence, new users bounce here
- Benchmark 88.24% had no baseline or context
- No social proof (YC badge, GitHub stars)
- No comparison table vs alternatives

**What changed:**
- Tagline → "Watches your work. Remembers what matters. Acts across your tools and agents — then brings you back only when judgment is needed."
- Video caption explains exactly what you'll watch before clicking
- Skills now has 3 concrete examples inline
- "Choose your path" table (machine / Railway / Mac waitlist) added to Quickstart
- "Your first task" 4-step walkthrough added after setup instructions
- Benchmark section points to repo for baseline comparisons
- Added YC S23 + GitHub Stars badges
- Added "How CORE compares" table vs Devin/Copilot Workspace, Zapier/n8n, Mem/Notion AI

## Test plan

- [ ] README renders correctly on GitHub (tables, badges, video thumbnail)
- [ ] YC and GitHub stars badges resolve correctly
- [ ] "Choose your path" table and "Your first task" steps are accurate vs current product behavior
- [ ] Comparison table claims are factually defensible

🤖 Generated with [Claude Code](https://claude.com/claude-code)