### PR TITLE
docs: align docs with new personal AI OS positioning

### DIFF
--- a/docs/concepts/meta-agent.mdx
+++ b/docs/concepts/meta-agent.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Agent"
-description: "The brain behind your named butler — memory, actions, and intent tied together"
+description: "The orchestrator — triggers, memory, tools, and execution"
 ---
 
 ## What is the Agent?
 
-Every butler needs a brain. The Agent is that brain — it's what makes your butler *yours*. It sits between you and everything CORE knows and can do: memory, toolkit, connected apps. When you send a message, it figures out what you need, pulls the right context, takes the right actions, and responds. Every conversation gets ingested back into memory, so your butler gets sharper the more you use it.
+The Agent is CORE's brain. It sits between you and everything CORE knows and can do: memory, toolkit, connected apps, and the gateway. When you send a message or a trigger fires, it figures out what's needed, pulls the right context, takes the right actions, and responds. Every conversation gets ingested back into memory, so CORE gets sharper the more you use it.
 
-You can talk to it from WhatsApp, the web dashboard, email, or through any MCP-compatible agent like Claude Code or Cursor. Same brain, same memory, regardless of where you start.
+You can reach it via voice, scratchpad, WhatsApp, Slack, the web dashboard, or through any MCP-compatible agent like Claude Code or Cursor. Same brain, same memory, regardless of where you start.
 
 ---
 
@@ -83,9 +83,9 @@ When you send a message, here's what happens:
 
 ## It Can Spawn Other Agents
 
-The Agent isn't limited to its own capabilities. It can spin up other agents on your behalf - a Claude Code session to write code, a browser session to research something - all triggered from whatever channel you're on.
+The Agent isn't limited to its own capabilities. It can spin up other agents on your behalf — a Claude Code or Codex session to write code, a browser session to research something — all triggered from whatever channel you're on.
 
-You're outside, a production bug comes in. You message the Butler on WhatsApp: "Fix the auth timeout issue in the API." The Butler spins up a Claude Code session on your machine, pulls the relevant context from memory, and starts working on the fix - while you're still on your phone.
+You're outside, a production bug comes in. You message CORE on WhatsApp: "Fix the auth timeout issue in the API." CORE spins up a Claude Code session via the gateway, pulls the relevant context from memory, and starts working on the fix — while you're still on your phone.
 
 ---
 

--- a/docs/concepts/scratchpad.mdx
+++ b/docs/concepts/scratchpad.mdx
@@ -1,29 +1,29 @@
 ---
 title: "Scratchpad"
-description: "Your daily page — a place to think out loud where the butler can read along"
+description: "Your daily page — write [ ] tasks and CORE picks them up within minutes"
 ---
 
 ## What it is
 
 The Scratchpad is the daily page CORE creates for you the moment you log in. One page per day, scoped to your local timezone. It's a collaborative block editor (paragraphs, headings, lists, tasks, code blocks, tables) backed by Yjs, so it autosaves and survives across devices without a save button.
 
-You can use it like any notes app — but the butler is reading along. There are two ways to put it to work.
+You can use it like any notes app — but CORE is watching. There are two ways to put it to work.
 
 ---
 
-## Two ways to engage the butler
+## Two ways to engage CORE
 
 <CardGroup cols={2}>
   <Card title="Write a task with [ ]" icon="square-check">
-    Type `[ ]` to start a checkbox item. The line becomes a real task the moment you stop typing — within ~2 minutes the butler picks it up and starts working on it. You'll see its progress on the task's badge right inside the scratchpad.
+    Type `[ ]` to start a checkbox item. The line becomes a real task the moment you stop typing — within ~2 minutes CORE picks it up and starts working on it. You'll see its progress on the task's badge right inside the scratchpad.
   </Card>
 
   <Card title="Mention with @butler" icon="at">
-    Type `@butler` followed by an instruction. After a short idle pause the butler reads the paragraph, runs your request, and replies as a comment attached to that paragraph — so the answer lives next to the question.
+    Type `@butler` followed by an instruction. After a short idle pause CORE reads the paragraph, runs your request, and replies as a comment attached to that paragraph — so the answer lives next to the question.
   </Card>
 </CardGroup>
 
