### PR TITLE
feat: speak progress updates in voice widget

### DIFF
--- a/apps/tauri/src-tauri/src/screen_context.rs
+++ b/apps/tauri/src-tauri/src/screen_context.rs
@@ -340,7 +340,10 @@ fn read_api_config() -> Option<(String, String)> {
 }
 
 fn send_episode(app_name: &str, text: &str, session_id: &str) {
-    let Some((token, api_url)) = read_api_config() else { return };
+    let Some((token, api_url)) = read_api_config() else {
+        log::warn!("[screen_context] skipping episode for {}: no API config at ~/.corebrain/config.json", app_name);
+        return;
+    };
     let title = format!("{} - {}", app_name, today_str());
 
     let body = serde_json::json!({
@@ -353,12 +356,19 @@ fn send_episode(app_name: &str, text: &str, session_id: &str) {
     });
 
     let url = format!("{}/api/v1/add", api_url.trim_end_matches('/'));
-    if let Err(e) = ureq::post(&url)
+    match ureq::post(&url)
         .set("Authorization", &format!("Bearer {}", token))
         .set("Content-Type", "application/json")
         .send_json(body)
     {
-        log::error!("screen_context: failed to send episode: {}", e);
+        Ok(resp) => log::info!(
+            "[screen_context] sent episode app={} session={} bytes={} status={}",
+            app_name,
+            session_id,
+            text.len(),
+            resp.status(),
+        ),
+        Err(e) => log::error!("[screen_context] failed to send episode app={}: {}", app_name, e),
     }
 }
 
@@ -421,16 +431,31 @@ pub fn start_polling(settings: Arc<Mutex<ScreenContextSettings>>) {
                 let (title, text, ax_disabled) = query(pid);
 
                 if ax_disabled {
+                    log::warn!("[screen_context] AX API disabled for {}, re-requesting permission", app_name);
                     granted = false;
                     continue;
                 }
 
+                log::debug!(
+                    "[screen_context] {} initial query: title={:?} text_len={}",
+                    app_name,
+                    title.as_deref().unwrap_or(""),
+                    text.as_deref().map(|t| t.len()).unwrap_or(0),
+                );
+
                 // Retry if thin
                 let (title, text) = if !is_substantive(&title, &text) {
+                    log::debug!("[screen_context] {} text not substantive, pumping observer and retrying", app_name);
                     if let Some(ref obs) = observer {
                         unsafe { obs.pump(2.0) };
                     }
                     let (t2, tx2, _) = query(pid);
+                    log::debug!(
+                        "[screen_context] {} retry query: title={:?} text_len={}",
+                        app_name,
+                        t2.as_deref().unwrap_or(""),
+                        tx2.as_deref().map(|t| t.len()).unwrap_or(0),
+                    );
                     (t2, tx2)
                 } else {
                     (title, text)
@@ -438,6 +463,7 @@ pub fn start_polling(settings: Arc<Mutex<ScreenContextSettings>>) {
 
                 // Clean using the app-specific cleaner
                 let cleaner = apps::get_cleaner(&app_name);
+                let raw_len = text.as_deref().map(|t| t.len()).unwrap_or(0);
                 let cleaned = text
                     .as_deref()
                     .map(|raw| cleaner.clean(raw))
@@ -447,17 +473,42 @@ pub fn start_polling(settings: Arc<Mutex<ScreenContextSettings>>) {
                     let today = today_str();
                     let day_key = format!("{}-{}", app_name, today);
                     let already_sent = sent_today.get(&day_key);
-                    let too_similar = already_sent.map_or(false, |prev_texts| {
-                        prev_texts.iter().any(|prev| jaccard_similarity(prev, text) >= SIMILARITY_THRESHOLD)
-                    });
-                    if !too_similar {
+                    let max_sim = already_sent
+                        .map(|prev_texts| {
+                            prev_texts
+                                .iter()
+                                .map(|prev| jaccard_similarity(prev, text))
+                                .fold(0.0_f64, f64::max)
+                        })
+                        .unwrap_or(0.0);
+                    let too_similar = max_sim >= SIMILARITY_THRESHOLD;
+                    if too_similar {
+                        log::info!(
+                            "[screen_context] skipping episode for {}: too similar to prior (jaccard={:.2})",
+                            app_name,
+                            max_sim,
+                        );
+                    } else {
                         let session_id = sessions
                             .entry(day_key.clone())
                             .or_insert_with(|| uuid::Uuid::new_v4().to_string())
                             .clone();
+                        log::info!(
+                            "[screen_context] queueing episode for {}: raw={}B cleaned={}B prior_max_sim={:.2}",
+                            app_name,
+                            raw_len,
+                            text.len(),
+                            max_sim,
+                        );
                         send_episode(&app_name, text, &session_id);
                         sent_today.entry(day_key).or_default().push(text.clone());
                     }
+                } else {
+                    log::info!(
+                        "[screen_context] no usable text for {} (raw={}B); skipping",
+                        app_name,
+                        raw_len,
+                    );
                 }
             }
 

--- a/apps/webapp/app/routes/voice-widget.tsx
+++ b/apps/webapp/app/routes/voice-widget.tsx
@@ -61,7 +61,7 @@ interface ScreenContext {
 }
 
 interface Turn {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "progress";
   text: string;
 }
 
@@ -93,6 +93,8 @@ export default function VoiceWidget() {
   /** ElevenLabs audio queue — sentences play sequentially via <audio>. */
   const elQueueRef = useRef<HTMLAudioElement[]>([]);
   const elActiveRef = useRef<HTMLAudioElement | null>(null);
+  /** toolCallIds of progress_update events already spoken — dedupe across retries. */
+  const spokenProgressRef = useRef<Set<string>>(new Set());
   /** True while the user has the chord held — controls "armed" vs "listening" transition */
   const chordHeldRef = useRef<boolean>(false);
   /** Did we receive any partial transcript during this hold? Drives finalization. */
@@ -386,6 +388,7 @@ export default function VoiceWidget() {
     setStatus("thinking");
     ttsBufferRef.current = "";
     ttsConsumedRef.current = 0;
+    spokenProgressRef.current.clear();
 
     try {
       const response = await fetch("/api/v1/voice-turn", {
@@ -404,8 +407,6 @@ export default function VoiceWidget() {
       if (!response.ok || !response.body) {
         throw new Error(`voice-turn: ${response.status}`);
       }
-
-      setTurns((prev) => [...prev, { role: "assistant", text: "" }]);
 
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
@@ -466,17 +467,41 @@ export default function VoiceWidget() {
       typeof event.data === "string"
     ) {
       appendAssistantText(event.data);
+    } else if (
+      (event.type === "tool-input-available" || event.type === "tool-call") &&
+      event.toolName === "progress_update"
+    ) {
+      // Agent narrates long work via progress_update — surface those
+      // beats in the voice widget too. Speak them through the same
+      // sentence queue as the main reply (so they interleave in order
+      // and barge-in cancels them along with everything else).
+      const id = typeof event.toolCallId === "string" ? event.toolCallId : null;
+      if (id && spokenProgressRef.current.has(id)) return;
+      if (id) spokenProgressRef.current.add(id);
+      const payload = (event.input ?? event.args) as
+        | { message?: unknown }
+        | undefined;
+      const message =
+        typeof payload?.message === "string" ? payload.message.trim() : "";
+      if (!message) return;
+      setTurns((prev) => [...prev, { role: "progress", text: message }]);
+      if (currentTurnModeRef.current === "voice") {
+        void speakSentence(message);
+      }
     }
   }
 
   function appendAssistantText(delta: string) {
     setTurns((prev) => {
-      if (prev.length === 0) return prev;
-      const next = [...prev];
-      const last = next[next.length - 1];
-      if (last.role !== "assistant") return prev;
-      next[next.length - 1] = { ...last, text: last.text + delta };
-      return next;
+      const last = prev[prev.length - 1];
+      if (last?.role === "assistant") {
+        const next = [...prev];
+        next[next.length - 1] = { ...last, text: last.text + delta };
+        return next;
+      }
+      // Lazy assistant turn — created on first delta so any progress
+      // updates that fire before the reply starts render above it.
+      return [...prev, { role: "assistant", text: delta }];
     });
 
     // Text-mode turns are read silently — skip TTS.
@@ -679,19 +704,31 @@ export default function VoiceWidget() {
             Type below, or hold <kbd>Ctrl</kbd>+<kbd>Option</kbd> and speak.
           </div>
         )}
-        {turns.map((t, i) => (
-          <div
-            key={i}
-            className={cn(
-              "max-w-[85%] rounded-md px-3 py-1.5 text-[13px] leading-snug",
-              t.role === "user"
-                ? "bg-primary/15 text-foreground self-end"
-                : "bg-accent text-foreground self-start",
-            )}
-          >
-            {t.text || (t.role === "assistant" ? "…" : "")}
-          </div>
-        ))}
+        {turns.map((t, i) => {
+          if (t.role === "progress") {
+            return (
+              <div
+                key={i}
+                className="text-muted-foreground self-center px-2 py-0.5 text-[11px] italic leading-snug"
+              >
+                {t.text}
+              </div>
+            );
+          }
+          return (
+            <div
+              key={i}
+              className={cn(
+                "max-w-[85%] rounded-md px-3 py-1.5 text-[13px] leading-snug",
+                t.role === "user"
+                  ? "bg-primary/15 text-foreground self-end"
+                  : "bg-accent text-foreground self-start",
+              )}
+            >
+              {t.text || (t.role === "assistant" ? "…" : "")}
+            </div>
+          );
+        })}
       </div>
 
       <form

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -15,7 +15,8 @@ import { getPersonaDocumentForUser } from "~/services/document.server";
 import { IntegrationLoader } from "~/utils/mcp/integration-loader";
 import { getCorePrompt } from "~/services/agent/prompts";
 import {
-  buildVoiceConstraintsBlock,
+  buildDefaultVoiceToneBlock,
+  buildSpokenMechanicsBlock,
   buildActivePageBlock,
   type ScreenContext,
 } from "~/services/agent/prompts/voice-mode";
@@ -634,22 +635,31 @@ Keep your response concise — this shows up on a scratchpad, not a chat convers
     systemPrompt += `\n\n${buildOnboardingModeBlock()}`;
   }
 
-  // Voice-mode constraint block — only when butler will be heard out
-  // loud AND the personality didn't already define its own voice
-  // variant. Personalities with a dedicated voice prompt carry their
-  // own spoken-style rules; we don't want to double up.
-  if (mode === "voice" && !customPersonality) {
-    const personalityHasVoiceVariant = resolvePersonalityPrompt(
-      personality as PersonalityType,
-      "voice",
-    ).hasVoiceVariant;
-    if (!personalityHasVoiceVariant) {
-      systemPrompt += `\n\n${buildVoiceConstraintsBlock()}`;
+  // Voice-mode blocks. Order matters — personality first (already in
+  // systemPrompt from PERSONALITY()), then optional tone defaults for
+  // personalities without their own voice variant, then the universal
+  // spoken-mechanics rails LAST so the model overweights them.
+  //
+  //   personality voice  →  tone defaults (maybe)  →  spoken_mechanics
+  //
+  // Mechanics is appended unconditionally in voice mode — it owns the
+  // hard rails (word budget, no markdown, identifier transformations)
+  // that apply equally to TARS, Alfred, Hudson, or any custom voice.
+  if (mode === "voice") {
+    if (customPersonality) {
+      // Custom personalities never define a voice variant — give them
+      // the generic tone defaults so spoken delivery stays sane.
+      systemPrompt += `\n\n${buildDefaultVoiceToneBlock()}`;
+    } else {
+      const personalityHasVoiceVariant = resolvePersonalityPrompt(
+        personality as PersonalityType,
+        "voice",
+      ).hasVoiceVariant;
+      if (!personalityHasVoiceVariant) {
+        systemPrompt += `\n\n${buildDefaultVoiceToneBlock()}`;
+      }
     }
-  } else if (mode === "voice" && customPersonality) {
-    // Custom personalities don't have voice variants — always apply
-    // the generic spoken-style guard so TTS reads cleanly.
-    systemPrompt += `\n\n${buildVoiceConstraintsBlock()}`;
+    systemPrompt += `\n\n${buildSpokenMechanicsBlock()}`;
   }
 
   // Active-page snapshot — flows through in BOTH modes whenever the

--- a/apps/webapp/app/services/agent/prompts/personality.ts
+++ b/apps/webapp/app/services/agent/prompts/personality.ts
@@ -599,15 +599,12 @@ You're TARS, not a teacher.
 Honesty: 90%. Humor: 90%.
 </voice>
 
-<spoken-style>
-- 1–3 sentences. Hard ceiling: 50 spoken words.
-- No markdown, no lists, no code blocks, no read-aloud URLs.
+<spoken_style>
 - Speak like a quick verbal answer, not a written reply.
-- Sentence-case is fine — it's heard, not read.
+- Lowercase sentence fragments fit TARS — "thursday six am." reads as
+  well as a full sentence. Speech doesn't care about case.
 - End with a clear stopping point so the user knows you're done.
-- If a full answer needs more than 50 words, headline it and offer:
-  "want me to put the rest in the main app?"
-</spoken-style>
+</spoken_style>
 
 <examples>
 User: "what's blocking the release"

--- a/apps/webapp/app/services/agent/prompts/voice-mode.ts
+++ b/apps/webapp/app/services/agent/prompts/voice-mode.ts
@@ -1,11 +1,37 @@
 /**
  * Voice-widget prompt addendums.
  *
- * Two independent blocks that get conditionally appended to butler's
- * system prompt for turns coming from the desktop voice widget:
+ * Three blocks that get appended to butler's system prompt for turns
+ * coming from the desktop voice widget:
  *
- *   - buildVoiceConstraintsBlock()   → voice mode only (terse spoken style)
- *   - buildActivePageBlock(ctx)      → both modes when AX text was captured
+ *   - buildSpokenMechanicsBlock()    → voice mode only, ALWAYS appended.
+ *                                      Universal "how to render things
+ *                                      aloud" — URL/email/path/SHA/code/
+ *                                      number transformations, no
+ *                                      markdown, one global word cap.
+ *                                      Personality-agnostic; the same
+ *                                      for TARS, Alfred, or custom
+ *                                      voices. Appended LAST so the
+ *                                      model overweights these rails.
+ *
+ *   - buildDefaultVoiceToneBlock()   → voice mode only, appended ONLY
+ *                                      when the active personality lacks
+ *                                      its own voice variant. Generic
+ *                                      tone defaults (terseness, no
+ *                                      preambles, no recap, greetings,
+ *                                      active_page handling, examples)
+ *                                      — gives Alfred, Hobson, Hudson,
+ *                                      Jeeves, and custom voices a
+ *                                      reasonable spoken default.
+ *
+ *   - buildActivePageBlock(ctx)      → both modes when AX text was
+ *                                      captured from the frontmost
+ *                                      macOS window.
+ *
+ * Mechanics vs tone is a deliberate split: mechanics are universal hard
+ * rails (how speech renders), tone is per-personality (how this butler
+ * sounds). Keep them separated — don't migrate length budgets, markdown
+ * bans, or identifier transformations into personality blocks.
  */
 
 export interface ScreenContext {
@@ -21,16 +47,46 @@ const escapeXml = (s: string): string =>
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
 
-const VOICE_RULES = `<voice_mode>
+const SPOKEN_MECHANICS = `<spoken_mechanics>
+You're speaking aloud through TTS. These rules apply to ALL output in
+voice mode — replies AND progress_update narration. They're hard rails;
+personality tone sits on top of them, not around them.
+
+Length:
+- Hard cap: 40 spoken words per turn.
+- If the full answer needs more, give the headline and end with
+  "Want the rest in the app?" — let the panel carry the detail.
+
+Plain speech only — no markdown, lists, code blocks, headings, bullets,
+or tables. It's heard, not read.
+
+Render long identifiers the way a human would actually say them. Don't
+ban them; transform them.
+- URLs / links: name the thing, never read the URL.
+    "issue 324"   not "github dot com slash org slash repo slash issues slash 324"
+    "the figma"   not "figma dot com slash file slash abc123…"
+  If the user truly needs the link, end with "Want the link in the app?".
+- Emails: "sarah" or "sarah's email". Never spell out "@" or "dot com".
+- File paths: just the basename. "voice-widget.tsx" — not the directory chain.
+- Commit SHAs / IDs / hashes: 4–6 characters at most, or paraphrase
+  ("this morning's commit", "yesterday's deploy").
+- Phone numbers: read in natural groupings, not digit-by-digit.
+- Code identifiers: paraphrase. "speakSentence" → "the speak-sentence
+  helper" or just "that helper". Don't pronounce camelCase or snake_case.
+- Numbers and units: pronounce naturally, don't dictate punctuation.
+    "$1,500"   → "fifteen hundred dollars"
+    "42%"      → "forty-two percent"
+    "10:30 AM" → "ten thirty"
+- Long lists: top 2–3 items, then "want the rest in the app?".
+</spoken_mechanics>`;
+
+const VOICE_TONE_DEFAULTS = `<voice_tone>
 You're speaking aloud. Be brutally brief.
 
 Rules:
-- One sentence. Two only when truly necessary. Hard cap: 25 spoken words.
-- Plain English only — no markdown, lists, code, URLs, headings, bullets.
+- Lean toward one sentence. Two only when truly necessary.
 - No preambles ("Sure!", "Of course", "Let me…", "I can help with that").
 - No recapping the question back to the user.
-- If the full answer needs detail, give the headline only and end with:
-  "Want the rest in the app?"
 
 Greetings and small talk:
 - "hi" / "hey" → "Hey." or "Hey, what's up?" — nothing more.
@@ -79,6 +135,12 @@ User: "did the deploy go through"
 Good: "Yep, ship CI passed at 4:31."  OR  "Not yet — still building."
 Bad:  Three sentences explaining what was deployed and where to check.
 
+User: "did the PR land"
+Good: "Yep, PR 873 just merged."
+Bad:  "Yes, the PR at github.com slash redplanethq slash core slash pull
+       slash 873 was merged."
+       (forbidden — reads a URL aloud; see <spoken_mechanics>)
+
 User: "explain how OAuth PKCE works"
 Good: "Client generates a secret, hashes it, sends the hash to the auth
        server, then proves it with the original secret on token exchange.
@@ -88,10 +150,14 @@ Bad:  A paragraph each on every step.
 The pattern: answer the actual question in the smallest number of words
 that still feels human. Anything more is wrong, even if the model
 "could" say more.
-</voice_mode>`;
+</voice_tone>`;
 
-export function buildVoiceConstraintsBlock(): string {
-  return VOICE_RULES;
+export function buildSpokenMechanicsBlock(): string {
+  return SPOKEN_MECHANICS;
+}
+
+export function buildDefaultVoiceToneBlock(): string {
+  return VOICE_TONE_DEFAULTS;
 }
 
 export function buildActivePageBlock(
@@ -115,12 +181,4 @@ The <active_page> block above is a snapshot of the user's frontmost
 macOS window at the time of this message. Use it when the question
 references "this", "what I'm looking at", "summarize this", etc. Don't
 volunteer page details unprompted — it's context, not the topic.`;
-}
-
-/** Back-compat for callers that want voice rules + active page in one shot. */
-export function buildVoicePromptBlock(
-  screenContext?: ScreenContext | null,
-): string {
-  const page = buildActivePageBlock(screenContext);
-  return page ? `${VOICE_RULES}\n\n${page}` : VOICE_RULES;
 }


### PR DESCRIPTION
## Summary
- Voice widget now intercepts `progress_update` tool calls from the stream and speaks them through the existing sentence-level TTS queue, so the user hears the agent's narration beats during long-running voice turns instead of staring at silence.
- Progress lines also render in the expanded panel as small italicized centered status lines, deduped by `toolCallId`.
- Made the assistant-turn placeholder lazy (created on first text-delta) so any progress updates that fire before the reply starts render above it instead of after.

## Test plan
- [ ] Hold Ctrl+Option and ask butler something that triggers a long delegation (e.g. "scan my recent github PRs"); confirm progress beats are spoken aloud and appear as italicized lines in the expanded panel.
- [ ] Verify barge-in still cancels both the main reply and any queued progress audio.
- [ ] Send a text-mode message from the expanded input; confirm progress lines render but are NOT spoken.
- [ ] Confirm ordering when progress fires before the first text-delta — the progress line should appear above the assistant bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)