### PR TITLE
fix: stop leaking MCP transports on stale-session POSTs

### DIFF
--- a/apps/webapp/app/services/mcp.server.ts
+++ b/apps/webapp/app/services/mcp.server.ts
@@ -390,21 +390,28 @@ async function createTransport(
     },
   });
 
-  const keepAlive = setInterval(() => {
-    try {
-      transport.send({ jsonrpc: "2.0", method: "ping" });
-    } catch (e) {
-      // If sending a ping fails, the connection is likely broken.
-      // Log the error and clear the interval to prevent further attempts.
-      logger.error("Failed to send keep-alive ping, cleaning up interval." + e);
-      clearInterval(keepAlive);
-    }
-  }, 30000); // Send ping every 60 seconds
+  // Only run keep-alive for sessionful transports. Stateless transports are
+  // one-shot and have no peer to ping; a setInterval here would retain the
+  // transport forever because transport.send() returns silently when no SSE
+  // stream is open (it does not throw), so the catch clause never clears it.
+  let keepAlive: ReturnType<typeof setInterval> | null = null;
+  if (!noSession) {
+    keepAlive = setInterval(() => {
+      try {
+        transport.send({ jsonrpc: "2.0", method: "ping" });
+      } catch (e) {
+        logger.error(
+          "Failed to send keep-alive ping, cleaning up interval." + e,
+        );
+        if (keepAlive) clearInterval(keepAlive);
+      }
+    }, 30000);
+  }
 
   // Setup cleanup on close
   transport.onclose = async () => {
     try {
-      clearInterval(keepAlive);
+      if (keepAlive) clearInterval(keepAlive);
       await MCPSessionManager.deleteSession(sessionId);
       await TransportManager.cleanupSession(sessionId);
     } catch (e) {
@@ -492,6 +499,10 @@ export const handleMCPRequest = async (
   try {
     let transport: StreamableHTTPServerTransport;
     let currentSessionId = sessionId;
+    // Stateless transports (noSession=true) are one-shot per SDK contract.
+    // Track them so we can close() after handleRequest — otherwise the
+    // transport + its MCP Server + tools closures are retained forever.
+    let isStateless = false;
 
     if (
       sessionId &&
@@ -521,6 +532,7 @@ export const handleMCPRequest = async (
             skipTools,
             true,
           );
+          isStateless = true;
 
           logger.log(`Successfully recreated session ${sessionId}`);
         } else {
@@ -561,6 +573,7 @@ export const handleMCPRequest = async (
         skipTools,
         true,
       );
+      isStateless = true;
 
       logger.log(`Successfully recreated session ${sessionId}`);
     } else {
@@ -571,8 +584,18 @@ export const handleMCPRequest = async (
       });
     }
 
-    // Handle the request through existing transport utility
-    return await transport.handleRequest(request, res, body);
+    try {
+      // Handle the request through existing transport utility
+      return await transport.handleRequest(request, res, body);
+    } finally {
+      if (isStateless) {
+        try {
+          await transport.close();
+        } catch (e) {
+          logger.error("Failed to close stateless transport", { error: e });
+        }
+      }
+    }
   } catch (error) {
     console.error("MCP SSE request error:", error);
     throw new Error("MCP SSE request error");

--- a/apps/webapp/app/utils/mcp/transport-manager.ts
+++ b/apps/webapp/app/utils/mcp/transport-manager.ts
@@ -49,11 +49,10 @@ export class TransportManager {
   ): void {
     const session = this.getOrCreateSession(sessionId);
     session.mainTransport = transport;
-
-    // Setup cleanup on transport close
-    transport.onclose = () => {
-      this.cleanupSession(sessionId);
-    };
+    // NOTE: do not override transport.onclose here — createTransport
+    // installs the canonical onclose (clearInterval + deleteSession +
+    // cleanupSession). Reassigning here would drop the keep-alive
+    // clearInterval and cause an OOM via retained timer closures.
   }
 
   /**


### PR DESCRIPTION
## Summary

Production webapp crashed with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` after ~8 hours uptime. The crash log showed 2,091 `Session X found in DB but not in memory. Recreating transport after server restart.` log lines over 8 hours — that path was leaking the full retained graph (transport + MCP `Server` + tool closures) per request, with GC unable to reclaim.

Three small fixes in two files:

- **`transport-manager.ts:setMainTransport`** — stop overriding `transport.onclose`. The override dropped the canonical cleanup (`clearInterval(keepAlive)` + `deleteSession` + `cleanupSession`) that `createTransport` installs, so even legitimate sessions leaked their keep-alive timer on disconnect.
- **`mcp.server.ts:createTransport`** — skip the keep-alive `setInterval` entirely when `noSession=true`. Stateless transports have no peer to ping, and the SDK's `transport.send()` returns silently when no SSE stream is open (it does not throw), so the catch clause never cleared the interval — the timer closure retained the transport forever.
- **`mcp.server.ts:handleMCPRequest`** — track `isStateless` and `await transport.close()` in a `finally` block. Stateless transports are one-shot per SDK contract (`Stateless transport cannot be reused across requests`) but the code wasn't calling `close()`, so the SDK never fired `onclose` and the retained graph was never released.

Sessionful transport behavior is unchanged — they continue to live across requests as before. Only the stale-session "recreate" path (which was never actually keeping the session alive across requests anyway) now disposes itself correctly.

## Verification

Standalone Node repro of the exact `createTransport` pattern:

| Mode | Start heap | End heap (3000 iterations) | Per-transport |
|------|-----------:|---------------------------:|--------------:|
| LEAK (buggy code) | 17.4 MB | 121.5 MB | ~35 KB retained |
| FIX (new code) | 17.4 MB | 17.9 MB | ~0 KB retained |

Forced `global.gc()` twice between samples — leak mode growth is genuinely retained memory GC can't reclaim, fix mode is flat.

## Test plan

- [ ] Deploy to staging and watch RSS/heap over 24h under normal MCP client traffic
- [ ] Confirm sessionful MCP clients (Claude Desktop, Cursor) still operate across multiple tool calls without re-initializing
- [ ] Confirm stale-session POSTs (after a server restart) still complete successfully — client behavior unchanged
- [ ] Watch logs for `Failed to close stateless transport` — should be rare/absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)