### PR TITLE
chore: log memory_ingest enqueue + worker firing for debugging

### DIFF
--- a/apps/webapp/app/jobs/case/case.logic.ts
+++ b/apps/webapp/app/jobs/case/case.logic.ts
@@ -196,6 +196,10 @@ async function runMemoryIngestCase(
     timezone,
   } = payload;
 
+  logger.info(
+    `[case/memory_ingest] Firing for document ${documentId} (session=${sessionId}, source=${source}, kind=${kind})`,
+  );
+
   try {
     // Read the latest compact for this document fresh. The payload was
     // captured 10 minutes ago when the first compact in this bucket fired;

--- a/apps/webapp/app/jobs/session/session-compaction.logic.ts
+++ b/apps/webapp/app/jobs/session/session-compaction.logic.ts
@@ -636,7 +636,7 @@ async function enqueueMacMemoryIngest(args: {
       (user.metadata as Record<string, unknown> | null) ?? null;
     const timezone = (userMetadata?.timezone as string) ?? "UTC";
 
-    await enqueueCase({
+    const result = await enqueueCase({
       type: "memory_ingest",
       workspaceId: args.workspaceId,
       userId: args.userId,
@@ -647,6 +647,11 @@ async function enqueueMacMemoryIngest(args: {
       kind: args.kind,
       timezone,
     });
+
+    logger.info(
+      `[memory-ingest] Enqueued Mac compact ${args.sessionId} (document=${args.documentId}, kind=${args.kind}, jobId=${result?.id ?? "unknown"}). ` +
+        `Throttled to once per documentId per 10 minutes — first fire will run after the bucketed delay elapses.`,
+    );
   } catch (err) {
     logger.error(
       `[memory-ingest] Failed to enqueue Mac compact ${args.sessionId}: ${err}`,


### PR DESCRIPTION
## Summary

Adds two diagnostic log lines so the memory_ingest pipeline is observable end-to-end without needing to query BullMQ directly.

After this lands, a Mac session compact produces:

\`\`\`
Session compaction completed
[memory-ingest] Enqueued Mac compact <sessionId> (document=<docId>, kind=created, jobId=case-memory-ingest-<docId>-<bucket>). Throttled to once per documentId per 10 minutes — first fire will run after the bucketed delay elapses.
\`\`\`

…and then, 10 minutes later when the bucket delay elapses:

\`\`\`
[case/memory_ingest] Firing for document <docId> (session=<sessionId>, source=mac, kind=created)
\`\`\`

That makes it easy to confirm both the enqueue side and the worker side are wired correctly. Especially helpful while validating the rollout.

## Notes

- No behavior changes — same throttle, same dedup, same worker logic.
- The "Enqueued" log goes through \`logger.info\` so it shows in the standard webapp logs, not just worker logs.

## Test plan

- [ ] Trigger a Mac session compact in dev.
- [ ] Confirm \`[memory-ingest] Enqueued Mac compact ...\` appears in the webapp logs right after \"Session compaction completed\".
- [ ] Confirm BullMQ worker metrics show \`[case] ... Delayed: 1\` until the bucket elapses.
- [ ] After ~10 min, confirm \`[case/memory_ingest] Firing for document ...\` appears in the worker logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)