-The split is intentional: tasks are *work the butler should run on its own and report back when done*; mentions are *a question or instruction you want answered right here in the page*.
+The split is intentional: tasks are *work CORE should run on its own and report back when done*; mentions are *a question or instruction you want answered right here in the page*.
 
 ---
 
@@ -33,22 +33,22 @@ A `[ ]` line isn't just text formatting — it's bound to a real Task in CORE th
 
 - Typing `[ ]` (or using the `Task` slash command) inserts a checkbox item, creates a Task row with `source: "daily"`, and links it to the scratchpad.
 - The text you type becomes the task title. Edits autosave to the task as you type.
-- The task shows a butler-run badge with the next scheduled run time. Within roughly two minutes the butler claims it and starts execution.
+- The task shows a badge with the next scheduled run time. Within roughly two minutes CORE claims it and starts execution.
 - Click the task's display id (e.g. `T-142`) to jump to its full task page — descriptions, subtasks, activity log, runs.
 - Check the box to mark it Done. Uncheck to send it back to Todo.
-- Delete the line and the task is cleaned up automatically — *unless* you've already typed a title or the butler has added context, in which case the task is preserved and you can find it on the tasks list.
+- Delete the line and the task is cleaned up automatically — *unless* you've already typed a title or CORE has added context, in which case the task is preserved and you can find it on the tasks list.
 
-This is why a Scratchpad task "just works" — you write a checkbox, it's now a tracked unit of work the butler will pick up and report back on, and you didn't have to leave the page to make any of that happen.
+This is why a Scratchpad task "just works" — you write a checkbox, it's now a tracked unit of work CORE will pick up and report back on, and you didn't have to leave the page to make any of that happen.
 
 ---
 
 ## How `@butler` mentions work
 
-`@butler` is for answers you want inline. Type it followed by an instruction, keep writing, and a few seconds after you stop, the butler reads the paragraph, runs the request through the Butler, and posts a comment on the paragraph with what it found or did.
+`@butler` is for answers you want inline. Type it followed by an instruction, keep writing, and a few seconds after you stop, CORE reads the paragraph, runs the request, and posts a comment on the paragraph with what it found or did.
 
 A few things worth knowing:
 
-- The mention text (minus `@butler`) is what the butler sees as your instruction — keep the rest of the paragraph self-contained.
+- The mention text (minus `@butler`) is what CORE sees as your instruction — keep the rest of the paragraph self-contained.
 - A comment shows up right on that paragraph; click it to expand the response and to open the underlying conversation if you want to follow up in chat.
 - Each mention is processed once — the butler tracks which paragraphs it has already answered on, so editing unrelated text won't re-trigger it. Edit the paragraph itself if you want a fresh reply.
 
@@ -66,4 +66,4 @@ You can also embed a widget *inline* in the page itself: type `/` and pick a wid
 
 ## Why a daily page (not one big page)
 
-A new page every day forces a clean break: yesterday's open loops are still in memory and searchable, but they're not staring at you. The butler treats today as the source of truth for what's currently top-of-mind, which is what makes the `[ ]` and `@butler` flows feel light — the butler has a small, fresh surface to reason about instead of an ever-growing journal.
+A new page every day forces a clean break: yesterday's open loops are still in memory and searchable, but they're not staring at you. CORE treats today as the source of truth for what's currently top-of-mind, which is what makes the `[ ]` and `@butler` flows feel light — CORE has a small, fresh surface to reason about instead of an ever-growing journal.

--- a/docs/concepts/tasks.mdx
+++ b/docs/concepts/tasks.mdx
@@ -1,35 +1,79 @@
 ---
 title: "Tasks"
-description: "SOL's task system and planner"
+description: "CORE's task system — one-shot and recurring work units with plans, state, and coding sessions"
 ---
 
 ## Overview
 
-SOL's task system is designed to centralize and streamline your work across multiple platforms, providing a unified system for tracking, prioritizing, and completing work items.
+CORE's task system is the unit of delegated work. When you write a `[ ]` in the Scratchpad, send a message, or set up a recurring job, CORE creates a task — loads context from memory and connected apps, drafts a plan, runs the work through the gateway, handles blockers where it can, and comes back when judgment is needed.
 
-A SOL task is a work item that:
+A CORE task is a work item that:
 
 - Has a clear objective
 - Can be tracked to completion
 - May be linked to external systems (GitHub, Linear, etc.)
 - Contains context relevant to the work needed
