### PR TITLE
fix: include repo name in GitHub user-event activity text

### DIFF
--- a/integrations/github/src/schedule.ts
+++ b/integrations/github/src/schedule.ts
@@ -241,19 +241,19 @@ async function processUserEvents(
 
           switch (event.type) {
             case 'pr':
-              title = `${username} created PR #${event.number}: ${event.title}`;
+              title = `${username} created PR #${event.number} in ${event.repository?.full_name}: ${event.title}`;
               break;
             case 'issue':
-              title = `${username} created issue #${event.number}: ${event.title}`;
+              title = `${username} created issue #${event.number} in ${event.repository?.full_name}: ${event.title}`;
               break;
             case 'pr_comment':
-              title = `${username} commented on PR #${event.number}: ${event.title}`;
+              title = `${username} commented on PR #${event.number} in ${event.repository?.full_name}: ${event.title}`;
               break;
             case 'issue_comment':
-              title = `${username} commented on issue #${event.number}: ${event.title}`;
+              title = `${username} commented on issue #${event.number} in ${event.repository?.full_name}: ${event.title}`;
               break;
             case 'self_assigned_issue':
-              title = `${username} assigned themselves to issue #${event.number}: ${event.title}`;
+              title = `${username} assigned themselves to issue #${event.number} in ${event.repository?.full_name}: ${event.title}`;
               break;
             default:
               title = `GitHub activity: ${event.title || 'Unknown'}`;


### PR DESCRIPTION
processUserEvents was omitting repository context from all five activity text strings (pr, issue, pr_comment, issue_comment, self_assigned_issue), producing text like "harshithmullapudi created issue #52: Jason" instead of "harshithmullapudi created issue #52 in owner/repo: Jason". The repository field is already present on every Search API item via object spread in getUserEvents; this change references event.repository?.full_name in each case to match the format used by processNotifications.