### PR TITLE
fix: preserve direct tool calls in cross-turn agent history

### DIFF
--- a/apps/webapp/app/routes/api.v1.conversation._index.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation._index.tsx
@@ -35,6 +35,7 @@ import { patchArgsDeep } from "~/services/agent/tool-args-patch-processor";
 import {
   selectModelMessages,
   describeAgentError,
+  prepareHistoryParts,
   type MessageEntry,
 } from "~/services/agent/context-window";
 
@@ -217,10 +218,7 @@ const { loader, action } = createHybridActionApiRoute(
         const role =
           history.role ?? (history.userType === "Agent" ? "assistant" : "user");
         const normalized = normalizeParts(history.parts);
-        const parts =
-          role === "assistant"
-            ? normalized.filter((p: any) => p.type === "text")
-            : normalized;
+        const parts = prepareHistoryParts(role, normalized);
         return { parts, role, id: history.id };
       },
     );

--- a/apps/webapp/app/routes/api.v1.voice-turn.tsx
+++ b/apps/webapp/app/routes/api.v1.voice-turn.tsx
@@ -31,6 +31,7 @@ import {
   resolveModelConfig,
 } from "~/services/llm-provider.server";
 import { buildAgentContext } from "~/services/agent/context";
+import { prepareHistoryParts } from "~/services/agent/context-window";
 import { mastra } from "~/services/agent/mastra";
 import {
   saveConversationResult,
@@ -83,14 +84,19 @@ const { loader, action } = createHybridActionApiRoute(
     // Build conversation history snapshot for the model
     const conversation = await getConversationAndHistory(conversationId, userId);
     const history = (conversation?.ConversationHistory ?? []).map(
-      (h: any) => ({
-        id: h.id,
-        role: h.userType === "Agent" ? "assistant" : "user",
-        parts:
+      (h: any) => {
+        const role: "assistant" | "user" =
+          h.userType === "Agent" ? "assistant" : "user";
+        const rawParts =
           h.parts && Array.isArray(h.parts) && h.parts.length > 0
             ? h.parts
-            : [{ type: "text", text: h.message ?? "" }],
-      }),
+            : [{ type: "text", text: h.message ?? "" }];
+        return {
+          id: h.id,
+          role,
+          parts: prepareHistoryParts(role, rawParts),
+        };
+      },
     );
 
     const modelString = body.modelId ?? getDefaultChatModelId();

--- a/apps/webapp/app/services/agent/context-window.ts
+++ b/apps/webapp/app/services/agent/context-window.ts
@@ -28,6 +28,32 @@ export interface MessageEntry {
   parts: MessagePart[];
 }
 
+/**
+ * Trim assistant-role history parts before sending them back to the model.
+ *
+ * Keeps direct tool calls intact so the agent remembers what it actually did
+ * last turn (otherwise it has been observed denying its own tool calls — e.g.
+ * calling `create_skill` then claiming it never ran). Collapses sub-agent
+ * tool calls (`tool-agent-*`) to drop their inlined `subAgentToolResults`
+ * trace, since the parent has already synthesized whatever mattered into the
+ * following text part and carrying the full sub-agent trace forward bloats
+ * context turn after turn.
+ */
+export function prepareHistoryParts(
+  role: "user" | "assistant" | "system",
+  parts: MessagePart[],
+): MessagePart[] {
+  if (role !== "assistant") return parts;
+  return parts.map((p) => {
+    if (typeof p.type === "string" && p.type.startsWith("tool-agent-")) {
+      const output = (p as { output?: { text?: unknown } }).output ?? {};
+      const text = typeof output.text === "string" ? output.text : "";
+      return { ...p, output: { text } };
+    }
+    return p;
+  });
+}
+
 export type SelectionMode = "full" | "compact+recent" | "budget-trim";
 
 export interface SelectionResult {

--- a/apps/webapp/app/services/agent/no-stream-process.ts
+++ b/apps/webapp/app/services/agent/no-stream-process.ts
@@ -26,6 +26,7 @@ import {
   selectModelMessages,
   generateWithRetry,
   describeAgentError,
+  prepareHistoryParts,
   type MessageEntry,
 } from "./context-window";
 
@@ -120,10 +121,7 @@ export async function noStreamProcess(
       const role =
         history.role ?? (history.userType === "Agent" ? "assistant" : "user");
       const normalized = normalizeParts(history.parts);
-      const parts =
-        role === "assistant"
-          ? normalized.filter((p: any) => p.type === "text")
-          : normalized;
+      const parts = prepareHistoryParts(role, normalized);
       return { parts, role, id: history.id };
     })
     .filter((m) => hasNonEmptyParts(m.parts));


### PR DESCRIPTION
## Summary

The agent was losing memory of its own tool calls between turns. When users asked the agent to update an existing skill, it would call `create_skill` instead, then on the next turn deny that the create_skill call ever happened ("I did not create anything new just now"). The root cause was the history rebuild filter stripping all non-text parts from assistant rows before feeding them back to the model.

Three rebuild sites were involved:

- `apps/webapp/app/routes/api.v1.conversation._index.tsx` — main web chat path. Stripped tool parts.
- `apps/webapp/app/services/agent/no-stream-process.ts` — background jobs / channel runs (Slack, Twilio, scratchpad scans, scheduled reminders). Stripped tool parts.
- `apps/webapp/app/routes/api.v1.voice-turn.tsx` — voice widget. Did the opposite — passed everything through unfiltered, which carried the entire inlined `subAgentToolResults` trace forward every turn (a single sub-agent call can be 3000+ tokens of progress updates, integration probes, and raw responses).

## What changed

Added `prepareHistoryParts` in `context-window.ts` that:
- Keeps assistant text parts as before.
- Keeps direct tool calls (`tool-create_skill`, `tool-update_skill`, `tool-web_search`, etc.) intact with their input AND output, so the agent remembers what it did.
- Collapses sub-agent calls (`tool-agent-*`) to just `{ output: { text } }` — drops the `subAgentToolResults` trace. The parent has already synthesized whatever mattered into its following text part, so the trace is redundant; keeping it inflates every future turn.

Applied at all three rebuild sites for consistency.

## Why this is the right tradeoff

- Parent text replies already contain the salient bits the model surfaced from sub-agent results, so follow-ups still work.
- Internal sub-agent results the parent didn't bother surfacing get dropped. That's intentional — if it didn't matter enough to mention, it doesn't matter enough to balloon every next turn.
- Direct tool calls survive, so the create_skill-then-deny class of bug is fixed.

## Test plan

- [ ] Web chat: trigger a sub-agent call (e.g. ask anything that hits gather_context for a gateway), follow up with another turn, confirm the previous sub-agent's `subAgentToolResults` are NOT in the model context (check via Mastra logs / network).
- [ ] Web chat: call a direct tool (e.g. create_skill), follow up by asking "what did you just do?" — agent should accurately report the tool call instead of denying.
- [ ] Voice widget: same sub-agent test — confirm bloat is gone.
- [ ] Background job (scratchpad scan or scheduled reminder): confirm conversation history continues working.
- [ ] Approval-resume flow (write tool requiring user approval): confirm the resume path still works since it uses `body.messages` directly (bypasses this filter entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)