-- Can be prioritized and scheduled
+- Can be one-shot or recurring on a schedule
 
-## Task Sources
+---
 
-Tasks in SOL can be created from multiple sources:
+## Task sources
 
-1. **Manual Creation**: Directly created by you in SOL
-2. **Automation Rules**: Generated automatically based on triggers from connected platforms (Linear issues, GitHub PRs, etc.)
-3. **Conversation**: Created from chat with SOL
+Tasks in CORE can be created from multiple sources:
 
-## Task Anatomy
+1. **Scratchpad** — Type `[ ]` on your daily page. CORE picks it up within 3 minutes and starts working.
+2. **Chat** — Created from a conversation with CORE directly.
+3. **Messaging** — Sent via WhatsApp, Slack, Telegram, or email.
+4. **Automation** — Triggered automatically from connected apps (a Sentry alert fires, a Linear issue is assigned, a GitHub PR is opened).
+5. **Recurring** — Scheduled to run at a set time, daily, weekly, or any cron pattern.
 
-Each task in SOL consists of:
+---
 
-- **Title**: Clear description of the work to be done
-- **Status**: Current state (Todo, Done)
-- **Scheduled Date**: When the task should be scheduled
-- **Descriptions**: Related information, links, and background
-- **Subtasks**: Smaller steps needed to complete the main task
-- **Activity**: History of actions and changes
+## Task anatomy
+
+Each task in CORE consists of:
+
+- **Title** — Clear description of the work to be done
+- **Status** — Current state (Todo, In Progress, Done)
+- **Scheduled date** — When the task is set to run
+- **Description** — Spec, related links, and background context
+- **Plan** — CORE's proposed steps, presented for your approval before execution
+- **Subtasks** — Smaller steps broken out during planning
+- **Sessions** — Coding, browser, or terminal sessions spawned to execute the work
+- **Activity** — Full history of actions, decisions, and changes
+- **Chat thread** — A dedicated conversation scoped to this task for follow-up
+
+---
+
+## How a task runs
+
+<Steps>
+  <Step title="Task is created">
+    You write a `[ ]`, send a message, or a trigger fires. CORE creates the task and loads context from memory and connected apps.
+  </Step>
+  <Step title="Plan is drafted">
+    CORE drafts a step-by-step plan and presents it for your approval. You can edit, approve, or reject it.
+  </Step>
+  <Step title="Work executes">
+    CORE runs the plan — taking direct actions in your apps, spawning Claude Code or Codex sessions via the gateway, or driving the browser. Skills fire automatically based on context.
+  </Step>
+  <Step title="Blockers are handled or escalated">
+    If CORE hits something it can resolve, it does. If it needs your judgment, it comes back with a tight question — not a stalled tab.
+  </Step>
+  <Step title="Result is delivered">
+    CORE brings back the output — a PR, a summary, a completed action — and logs everything to memory so future tasks start with that context loaded.
+  </Step>
+</Steps>
+
+---
+
+## Recurring tasks
+
+Tasks can be scheduled to run on a recurring basis. Set a time and CORE runs the full loop — gathering fresh context, executing the work, and reporting back — on every cycle.
+
+Examples:
+- `Every morning at 8am, pull from email, GitHub, and Slack and surface what needs attention`
+- `Every Monday, find 10 new leads matching our ICP on LinkedIn and add them to the Leads sheet`
+- `Every night at 11pm, work through the backlog`
+
+Recurring tasks are created from the Tasks page or from a message in any channel.

--- a/docs/concepts/toolkit.mdx
+++ b/docs/concepts/toolkit.mdx
@@ -3,13 +3,13 @@ title: "Toolkit"
 description: "How CORE takes actions across your connected apps"
 ---
 
-## Pillar 2: It Can Take Actions
+## Taking actions across your apps
 
 The Toolkit is CORE's hands. While the Agent thinks and Memory remembers, the Toolkit actually *does things* — creates issues, drafts emails, schedules meetings, sends messages — across all your connected apps.
 
 You connect each app once. After that, every interface to CORE (WhatsApp, web dashboard, Claude Code, Cursor) can use those integrations. One connection, available everywhere.
 
-**What a multi-step action looks like:** A user emails reporting a bug → your butler creates a Todoist task, spins up a Claude Code session with context from memory, writes a fix, and opens a PR. You come back to a summary and a link. One message, multiple tools, coordinated automatically.
+**What a multi-step action looks like:** A user emails reporting a bug → CORE creates a Todoist task, spins up a Claude Code session with context from memory, writes a fix, and opens a PR. You come back to a summary and a link. One message, multiple tools, coordinated automatically.
 
 ---
 
@@ -19,7 +19,7 @@ You connect each app once. After that, every interface to CORE (WhatsApp, web da
 
 From the [CORE Dashboard](https://app.getcore.me), connect the apps you use daily. Each integration authenticates via OAuth — no API keys to manage.
 
-### 2. Your Butler Decides What to Use
+### 2. CORE Decides What to Use
 
 When you ask CORE to do something, the Agent figures out which integration(s) to use:
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,51 +1,108 @@
 ---
 title: "Getting Started"
-description: "Your personal AI butler — open source, named, persistent, yours."
+description: "Install and run your personal AI OS in minutes. Open source, self-hosted, yours forever."
 ---
 
-CORE is your personal AI butler. It knows your tools, your preferences, and your people. It remembers everything across conversations, takes actions across your apps, and works proactively — so you describe outcomes and it does the work.
-
-**Open source. Named. Persistent. Yours.**
-
----
-
-## How do you want to get started?
-
-<CardGroup cols={2}>
-  <Card title="Join the Cloud Waitlist" icon="cloud" href="https://app.getcore.me">
-    Cloud is coming. Join the waitlist and we'll reach out when your spot is ready.
-  </Card>
-
-  <Card title="Self-Host (Open Source)" icon="server" href="/self-hosting/setup">
-    Run your butler on your own infrastructure today. Docker-based, fully open source, your data stays with you.
-  </Card>
-</CardGroup>
+CORE is your personal AI OS. It watches your apps and AI sessions, remembers what matters across every conversation, and acts — directly in your tools or by spawning coding and browser agents — without you staying in the loop for every step.
 
 ---
 
-## What your butler can do
+## Choose your path
 
-Once you're set up, you can message your butler from WhatsApp, Slack, email, or the web dashboard — like messaging a person:
-
-- *"What are my priorities for today?"*
-- *"Fix the auth timeout bug in the API repo"*
-- *"When a Sentry alert fires tonight, investigate it and create an issue"*
-- *"Summarise my emails from the last 24 hours"*
-
-The more you use it, the more it learns — your preferences, patterns, and relationships. That's what makes it a butler, not just a chatbot.
+| I want to... | How |
+|---|---|
+| Try it on my machine | Run the one-step install below (requires Docker) |
+| Deploy on a server or VPS | One-click Railway deploy |
+| Use the Mac app | [Join the waitlist](https://www.getcore.me/) |
 
 ---
 
-## Want to understand how it works first?
+## Install and start CORE
+
+```bash
+npm install -g @redplanethq/corebrain && corebrain setup
+```
+
+The setup wizard asks for an install directory, AI provider, API key, and chat model. It generates secrets, starts the stack, and opens `http://localhost:3033`.
+
+Most local installs take a few minutes once Docker is running.
+
+**Requirements:** Docker 20.10+, Docker Compose 2.20+, 4 vCPU / 8GB RAM
+
+**Or deploy on Railway:**
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.com/deploy/core)
+
+[Full self-hosting guide →](/self-hosting/setup)
+
+---
+
+## Connect a gateway
+
+The gateway is what lets CORE drive coding agents, your browser, and terminal commands — even when your laptop is closed.
+
+```bash
+corebrain login
+corebrain gateway setup
+```
+
+Run this on your laptop, a Docker host, or a Railway service. Once it's connected, CORE can spawn Claude Code or Codex sessions, run terminal commands, and open PRs on your behalf.
+
+---
+
+## Your first task
+
+Once CORE is running:
+
+1. Open the **Scratchpad** — your daily page at `http://localhost:3033`
+2. Type `[ ] Summarize my open GitHub issues` (or any task you'd normally handle yourself)
+3. CORE picks it up within 3 minutes, gathers context from your connected apps and memory, and drafts a plan
+4. Approve the plan — CORE runs it and brings back the result
+
+That's the core loop: you write what needs doing, CORE owns it end to end.
+
+---
+
+## CORE in action
+
+### Say it, come back to a PR.
+
+Press Ctrl+Option, speak: *"Fix the race condition in the checkout flow from issue #312."*
+
+CORE loads the issue, pulls related commits and Slack threads, drafts a plan, and runs a Claude Code session. You come back to a diff.
+
+### Write it at night, review it in the morning.
+
+Scratchpad: `[ ] Work through tonight's backlog starting at 11pm`
+
+CORE pulls from Linear, GitHub, and memory, prioritizes, and works through it while you sleep. Smooth runs are waiting for your review. Stuck sessions come back with one tight question, not a stalled tab.
+
+### Message it from anywhere.
+
+WhatsApp from the airport: *"Ship the auth refactor."*
+
+CORE already knows the branch, the context, and your preferences. It is running in Railway. It kicks off the session before you board.
+
+### Investigate alerts before they become incidents.
+
+Sentry fires at 2am. CORE investigates, pulls related traces and prior incidents from memory, proposes a fix, and pings you on Slack: "Issue #847, fix proposed, awaiting your review." You approve from your phone.
+
+### Get a brief that already knows your week.
+
+Recurring task, every morning at 8am. CORE pulls from email, GitHub, Linear, and Slack, surfaces what actually needs attention, skips what does not, and turns follow-ups into tasks automatically.
+
+---
+
+## Next steps
 
 <CardGroup cols={3}>
-  <Card title="Concepts" icon="brain" href="/introduction">
-    The four pillars: memory, agent, toolkit, proactive actions.
+  <Card title="Connect apps" icon="plug" href="/toolkit/overview">
+    50+ connectors — GitHub, Linear, Slack, Gmail, and more.
   </Card>
   <Card title="Memory" icon="database" href="/memory/overview">
-    How your butler never forgets anything you tell it.
+    How CORE remembers across every tool and conversation.
   </Card>
-  <Card title="Toolkit" icon="wrench" href="/concepts/toolkit">
-    200+ actions across 50+ apps through a single connection.
+  <Card title="Skills" icon="wand-magic-sparkles" href="/skills/overview">
+    Reusable instructions that fire automatically based on context.
   </Card>
 </CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,81 +1,88 @@
 ---
-title: "CORE - Your Personal Butler"
-description: "The first AI butler you actually own. Open source. Named. Persistent. Yours."
+title: "Introduction"
+description: "Your personal AI OS — always on, always watching, open source and self-hosted."
 ---
 
-AI removed the inertia of building. CORE removes the inertia of operating.
+Not a chatbot you open. An AI that is always on, always watching.
+Name it. Shape it. Connect it to everything you use. Reach it however you work.
+Open source, self-hosted, yours forever.
 
-You built more tools, more systems, more things that need to run. Then the problem changed — it was no longer about building. It was about operating everything you built. Deployments to watch. Issues to follow up on. Customers to reply to. Systems that only worked if someone kept an eye on them.
+---
 
-Your butler handles that. It knows your tools, your preferences, and your people. It's always on, it remembers everything, and it acts — so you don't have to.
+## What CORE does
 
-**Open source. Named. Persistent. Yours.**
+CORE watches activity across your connected apps and AI sessions. An email arrives from a client, a GitHub issue gets assigned, a Sentry alert fires, a meeting ends — CORE sees it, checks your memory and the skills you have set, and either handles it or surfaces it for your judgment. You do not trigger it. It notices on its own.
 
-## What Makes a Personal Butler?
+It remembers what matters. Not just what you said, but what you decided, when, and why — across every tool and conversation. Install the CORE plugin in Claude Code, Codex, or Cursor and your agent sessions get watched too, so the next task CORE picks up already knows what happened in your last session.
 
-A personal butler isn't just another AI assistant. It needs to do four things:
+When it acts, it acts directly. It can reply to emails, update Linear issues, file GitHub PRs, send Slack messages, run terminal commands, drive a browser, and spawn a Claude Code or Codex session — from any interface, even when your laptop is closed. The gateway is what makes this possible: it runs on your machine or in Docker and Railway, keeping CORE operational around the clock.
 
-### It Remembers Everything
+Where it acts on its own and where it waits for your call is yours to set, per task, per app, per action.
 
-Nothing you say is ever lost. Every conversation, decision, preference, and relationship is retained - not as raw text, but as structured knowledge. It knows who said what, when things changed, and what kind of information it's holding (a preference vs. a decision vs. a goal). Ask about something from weeks ago and the answer is there, with full context of how you got there.
+---
 
-CORE implements this through a [temporal knowledge graph](/memory/overview) that captures, classifies, and connects everything over time.
+## Four ways to reach it
 
-### It Can Take Actions
+A chatbot has one interface. An OS has many.
 
-Remembering is not enough if it can't act on what it knows. A personal butler should be able to perform actions on your behalf without you leaving the conversation.
-
-Simple actions: create a GitHub issue, send a Slack message, add a calendar event.
-
-Complex actions: research LinkedIn to find leads matching a criteria, add them to a Google Sheet, and send the sheet over Slack to your sales team — all from a single request. Multiple tools, multiple steps, orchestrated together with context carried through each one.
-
-CORE's [Toolkit](/concepts/toolkit) gives the brain hands — 200+ actions across 50+ apps, all through a single connection point.
-
-### It Thinks and Works Across Systems
-
-Your tools are siloed. Claude Code can't talk to your WhatsApp. Cursor can't check your calendar. A personal butler breaks these walls — it can access and coordinate across all your agents and apps from any single interface.
-
-Message the Butler on WhatsApp and it can spin up a Claude Code session to fix a bug, start a browser session to research something, or pull context from memory - all without you opening a laptop. One brain that reaches into every tool you use, from wherever you are.
-
-The [Agent](/concepts/meta-agent) is this orchestrator - it understands intent, searches memory, picks tools, and coordinates across agents and apps.
-
-### It Can Proactively Act
-
-You shouldn't have to ask for everything. A personal butler monitors what's happening — a new email, a GitHub event, a calendar change — and evaluates it against what it knows about you: your preferences, your rules, your relationships. When the situation calls for it, it acts on your behalf. An email arrives from a client; your butler already knows how you handle that relationship and drafts the right response for your review.
-
-CORE combines [Agent, Memory, and Toolkit](/memory/overview#how-core-learns-about-you) to make this happen.
-
-## How CORE Implements This
-
-CORE's architecture has three layers that implement these four pillars:
-
-<CardGroup cols={3}>
-  <Card title="Agent" icon="brain" href="/concepts/meta-agent">
-    The orchestrator. Understands intent, searches memory, routes to tools, and acts proactively. (Pillars 3 & 4)
+<CardGroup cols={2}>
+  <Card title="Voice" icon="microphone">
+    Press **Ctrl+Option** on Mac and say what needs doing. CORE runs it in the background without breaking your flow.
   </Card>
 
-  <Card title="Memory" icon="database" href="/memory/overview">
-    The knowledge graph. Stores episodes, entities, and facts. Gets smarter over time. (Pillar 1)
+  <Card title="Scratchpad" icon="pen-to-square">
+    Open your daily page and write `[ ] Fix the auth bug from issue #47`. CORE picks it up within 3 minutes, loads context from your repo and memory, and drafts a plan.
   </Card>
 
-  <Card title="Toolkit" icon="wrench" href="/concepts/toolkit">
-    The actions layer. 15+ app integrations through a single MCP endpoint. (Pillar 2)
+  <Card title="Messaging" icon="message">
+    WhatsApp, Slack, Telegram. Send a task from the airport, from your phone, from bed. CORE has your full context regardless of where the message comes from.
+  </Card>
+
+  <Card title="Chat" icon="comments">
+    Open the dashboard and talk directly. When you want a back-and-forth before delegating.
   </Card>
 </CardGroup>
 
-## Get Started
+One AI, four surfaces, the same memory and context behind all of them.
+
+---
+
+## Make it yours
+
+Give it a name. Choose how it speaks. Set the rules it follows everywhere.
+
+Pick from built-in personalities — TARS's dry efficiency, Alfred's loyal formality, Hudson's warm practicality — or write your own. The personality carries into every task it runs, every plan it drafts, every message it sends on your behalf.
+
+Choose its voice for spoken interactions. From then on, it sounds and behaves like the AI you configured, across every interface.
+
+---
+
+## What's inside CORE
+
+| | |
+|---|---|
+| **Memory** | Temporal knowledge graph across every tool and conversation. Preferences, decisions, goals, and directives — so every task starts with context loaded. |
+| **Tasks** | One-shot or recurring work units with your spec, CORE's plan, live state, and a dedicated chat thread. Each task can spawn coding, browser, or terminal sessions. |
+| **Connectors** | 50+ apps through one MCP endpoint, plus webhook triggers for proactive automation. GitHub, Linear, Jira, Slack, Gmail, Calendar, Sentry, Notion, Todoist, and more. |
+| **Skills** | Reusable instructions that fire automatically based on context — "always pull related Linear issues before planning a fix," "run tests before opening a PR." 100+ built-in, or write your own. |
+| **Gateway** | Runs Claude Code, Codex, browser agents, and terminal commands on your machine or in Docker and Railway, so CORE keeps working when your laptop is closed. |
+| **Model agnostic** | Bring your own provider: Anthropic, OpenAI, or open-weight models. Self-host the full stack for full isolation. |
+
+---
+
+## Get started
 
 <CardGroup cols={2}>
-  <Card title="Get Started" icon="rocket" href="/getting-started">
-    Ready to set it up? Cloud waitlist or self-host in minutes.
-  </Card>
-  <Card title="Talk to Your Butler" icon="message" href="/access-core/overview">
-    Connect via WhatsApp, Slack, email, or the web dashboard.
+  <Card title="Quickstart" icon="rocket" href="/getting-started">
+    Install and run CORE in minutes. Self-hosted, your data stays with you.
   </Card>
   <Card title="Self-Host" icon="server" href="/self-hosting/setup">
-    Open source. Run your butler on your own infrastructure — your data never leaves.
+    Full deployment guide — Docker, Railway, or your own infrastructure.
   </Card>
-  <Card title="Local Development" icon="code" href="/guides/local-setup">
-    Modify CORE's source code and run it locally.
+  <Card title="Memory" icon="database" href="/memory/overview">
+    How CORE remembers what matters across every tool and conversation.
+  </Card>
+  <Card title="Gateway" icon="terminal" href="/gateway/overview">
+    How CORE drives coding agents, browsers, and terminal commands.
   </Card>
 </CardGroup>

--- a/docs/self-hosting/setup.mdx
+++ b/docs/self-hosting/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Self-Host CORE"
-description: "Run your butler on your own infrastructure. Docker-based, fully open source."
+description: "Run CORE on your own infrastructure. Docker-based, fully open source."
 ---
 
 CORE runs as a set of Docker containers: the web app, PostgreSQL, Neo4j (memory graph), and Redis. You manage the infrastructure; your data never leaves your machine.
@@ -54,7 +54,7 @@ A channel is how you message your butler. **Email is the easiest to start with**
 | WhatsApp       | Medium    | Requires Twilio: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_WHATSAPP_NUMBER` |
 | Telegram       | Community | [Setup guide](/channels/telegram) |
 
-Once a channel is connected, send your first message: your butler will respond.
+Once a channel is connected, open the Scratchpad, write a `[ ]` task, and CORE will pick it up within 3 minutes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrites `introduction.mdx` and `getting-started.mdx` to reflect the new "Your personal AI OS" narrative, replacing all "Personal Butler" framing
- Adds new sections: "What CORE does" (watches/remembers/acts/escalates), "Four ways to reach it" (Voice, Scratchpad, Messaging, Chat), "Make it yours" (name, personality, voice)
- Adds inline quickstart, gateway setup, and "Your first task" walkthrough to getting-started with 5 CORE-in-action use cases
- Rewrites `concepts/tasks.mdx`: fixes all "SOL" → "CORE" references, adds task sources, anatomy with plan/sessions/chat thread fields, 5-step execution flow, recurring tasks
- Replaces all remaining "butler" references across `meta-agent.mdx`, `scratchpad.mdx`, `toolkit.mdx`, and `setup.mdx`

## Test plan

- [ ] Read through `introduction.mdx` — confirm no "butler" references, OS narrative is consistent with README
- [ ] Read through `getting-started.mdx` — confirm quickstart command, gateway setup, and first-task steps are present
- [ ] Read through `concepts/tasks.mdx` — confirm no "SOL" references remain
- [ ] Spot-check `scratchpad.mdx`, `meta-agent.mdx`, `toolkit.mdx` for any remaining "butler" language

🤖 Generated with [Claude Code](https://claude.com/claude-code)