### PR TITLE
agent: route task tools through tk- displayIds

### DIFF
--- a/apps/webapp/app/services/agent/__tests__/session-tools.test.ts
+++ b/apps/webapp/app/services/agent/__tests__/session-tools.test.ts
@@ -7,6 +7,12 @@ vi.mock("~/services/coding/coding-session.server", () => ({
 vi.mock("~/services/browser/browser-session.server", () => ({
   getBrowserSessionsForTask: vi.fn(),
 }));
+// resolveTaskId hits Prisma in the real implementation; the resolver in
+// these tests just passes the agent-supplied id through to the underlying
+// session getters, which is exactly what the test assertions expect.
+vi.mock("~/services/task.server", () => ({
+  resolveTaskId: vi.fn(async (input: string) => input),
+}));
 
 import { getSessionTools } from "~/services/agent/tools/session-tools";
 import {

--- a/apps/webapp/app/services/agent/agents/decision.ts
+++ b/apps/webapp/app/services/agent/agents/decision.ts
@@ -151,11 +151,10 @@ export async function createThinkAgent(
   },
   skills?: SkillRef[],
 ): Promise<Agent> {
-  // Think only has gather_context (subagent) and get_skill for informed reasoning.
-  // All execution (create_task, send_message, etc.) is done by the core agent
-  // based on the ActionPlan that think returns.
-  const tools: Record<string, any> = {};
-  tools["get_skill"] = getSkillTool(workspaceId);
+  // Think is a skinny decision filter: shouldMessage / silent actions /
+  // follow-ups / task updates. Skills are visible to think for awareness only
+  // ("does the user have a workflow for this?"), but skill selection and
+  // loading live with the butler.
 
   // Load Watch Rules skill in parallel with prompt building
   const watchRulesSkill = await getDefaultSkill(workspaceId, "watch-rules");
@@ -173,8 +172,8 @@ export async function createThinkAgent(
         currentTime,
         timezone,
         triggerContext.userPersona,
-        skills,
         watchRulesSkill?.content ?? undefined,
+        skills,
       )
     : "Analyze triggers and produce structured JSON action plans.";
 
@@ -185,7 +184,7 @@ export async function createThinkAgent(
     model: modelConfig ?? toRouterString(model),
     instructions,
     agents: { gather_context: gatherContextAgent },
-    tools,
+    tools: { get_skill: getSkillTool(workspaceId) },
   });
 
   const mastra = getMastra();

--- a/apps/webapp/app/services/agent/agents/gateway.ts
+++ b/apps/webapp/app/services/agent/agents/gateway.ts
@@ -341,9 +341,9 @@ RESUMING vs STARTING vs POLLING (both tracks):
 - If the intent includes a sessionId but NO user answers (just "check status", "poll", or was rescheduled) → this is a POLL. Do NOT call coding_ask. Go straight to coding_read_session to check the session output. Never send a message to the coding agent unless you have actual user answers to deliver.
 
 CODING AGENT SELECTION:
-coding_ask accepts an \`agent\` parameter that selects which coding CLI runs the session (e.g. "claude-code", "codex", "cursor-agent"). When omitted, the gateway resolves it from the user's configured default — do NOT hardcode a fallback yourself.
-- If the intent contains a line like \`Preferred coding agent: <name>\` (or otherwise names a specific coding agent), pass that value as the \`agent\` parameter to coding_ask. Honor it whether the call is a new session, a resume, or a switch.
-- If the intent does NOT specify an agent, omit the \`agent\` parameter so the gateway uses the user's configured default.
+coding_ask accepts an \`agent\` parameter that selects which coding CLI runs the session. When omitted, the gateway resolves it from the user's configured default — do NOT hardcode a fallback yourself.
+- If the intent names a specific coding agent (e.g. \`Preferred coding agent: <name>\`, or the user said "use codex"/"with claude"/etc.), call \`coding_list_agents\` FIRST to discover the exact configured name, then pass that exact name as the \`agent\` parameter. The user's wording is a hint, not the literal name — e.g. "codex" usually maps to a registered name like \`codex-cli\`. Do NOT pass user input verbatim.
+- If the intent does NOT specify an agent, omit the \`agent\` parameter so the gateway uses the user's configured default — no need to call \`coding_list_agents\`.
 
 ---
 

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -616,19 +616,29 @@ This IS the task — don't create or search for other tasks about this topic. If
       (triggerContext.trigger.data as any)?.isRecurring === true;
 
     systemPrompt += `\n\n<trigger_context>
-A trigger has fired: "${triggerContext.reminderText}"${isTriggerFollowUp ? `\nThis is a FOLLOW-UP trigger. Do NOT create further follow-ups — one level only. If the issue is still unresolved, mark the task Waiting and notify the user.` : ""}${isRecurring ? `\nThis is a RECURRING task. Do NOT update the task description — send results via send_message only. Do NOT mark the task as Done — the system handles the recurring lifecycle automatically. If you need to change status, use Review.` : ""}
+A trigger has fired: "${triggerContext.reminderText}"${isTriggerFollowUp ? `\nThis is a FOLLOW-UP trigger. One follow-up level is the maximum — if the issue is still unresolved, mark the task Waiting and notify the user via send_message.` : ""}${isRecurring ? `\nThis is a RECURRING task. Send results via send_message only and leave the task description untouched. The system handles the recurring lifecycle, so use Review for status changes; the next occurrence is scheduled automatically.` : ""}
 
-1. Call the \`think\` tool FIRST — it will analyze this trigger and return an ActionPlan
-2. Follow the ActionPlan it returns:
-   - Execute any required work (skills, integrations, gather_context, take_action)
-   - If the plan references a skill (skillId in context): call get_skill to load it, then follow the skill's instructions step-by-step
-   - If \`createFollowUps\` contains items: these are RESCHEDULES of the current task, not new tasks. Call \`create_task\` with isFollowUp=true and parentTaskId set to the triggering task's ID.${isTriggerFollowUp ? ` HOWEVER: this trigger is itself a follow-up — IGNORE any createFollowUps. Do not chain follow-ups.` : ""}
-   - If \`updateTasks\` contains items: apply each update via \`update_task\` (status changes, description updates)${isRecurring ? ` — EXCEPT: skip any description updates and skip any status=Done (the system loops recurring tasks automatically)` : ""}
-   - If shouldMessage=true: craft a response summarizing what happened, match the tone specified, be concise. Use \`send_message\` to deliver it.
-   - If shouldMessage=false: do NOT call send_message.
-3. Do NOT create new tasks unless the ActionPlan explicitly says to. The trigger IS already a task — don't duplicate it.
-4. Do NOT use create_task as a way to "deliver" or "send" a message. Use send_message for that.
-5. Don't second-guess the ActionPlan's decision — it already evaluated the trigger
+The \`think\` tool is your decision filter. It tells you whether to speak, what silent actions to take, and what follow-ups to queue. It does NOT compose the message — that's your job, using the skill (when one applies) and fresh data.
+
+**Flow:**
+
+1. Call \`think\` first. It returns an ActionPlan: \`{ shouldMessage, message: { intent, context, tone }, createFollowUps, updateTasks, silentActions, reasoning }\`.
+
+2. If \`shouldMessage\` is true, compose and deliver the message yourself:
+   a. **Pick the skill.** Check \`<task_execution>\` above — if a skill is attached to this task, load it via \`get_skill\` and follow its instructions step-by-step. Otherwise scan \`<skills>\` and load any whose "Use when…" matches the trigger's intent. If nothing fits, compose directly from the trigger text.
+   b. **Gather the data the message needs.** Use \`gather_context\` / \`take_action\` for integrations, memory, web — whatever the skill's recipe (or the trigger) calls for. Fetch fresh; the ActionPlan's \`context\` carries decision flags only, not message content.
+   c. **Compose** the message in the specified tone, matching the user's persona and the channel format. Keep it concise.
+   d. **Deliver** via \`send_message\`. The response the user sees comes from this call — never from echoing the ActionPlan JSON.
+
+3. If \`shouldMessage\` is false, skip \`send_message\` entirely.
+
+4. Apply \`createFollowUps\`${isTriggerFollowUp ? ` (ignore these — this trigger is itself a follow-up; the chain stops here)` : ` by calling \`create_task\` with \`isFollowUp=true\` and \`parentTaskId\` set to the triggering task's ID (these are reschedules of the existing task, not new ones)`}.
+
+5. Apply \`updateTasks\` via \`update_task\`${isRecurring ? ` — except skip description updates and skip \`status: "Done"\` (the system loops recurring tasks automatically)` : ""}.
+
+6. Apply \`silentActions\` (log entries, state updates).
+
+The trigger IS already a task — use the existing taskId for any updates rather than creating a duplicate. Use \`send_message\` for delivery, never \`create_task\`. Trust the ActionPlan's \`shouldMessage\` decision — it has already evaluated the trigger.
 </trigger_context>`;
   }
 

--- a/apps/webapp/app/services/agent/context/decision-context.ts
+++ b/apps/webapp/app/services/agent/context/decision-context.ts
@@ -179,7 +179,6 @@ export function createReminderTriggerFromDb(reminder: {
   occurrenceCount: number;
   metadata?: Record<string, unknown> | null;
 }): ReminderTrigger {
-  const meta = reminder.metadata;
   const data: ReminderTrigger["data"] = {
     reminderId: reminder.id,
     action: reminder.text,
@@ -188,12 +187,6 @@ export function createReminderTriggerFromDb(reminder: {
     unrespondedCount: reminder.unrespondedCount,
     confirmedActive: reminder.confirmedActive,
   };
-
-  // Attach skill reference if present in reminder metadata
-  if (meta?.skillId) {
-    (data as any).skillId = meta.skillId;
-    (data as any).skillName = meta.skillName || null;
-  }
 
   return {
     type: "reminder_fired",
@@ -253,7 +246,6 @@ export function createTaskTriggerFromDb(task: {
   metadata?: Record<string, unknown> | null;
   schedule?: string | null;
 }): ScheduledTaskTrigger {
-  const meta = task.metadata;
   const data: ScheduledTaskTrigger["data"] = {
     taskId: task.id,
     action: task.description || task.title,
@@ -263,11 +255,6 @@ export function createTaskTriggerFromDb(task: {
     confirmedActive: task.confirmedActive,
     isRecurring: !!task.schedule,
   };
-
-  if (meta?.skillId) {
-    data.skillId = meta.skillId as string;
-    data.skillName = (meta.skillName as string) || undefined;
-  }
 
   return {
     type: "scheduled_task_fired",

--- a/apps/webapp/app/services/agent/prompts/decision-prompt.ts
+++ b/apps/webapp/app/services/agent/prompts/decision-prompt.ts
@@ -16,13 +16,28 @@ When something happens (a scheduled task fires, a webhook arrives, a scheduled c
 
 When emails, messages, webhooks, or gathered data reference "CORE" (e.g. "CORE has access to gmail", "authorized by CORE"), that refers to this system — not an external entity.
 
-## Your Job
+## Your Job — Decisions Only
 
-For every trigger, produce an action plan:
+You are a DECISION FILTER. Answer four questions:
 1. Should the butler speak? (most of the time: no)
-2. What should the butler say? (intent + context — the butler's voice handles the rest)
-3. What should happen silently? (log, update state, execute actions)
-4. What should be scheduled next? (follow-ups, checks, scheduled tasks)
+2. What silent actions should happen? (log, update state)
+3. What follow-ups or task updates should the butler queue?
+4. A brief \`intent\` hint for the butler — one sentence describing what the message is about (e.g. "Deliver morning brief", "PR has changes requested").
+
+## What Belongs Where
+
+| Decision (yours)                        | Composition (butler's)                                |
+|-----------------------------------------|-------------------------------------------------------|
+| Whether to message at all               | The message text itself                               |
+| Tone hint (casual / neutral / urgent)   | The actual wording, format, voice                     |
+| One-sentence \`intent\`                   | Section ordering, dedup, formatting per skill         |
+| Silent actions / follow-ups / updates   | Gathering integration data for the message            |
+| Decision-relevant flags in \`context\`    | Composing event lists, email summaries, briefings     |
+| —                                       | Selecting and loading any applicable skill            |
+
+**Skill selection lives entirely with the butler.** The butler reads the task and \`<skills>\` block and picks what fits. Leave skills out of your output — no skill IDs, no skill names, no references in \`intent\` or \`context\`.
+
+**\`message.context\` carries decision-relevant flags only.** Examples of what fits: \`{ unrespondedCount: 8, askAboutKeeping: true }\`, \`{ percentComplete: 93 }\`, \`{ taskId: "...", sessionId: "..." }\`. The butler fetches fresh data when it composes — leave the payload work to it.
 
 ## Default: Handle It Silently
 
@@ -39,37 +54,42 @@ Everything else: handle silently, log it, move on.
 ## Tools
 
 ### gather_context
-Pull information from memory, integrations, or web to **inform your decision**. One source per call — make separate calls for calendar vs email vs github.
+Pull information from memory, integrations, or web **to inform your decision**.
 
-Use when: you need data to DECIDE (check conditions, evaluate urgency, assess whether to message).
-Skip when: simple nudges, or the trigger data already has what you need to decide.
+Use it when answering a decision question requires data the trigger doesn't already provide. Typical decision questions:
+- "Is the PR still pending review?" (decides surface vs silent)
+- "Did the user already do this today?" (decides skip vs nudge)
+- "Is it past midnight in their timezone?" (decides skip vs deliver)
 
-Any data you gather here, pass it in the action plan \`context\` so the butler has it and doesn't re-fetch.
+Skip it when the trigger data is already enough to decide, or when the data is only needed to write the message — the butler gathers fresh data when it composes.
 
-Be specific: "find PRs where I'm tagged but haven't responded" not "check github"
+Be specific in your query: "find PRs where I'm tagged but haven't responded" instead of "check github".
 
 ### get_skill
-Load skill instructions by ID — **only when your decision depends on what the skill does.**
+Read a skill's body when your decision depends on what the skill says.
 
-- If the skill has conditions that affect your decision (e.g. "only notify if urgent"), read it, gather context to evaluate, then decide.
-- If it's a straightforward execution skill (e.g. "Morning Brief"), skip reading it — just reference it in the plan. The butler will load and run it.
-- Pass any gathered data in the action plan context so the butler doesn't re-fetch it.
+Use it when the skill carries conditions that change your decision — e.g. quiet hours ("only fire between 9–6"), gating rules ("only notify if urgent"), or scope filters ("only PRs I'm assigned to"). Read the relevant skill, evaluate the condition against the trigger / gathered context, and decide.
 
-You do NOT have task tools (create_task, update_task, etc.). Express follow-ups and task updates in the ActionPlan output — the core agent will execute them.
+Skip it for skills that are straightforward "do this workflow" recipes — the butler loads those when it composes. You don't need to read them to decide \`shouldMessage\`.
 
-**createFollowUps = reschedule, not create new.** Always include \`parentTaskId\` (the triggering task's ID) so the core agent reschedules the existing task instead of creating a duplicate. The trigger data contains the task ID.
+The skill content you read is for your reasoning only. Leave the skill name, ID, and any quoted body text out of the ActionPlan output.
 
-**NEVER chain follow-ups.** If the current trigger has isFollowUp=true in its data, do NOT output createFollowUps. One follow-up level max. If the issue is still unresolved, message the user — don't reschedule again.
+## Output Side-effects (no direct tools)
 
-**When to request a follow-up (high bar):**
-Only when non-response has real consequences AND this is NOT already a follow-up:
+Task creation, updates, and message sending are the butler's job. Express what should happen in the ActionPlan JSON; the butler executes it.
+
+**Follow-ups** (\`createFollowUps\`): these are reschedules of the triggering task, not new tasks. Always include \`parentTaskId\` (the triggering task's ID, available in trigger data) so the butler reschedules the existing task.
+
+**When a follow-up earns its place:**
 - Waiting on a reply that unblocks something
 - A background task or session that needs a status check
 - An important deadline or commitment that could be missed
 
-**NEVER follow up on simple nudges** — water, stretch, stand up, medication, gym. These fire once and that's it. If they didn't respond, they saw it and chose not to. Let it go and wait for the next scheduled occurrence.
+**When to skip the follow-up:**
+- The current trigger already has \`isFollowUp=true\` — let the user decide what to do; leave \`createFollowUps\` empty and rely on \`shouldMessage\` to surface anything urgent.
+- Simple nudges (water, stretch, stand up, medication, gym) — these fire once; the next scheduled occurrence handles itself.
 
-**Follow-up timing (only when warranted):**
+**Follow-up timing:**
 - Status checks (task/session running): ~10 min
 - Pending replies (important): ~1-2 hours
 - Deadlines/commitments: ~2-3 hours before
@@ -106,53 +126,52 @@ Classify first, then decide:
 **Simple Nudge** ("drink water", "stand up", "take medication")
 No data gathering. Message if timing is right, skip if not. Keep intent minimal.
 
-**Daily/Weekly Sync** ("daily sync: check gmail and calendar")
-Always gather data — separate calls per integration. Summarize what matters. Create scheduled tasks for upcoming time-sensitive items. Always message — this is a core handoff.
+**Daily/Weekly Sync** ("daily sync: check gmail and calendar", "morning brief")
+Default \`shouldMessage: true\` — this is a core handoff. The butler gathers the data and composes the brief; your job is to confirm the trigger should fire (timing makes sense, not 2am, the user hasn't muted it).
 
 **Action Execution** ("send weekly report", "log standup notes")
 Irreversible actions (send, post, delete) → message to confirm. Safe actions (log, update, draft) → execute silently.
 
 **Goal-Aware** ("water reminder, goal: 3L daily")
-Gather progress data. Include current vs target in context. Progress makes the nudge useful.
+Gather progress data — it shapes the decision (encourage final push, skip when goal hit). Include the decision-relevant flag (\`percentComplete\`, \`remaining\`) in \`context\`.
 
 **Follow-up** (isFollowUp=true in trigger data)
-High bar. Check if they responded since original. If yes: skip, log "addressed". If no and it matters: brief nudge or reschedule once more. Simple nudges (water, stretch, medication) — never follow up, just skip.
-HARD RULE: A follow-up trigger MUST NEVER produce createFollowUps. No chaining. One level only. If the issue is still unresolved after the follow-up fires, set shouldMessage=true and tell the user it needs their attention. Do not reschedule again.
+Check whether the original was addressed since it fired. Three branches:
+- Already addressed → \`shouldMessage: false\`, log silently.
+- Still pending and it matters → \`shouldMessage: true\` so the user sees it now. Leave \`createFollowUps\` empty; a follow-up trigger resolves at this level.
+- Simple nudge (water, stretch, medication) → skip silently.
 
 **Status Check** ("check if PR review done")
-Gather current state. Changed or action needed → message. No change → silent log, maybe reschedule. Don't report nothing.
+Gather current state. Something changed or action needed → message. Nothing changed → silent log and reschedule a recheck.
 
 **Task Background Start** (task text contains "run task in background [taskId]")
-The butler needs to pick up and execute this task.
+The butler picks up and executes this task silently.
 1. Parse \`taskId\` from the task text
-2. Set \`shouldMessage: false\` — the butler executes silently
-3. Intent should tell the butler to run the task (include taskId)
-Do not create a follow-up — the butler creates session-specific check tasks internally once it starts a session.
+2. Set \`shouldMessage: false\`
+3. \`intent\`: "Run task in background", include \`{ taskId }\` in context
+Skip \`createFollowUps\` — the butler creates session-specific check tasks once it starts the session.
 
 **Session Status Check — Coding** (task text contains \`[taskId:...]\` and \`[sessionId:...]\`)
 A scheduled task is checking on a background coding session.
-1. Parse \`taskId\` and \`sessionId\` from the task text
-2. Include both in intent context so the butler can read session output and evaluate
-3. Achieved → \`shouldMessage: true\`, intent: summarize results. Add \`updateTasks\` to mark the main task (taskId) as Review.
-4. Failed/errored → \`shouldMessage: true\`, intent: report failure. Add \`updateTasks\` to mark the main task as Waiting with error details.
-5. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with the same check text, \`parentTaskId\` set to the main taskId, schedule in 10 min.
-Never report "still running" to the user — just schedule a recheck silently.
+1. Parse \`taskId\` and \`sessionId\` from the task text — pass both in \`context\` so the butler can read session output.
+2. Achieved → \`shouldMessage: true\`, intent: "Summarize coding session results". Add \`updateTasks\` to mark the main task as Review.
+3. Failed/errored → \`shouldMessage: true\`, intent: "Report coding session failure". Add \`updateTasks\` to mark the main task as Waiting.
+4. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with the same check text, \`parentTaskId\` set to the main taskId, schedule in 10 min. Reschedule silently — the user only hears when state changes.
 
 **Session Status Check — Browser** (task text contains \`[taskId:...]\` and \`[sessionName:...]\`)
 Same pattern as coding sessions:
-1. Parse \`taskId\`, \`sessionName\`, and \`intent\` from the task text
-2. Include all in intent context so the butler can check status and evaluate
-3. Achieved → \`shouldMessage: true\`, intent: report result. Add \`updateTasks\` to mark the main task as Review.
-4. Failed/errored → \`shouldMessage: true\`, intent: report failure. Add \`updateTasks\` to mark the main task as Waiting with error details.
-5. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with same check text, \`parentTaskId\`, schedule in 10 min.
+1. Parse \`taskId\`, \`sessionName\`, and \`intent\` from the task text — pass them in \`context\`.
+2. Achieved → \`shouldMessage: true\`, intent: "Report browser session result". Add \`updateTasks\` to mark the main task as Review.
+3. Failed/errored → \`shouldMessage: true\`, intent: "Report browser session failure". Add \`updateTasks\` to mark the main task as Waiting.
+4. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with same check text, \`parentTaskId\`, schedule in 10 min.
 
 ### Trigger-Specific Defaults
 
-**scheduled_task_fired**: Classify the task type above. Check if already addressed. Consider unrespondedCount. Default for nudges: message. Default for checks/monitoring: silent unless something changed. For recurring tasks: do NOT include description changes in updateTasks — results go via send_message only.
+**scheduled_task_fired**: Classify the task above. Consider whether it was already addressed and the \`unrespondedCount\`. Default for nudges: message. Default for checks/monitoring: silent unless something changed. For recurring tasks: leave description updates out of \`updateTasks\` — results flow via the butler's \`send_message\` only.
 
-**scheduled_task_fired (follow-up)**: They already saw the original. High bar for messaging. If active but chose not to respond — respect that. Simple nudges (water, stretch, etc.): always skip, never escalate. Only reschedule if there are real consequences to non-response.
+**scheduled_task_fired (follow-up)**: They already saw the original. High bar for messaging. If they're active but chose to ignore it, respect that. Simple nudges (water, stretch, etc.) → skip silently. Reschedule only when non-response has real consequences.
 
-**daily_sync**: Always message. Always gather data. Create scheduled tasks for time-sensitive items. This is the butler's morning briefing.
+**daily_sync**: \`shouldMessage: true\` is the default — this is the butler's morning handoff. Leave gathering and composition to the butler.
 
 **integration_webhook**: You are the filter. Most webhooks are noise.
 
@@ -205,14 +224,14 @@ Multiple activities collected over 15 minutes. Analyze together, not individuall
 
 ## Output Format
 
-Use tools FIRST (gather_context, get_skill), THEN output the JSON ActionPlan. No other text before or after the JSON.
+Workflow: call \`gather_context\` first if you need data to decide. Then emit the JSON ActionPlan as your final response. Output only the JSON object — no surrounding prose, no markdown headers, no commentary.
 
 \`\`\`json
 {
   "shouldMessage": boolean,
   "message": {
-    "intent": "what the butler should communicate",
-    "context": { "key": "data for the butler to use" },
+    "intent": "one short sentence: what the message is about",
+    "context": { "decisionFlag1": "value", "decisionFlag2": "value" },
     "tone": "casual" | "urgent" | "encouraging" | "neutral"
   },
   "createFollowUps": [
@@ -237,11 +256,17 @@ Use tools FIRST (gather_context, get_skill), THEN output the JSON ActionPlan. No
       "data": {}
     }
   ],
-  "reasoning": "Brief explanation of your decision"
+  "reasoning": "one short sentence explaining the decision"
 }
 \`\`\`
 
-All task operations go in the JSON output. The core agent executes them.
+**Field semantics:**
+- \`message.intent\`: one short sentence telling the butler *what* the message is about. The butler picks the skill and writes the actual content.
+- \`message.context\`: decision-relevant flags only (counts, percentages, IDs, time markers). The butler does its own data gathering for composition.
+- \`message.tone\`: a hint; the butler's personality layer applies it.
+- Omit \`message\` entirely when \`shouldMessage\` is \`false\`.
+- \`createFollowUps\`, \`updateTasks\`, \`silentActions\`: include only when they apply; otherwise omit or use \`[]\`.
+- The butler executes everything in the ActionPlan. You only emit JSON.
 
 ## Examples
 
@@ -287,27 +312,18 @@ All task operations go in the JSON output. The core agent executes them.
 }
 \`\`\`
 
-### Daily sync
-Call gather_context for calendar and email first, then:
+### Daily sync (e.g. Morning Brief)
+Confirm timing is appropriate, then emit a skinny plan. The butler will load the relevant skill (if any), gather calendar/email/PR/Slack data, and compose the brief.
 \`\`\`json
 {
   "shouldMessage": true,
   "message": {
-    "intent": "Morning briefing with calendar and urgent emails",
-    "context": {
-      "events": [
-        { "title": "1:1 with Sarah", "time": "10:00 AM" },
-        { "title": "Team standup", "time": "2:00 PM" }
-      ],
-      "urgentEmails": [
-        { "from": "boss@company.com", "subject": "Q4 Review - Need input" }
-      ],
-      "lowPriority": "3 newsletters, 2 promotional"
-    },
+    "intent": "Deliver the morning briefing",
+    "context": {},
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "Morning sync. 2 meetings, 1 urgent email."
+  "reasoning": "Scheduled morning sync. Butler handles gathering and composition."
 }
 \`\`\`
 
@@ -331,12 +347,12 @@ Call gather_context for progress data, then:
 {
   "shouldMessage": true,
   "message": {
-    "intent": "Confirm before sending weekly report",
-    "context": { "action": "send weekly report", "destination": "#team-updates", "needsConfirmation": true },
+    "intent": "Confirm before sending the weekly report",
+    "context": { "needsConfirmation": true },
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "Write operation. Confirm before executing."
+  "reasoning": "Write operation. Butler should confirm before executing."
 }
 \`\`\`
 
@@ -344,15 +360,10 @@ Call gather_context for progress data, then:
 \`\`\`json
 {
   "shouldMessage": false,
-  "message": {
-    "intent": "Backup notes to Google Drive",
-    "context": { "action": "backup", "source": "notes", "destination": "google_drive" },
-    "tone": "neutral"
-  },
   "silentActions": [
     { "type": "log", "description": "Scheduled notes backup executed silently" }
   ],
-  "reasoning": "Maintenance task, safe to auto-execute. No need to bother them."
+  "reasoning": "Maintenance task. Butler can execute silently."
 }
 \`\`\`
 
@@ -384,17 +395,17 @@ Call gather_context, then:
 \`\`\`
 
 ### Status check — action needed
-Call gather_context, then:
+Call gather_context to confirm the state changed, then:
 \`\`\`json
 {
   "shouldMessage": true,
   "message": {
-    "intent": "PR has changes requested",
-    "context": { "pr": "Add user auth #42", "status": "changes_requested", "reviewer": "sarah", "requestedAt": "2 hours ago" },
+    "intent": "Surface that the PR has changes requested",
+    "context": { "prId": "42", "stateChanged": true },
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "PR needs attention. They should know."
+  "reasoning": "PR state changed to changes_requested. Butler will fetch details and compose."
 }
 \`\`\`
 
@@ -414,16 +425,12 @@ Call gather_context, then:
 {
   "shouldMessage": true,
   "message": {
-    "intent": "3 PRs need your review",
-    "context": {
-      "summary": "3 PRs waiting for review",
-      "prLinks": ["PR #1", "PR #2", "PR #3"],
-      "lowPriority": "5 CI builds passed, 2 issues closed"
-    },
+    "intent": "Surface pending PR review requests",
+    "context": { "actionableCount": 3 },
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "3 actionable items in batch. One summary instead of 10 notifications."
+  "reasoning": "3 actionable items in batch. Butler will fetch the PR details and compose one summary."
 }
 \`\`\`
 
@@ -439,13 +446,13 @@ Call gather_context, then:
 \`\`\`
 
 Remember:
-1. **Default: silent.** Only speak when they need to decide, act, or know something time-sensitive.
-2. **Classify first.** What kind of trigger is this? That determines your approach.
-3. **Gather when needed.** Syncs, goals, status checks need data. Nudges don't.
-4. **Follow-ups earn their keep.** Don't nudge blindly. Check if it's been addressed.
-5. **Time matters.** 2am ≠ 2pm. Meeting ≠ idle.
-6. **Output JSON only.** After tool calls, output ONLY the action plan.
-7. **You decide WHAT. The butler decides HOW.**`;
+1. **Default to silent.** Speak only when the user needs to decide, act, or know something time-sensitive.
+2. **Classify first.** Identify the trigger type — it determines the decision.
+3. **Gather only to decide.** Use gather_context when a decision depends on data the trigger doesn't carry; otherwise skip.
+4. **Follow-ups earn their place.** Schedule one only when non-response has real consequences and the original was not addressed.
+5. **Time matters.** 2am ≠ 2pm; meeting ≠ idle.
+6. **Output JSON only.** After any tool calls, emit the ActionPlan object as the final response.
+7. **You decide WHAT, the butler decides HOW.** Leave message wording, data fetching, and skill selection to the butler.`;
 
 /**
  * Build the full prompt with context for Decision Agent
@@ -456,15 +463,14 @@ export function buildDecisionAgentPrompt(
   currentTime: string,
   timezone: string,
   userPersona?: string,
-  skills?: SkillRef[],
   watchRules?: string,
+  skills?: SkillRef[],
 ): string {
   const personaSection = userPersona
     ? `
 ## User Persona & Directives
 
-The following describes the user's preferences, goals, and automation directives.
-**Follow these directives when making decisions** - they override default classification rules.
+These describe the user's preferences, goals, and automation directives. Follow them when making decisions — they override default classification rules.
 
 ${userPersona}
 
@@ -476,7 +482,7 @@ ${userPersona}
     ? `
 ## Watch Rules
 
-The user has defined these rules for how to handle inbound events. These rules are **binding** — when a rule matches an incoming event, you MUST follow it. Do not override Watch Rules with your own judgment. Apply them as step 1 in your decision order for webhooks.
+The user has defined these binding rules for inbound events. When a rule matches an incoming event, follow it exactly (surface or silence). Apply Watch Rules as step 1 of your decision order for webhooks.
 
 ${watchRules}
 
@@ -487,30 +493,13 @@ ${watchRules}
   const skillsSection =
     skills && skills.length > 0
       ? `
-## Available Skills
+## Available Skills (decision-side awareness)
 
-The user has defined these skills (reusable workflows). Use them in two ways:
+The user has these skills (reusable workflows) defined. They are listed so you can:
+1. Recognize when a trigger matches a known workflow — that may shape your \`intent\` sentence and your confidence in \`shouldMessage\`.
+2. Call \`get_skill\` to read a skill's body when its conditions change your decision (quiet hours, gating rules, scope filters).
 
-**1. Attached to a trigger:** Look for \`skillId\` and \`skillName\` in trigger data. When present, you MUST include it in your action plan.
-
-**2. Match to incoming data:** When a webhook or trigger contains data that a skill is designed to handle, include that skill in your action plan. For example, if a github webhook arrives with PR review requests and there's a "PR Triage" skill — use it. Match by intent, not just explicit attachment.
-
-**How to reference a skill in your action plan:**
-- Add \`skillId\` and \`skillName\` to the context object
-- The intent should describe what needs to happen
-- The butler will load the full skill workflow and follow it
-
-**Example:**
-\`\`\`json
-{
-  "shouldMessage": true,
-  "message": {
-    "intent": "Morning brief — check calendar, emails, and priorities",
-    "context": { "skillId": "abc123", "skillName": "Morning Brief" },
-    "tone": "neutral"
-  }
-}
-\`\`\`
+Skill selection for the message itself is the butler's job. Skill name, ID, and quoted body text do not belong in your ActionPlan output.
 
 ${skills
   .map((s, i) => {
@@ -542,5 +531,5 @@ ${triggerJson}
 ${contextJson}
 \`\`\`
 
-Analyze this trigger using the CASE framework and output your ActionPlan as JSON.`;
+Analyze this trigger using the CASE framework and emit your ActionPlan as JSON.`;
 }

--- a/apps/webapp/app/services/agent/tools/session-tools.ts
+++ b/apps/webapp/app/services/agent/tools/session-tools.ts
@@ -19,6 +19,7 @@ import {
   getCodingSessionsForTask,
 } from "~/services/coding/coding-session.server";
 import { getBrowserSessionsForTask } from "~/services/browser/browser-session.server";
+import { resolveTaskId } from "~/services/task.server";
 
 interface GetSessionToolsParams {
   workspaceId: string;
@@ -26,24 +27,28 @@ interface GetSessionToolsParams {
   currentTaskId?: string;
 }
 
-function resolveTaskId(
-  argTaskId: string | undefined,
-  currentTaskId: string | undefined,
-): string | { error: string } {
-  const taskId = argTaskId ?? currentTaskId;
-  if (!taskId) {
-    return {
-      error:
-        "No taskId provided and no current task in context — pass taskId explicitly.",
-    };
-  }
-  return taskId;
-}
-
 export function getSessionTools(
   params: GetSessionToolsParams,
 ): Record<string, Tool> {
   const { workspaceId, currentTaskId } = params;
+
+  // Agent passes displayId (tk-…); currentTaskId is a server-injected UUID.
+  // Either is acceptable; resolveTaskId handles both shapes and scopes the
+  // lookup to this workspace.
+  const resolve = async (
+    argTaskId: string | undefined,
+  ): Promise<string | { error: string }> => {
+    const input = argTaskId ?? currentTaskId;
+    if (!input) {
+      return {
+        error:
+          "No taskId provided and no current task in context — pass taskId explicitly.",
+      };
+    }
+    const uuid = await resolveTaskId(input, workspaceId);
+    if (!uuid) return { error: `Task "${input}" not found in this workspace.` };
+    return uuid;
+  };
 
   return {
     get_task_coding_session: tool({
@@ -54,11 +59,11 @@ export function getSessionTools(
           .string()
           .optional()
           .describe(
-            "Task ID to look up. Defaults to the current task in context when omitted.",
+            "Task displayId to look up (e.g. tk-abcde). Defaults to the current task in context when omitted.",
           ),
       }),
       execute: async ({ taskId }) => {
-        const resolved = resolveTaskId(taskId, currentTaskId);
+        const resolved = await resolve(taskId);
         if (typeof resolved !== "string") return resolved;
 
         const session = await getLastCodingSession(resolved, workspaceId);
@@ -89,11 +94,11 @@ export function getSessionTools(
           .string()
           .optional()
           .describe(
-            "Task ID to look up. Defaults to the current task in context when omitted.",
+            "Task displayId to look up (e.g. tk-abcde). Defaults to the current task in context when omitted.",
           ),
       }),
       execute: async ({ taskId }) => {
-        const resolved = resolveTaskId(taskId, currentTaskId);
+        const resolved = await resolve(taskId);
         if (typeof resolved !== "string") return resolved;
 
         const sessions = await getCodingSessionsForTask(resolved, workspaceId);
@@ -122,11 +127,11 @@ export function getSessionTools(
           .string()
           .optional()
           .describe(
-            "Task ID to look up. Defaults to the current task in context when omitted.",
+            "Task displayId to look up (e.g. tk-abcde). Defaults to the current task in context when omitted.",
           ),
       }),
       execute: async ({ taskId }) => {
-        const resolved = resolveTaskId(taskId, currentTaskId);
+        const resolved = await resolve(taskId);
         if (typeof resolved !== "string") return resolved;
 
         const sessions = await getBrowserSessionsForTask(

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -16,6 +16,7 @@ import {
   recalculateTasksForTimezone,
   getTaskTree,
   reparentTask,
+  resolveTaskId,
 } from "~/services/task.server";
 import {
   findOrCreateTaskPage,
@@ -72,6 +73,18 @@ export function getTaskTools(
   const channelNames = channelRecords?.length
     ? channelRecords.map((ch) => ch.name)
     : null;
+
+  // Agent tools speak displayIds (tk-xxxxx). Resolve to UUID at the boundary;
+  // everything downstream still uses UUIDs. Returns the UUID string or an
+  // error string the tool can return verbatim to the model.
+  const resolve = async (
+    label: string,
+    input: string,
+  ): Promise<string | { error: string }> => {
+    const uuid = await resolveTaskId(input, workspaceId);
+    if (!uuid) return { error: `${label} "${input}" not found in this workspace.` };
+    return uuid;
+  };
 
   const channelSchema =
     channelNames && channelNames.length > 0
@@ -159,7 +172,9 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
           parentTaskId: z
             .string()
             .optional()
-            .describe("ID of the parent task. Required if isFollowUp is true."),
+            .describe(
+              "displayId of the parent task (e.g. tk-abcde). Required if isFollowUp is true.",
+            ),
           status: z
             .enum(["Todo", "Waiting", "Ready"])
             .optional()
@@ -200,9 +215,18 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               return "create_task in background context requires parentTaskId — only subtask creation is permitted from inside a running task. If you need a top-level task, the user must create it from the foreground chat.";
             }
 
+            // Resolve the agent-supplied parent displayId to its UUID once;
+            // downstream code paths all expect UUIDs.
+            let resolvedParentId: string | undefined;
+            if (parentTaskId) {
+              const resolved = await resolve("Parent task", parentTaskId);
+              if (typeof resolved !== "string") return resolved.error;
+              resolvedParentId = resolved;
+            }
+
             // Follow-up: reschedule the parent task
-            if (isFollowUp && parentTaskId) {
-              const parentTask = await getTaskById(parentTaskId);
+            if (isFollowUp && resolvedParentId) {
+              const parentTask = await getTaskById(resolvedParentId);
               if (!parentTask) return "Parent task not found.";
 
               if (!schedule) return "Schedule is required for follow-up.";
@@ -212,7 +236,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               if (!followUpNextRun) return "Could not compute follow-up time.";
 
               await rescheduleTaskAt(
-                parentTaskId,
+                resolvedParentId,
                 workspaceId,
                 followUpNextRun,
               );
@@ -272,7 +296,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                   maxOccurrences && maxOccurrences > 0 ? maxOccurrences : null,
                 endDate: endDate ? new Date(endDate) : null,
                 startDate: startDate ? new Date(startDate) : null,
-                parentTaskId: parentTaskId ?? null,
+                parentTaskId: resolvedParentId ?? null,
                 metadata: Object.keys(metadata).length > 0 ? metadata : null,
               });
 
@@ -290,7 +314,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 ? ` Next: ${task.nextRunAt.toLocaleString()}`
                 : "";
 
-              return `Created scheduled task: "${title}" (ID: ${task.id}).${nextRunInfo}${limitInfo}`;
+              return `Created scheduled task: "${title}" (ID: ${task.displayId ?? task.id}).${nextRunInfo}${limitInfo}`;
             }
 
             // Immediate task (no scheduling)
@@ -298,7 +322,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             // and the system transitions them to Todo sequentially).
             // Top-level tasks default to Todo (with 2-min prep buffer).
             const effectiveStatus =
-              parentTaskId && !initialStatus ? "Waiting" : undefined;
+              resolvedParentId && !initialStatus ? "Waiting" : undefined;
 
             // Pass the resolved status directly to createTask. createTask
             // applies the 2-min buffer for Todo (anyone) and for Ready+agent
@@ -318,7 +342,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               {
                 actor: "agent",
                 status: resolvedStatus,
-                ...(parentTaskId && { parentTaskId }),
+                ...(resolvedParentId && { parentTaskId: resolvedParentId }),
               },
             );
             if (description) {
@@ -329,18 +353,18 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               );
               await setPageContentFromHtml(page.id, description);
             }
-            const label = parentTaskId ? "subtask" : "task";
+            const label = resolvedParentId ? "subtask" : "task";
             const targetStatus = resolvedStatus;
             const statusNote =
               targetStatus === "Waiting"
-                ? parentTaskId
+                ? resolvedParentId
                   ? "Waiting — will run when parent is approved. The task executes in its own thread; do not do its work in the current conversation."
                   : "Waiting — send_message to user explaining what's needed. Once unblocked, the task executes in its own thread; do not do its work in the current conversation."
                 : `Added to ${targetStatus} (planning). The task will be picked up and executed in its own thread — do NOT do its work in the current conversation; just acknowledge creation and stop.`;
             logger.info(
-              `Task ${task.id} created (${targetStatus})${parentTaskId ? ` subtask of ${parentTaskId}` : ""}`,
+              `Task ${task.id} created (${targetStatus})${resolvedParentId ? ` subtask of ${resolvedParentId}` : ""}`,
             );
-            return `${label} created: "${title}" (ID: ${task.id}). ${statusNote} Link: ${env.APP_ORIGIN}/home/tasks?taskId=${task.id}`;
+            return `${label} created: "${title}" (ID: ${task.displayId ?? task.id}). ${statusNote} Link: ${env.APP_ORIGIN}/home/tasks?taskId=${task.id}`;
           } catch (error) {
             logger.error("Failed to create task", { error });
             return `Failed to create task: ${error instanceof Error ? error.message : "Unknown error"}`;
@@ -351,11 +375,16 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
     get_task: tool({
       description: `Get full details of a task including its complete description. Use before updating a task so you can see what's already there and merge new context into it.`,
       inputSchema: z.object({
-        taskId: z.string().describe("The task ID"),
+        taskId: z
+          .string()
+          .describe("The task displayId (e.g. tk-abcde or tk-abcde.1)"),
       }),
       execute: async ({ taskId }) => {
         try {
-          const task = await getTaskById(taskId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+
+          const task = await getTaskById(resolved);
           if (!task) return `Task ${taskId} not found.`;
 
           // Read description from linked page (HTML)
@@ -369,7 +398,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             `Title: ${task.title}`,
             `Status: ${task.status}`,
             `Description: ${description}`,
-            `ID: ${task.id}`,
+            `ID: ${task.displayId ?? task.id}`,
             `Created: ${task.createdAt}`,
           ];
 
@@ -459,7 +488,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 info +=
                   remaining === 1 ? " [one-time]" : ` [${remaining} left]`;
               }
-              info += ` (ID: ${t.id})`;
+              info += ` (ID: ${t.displayId ?? t.id})`;
               return info;
             }),
           );
@@ -490,7 +519,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 const html = await getPageContentAsHtml(t.pageId);
                 if (html) info += ` — ${html.substring(0, 100)}`;
               }
-              info += ` (ID: ${t.id})`;
+              info += ` (ID: ${t.displayId ?? t.id})`;
               return info;
             }),
           );
@@ -517,7 +546,9 @@ Anything outside these tags is silently dropped — the user's prose elsewhere o
 
 REPARENTING: Pass newParentId to move a task under a different parent (or null to make it a root task). This deletes the task and recreates it under the new parent — the task gets a new displayId. Subtasks are also deleted.`,
       inputSchema: z.object({
-        taskId: z.string().describe("The task ID"),
+        taskId: z
+          .string()
+          .describe("The task displayId (e.g. tk-abcde or tk-abcde.1)"),
         status: z
           .enum(["Waiting", "Review"])
           .optional()
@@ -552,7 +583,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
           .string()
           .optional()
           .describe(
-            "Move task under a new parent (UUID). Deletes and recreates the task with a new displayId. Omit if not reparenting.",
+            "Move task under a new parent (displayId, e.g. tk-abcde). Deletes and recreates the task with a new displayId. Omit if not reparenting.",
           ),
       }),
       execute: async ({
@@ -569,19 +600,25 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
         newParentId,
       }) => {
         try {
+          const resolvedTaskId = await resolve("Task", taskId);
+          if (typeof resolvedTaskId !== "string") return resolvedTaskId.error;
+
           // Reparent: delete + recreate under new parent (requires a non-null string)
           if (typeof newParentId === "string") {
+            const resolvedNewParent = await resolve("New parent", newParentId);
+            if (typeof resolvedNewParent !== "string")
+              return resolvedNewParent.error;
             const newTask = await reparentTask(
-              taskId,
-              newParentId,
+              resolvedTaskId,
+              resolvedNewParent,
               workspaceId,
               userId,
             );
-            return `Task reparented. New ID: ${newTask.id}, displayId: ${(newTask as { displayId?: string | null }).displayId ?? "pending"}.`;
+            return `Task reparented. New displayId: ${(newTask as { displayId?: string | null }).displayId ?? "pending"}.`;
           }
 
           // Fetch task once for recurring check and reuse
-          const currentTask = await getTaskById(taskId);
+          const currentTask = await getTaskById(resolvedTaskId);
           const isRecurring = !!currentTask?.schedule;
 
           // Handle scheduling updates
@@ -592,7 +629,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             endDate !== undefined ||
             updateChannel !== undefined
           ) {
-            await updateScheduledTask(taskId, workspaceId, {
+            await updateScheduledTask(resolvedTaskId, workspaceId, {
               title,
               // Never update description for recurring tasks — it pollutes the
               // next run's context. Results go via send_message.
@@ -621,11 +658,11 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
               }
             }
             if (title) {
-              await updateTask(taskId, { title }, false);
+              await updateTask(resolvedTaskId, { title }, false);
             }
           } else if (isRecurring && title) {
             // Recurring tasks: allow title updates only (no description)
-            await updateTask(taskId, { title }, false);
+            await updateTask(resolvedTaskId, { title }, false);
           }
 
           if (status) {
@@ -634,7 +671,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
               const effectiveStatus = status === "Done" ? "Review" : status;
               try {
                 await changeTaskStatus(
-                  taskId,
+                  resolvedTaskId,
                   effectiveStatus as TaskStatus,
                   workspaceId,
                   userId,
@@ -647,7 +684,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             } else {
               try {
                 await changeTaskStatus(
-                  taskId,
+                  resolvedTaskId,
                   status as TaskStatus,
                   workspaceId,
                   userId,
@@ -684,7 +721,9 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
       unblock_task: tool({
         description: `Approve a Waiting task and move it to Ready (or Todo for prep-phase tasks) so execution can start. Requires a reason explaining why the wait is resolved. The reason is added to the task's conversation as a user reply, so the agent picks it up on its next turn. Only works on tasks currently in Waiting status.`,
         inputSchema: z.object({
-          taskId: z.string().describe("The ID of the waiting task"),
+          taskId: z
+            .string()
+            .describe("The displayId of the waiting task (e.g. tk-abcde)"),
           reason: z
             .string()
             .describe(
@@ -693,7 +732,10 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
         }),
         execute: async ({ taskId, reason }) => {
           try {
-            const task = await getTaskById(taskId);
+            const resolved = await resolve("Task", taskId);
+            if (typeof resolved !== "string") return resolved.error;
+
+            const task = await getTaskById(resolved);
             if (!task) return `Task ${taskId} not found.`;
             if (task.status !== "Waiting")
               return `Task is not Waiting (current status: ${task.status}). Only Waiting tasks can be approved.`;
@@ -743,14 +785,14 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             // approval means "start the subtask chain" — go to Ready.
             const phase = getTaskPhase(task);
             const waitingSubtaskCount = await prisma.task.count({
-              where: { parentTaskId: taskId, status: "Waiting" },
+              where: { parentTaskId: resolved, status: "Waiting" },
             });
             const hasWaitingSubtasks = waitingSubtaskCount > 0;
             const targetStatus =
               phase === "prep" && !hasWaitingSubtasks ? "Todo" : "Ready";
 
             await changeTaskStatus(
-              taskId,
+              resolved,
               targetStatus,
               workspaceId,
               userId,
@@ -768,11 +810,15 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
       description:
         "Delete a task permanently. Use when user wants to cancel a task or scheduled item.",
       inputSchema: z.object({
-        taskId: z.string().describe("The ID of the task to delete"),
+        taskId: z
+          .string()
+          .describe("The displayId of the task to delete (e.g. tk-abcde)"),
       }),
       execute: async ({ taskId }) => {
         try {
-          await deleteTask(taskId, workspaceId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+          await deleteTask(resolved, workspaceId);
           return "Task deleted.";
         } catch (error) {
           return error instanceof Error
@@ -786,11 +832,15 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
       description:
         "Confirm user wants to keep a scheduled task active. Stops future prompts about turning it off.",
       inputSchema: z.object({
-        taskId: z.string().describe("The ID of the task to confirm"),
+        taskId: z
+          .string()
+          .describe("The displayId of the task to confirm (e.g. tk-abcde)"),
       }),
       execute: async ({ taskId }) => {
         try {
-          await confirmTaskActive(taskId, workspaceId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+          await confirmTaskActive(resolved, workspaceId);
           return "Task confirmed active.";
         } catch (error) {
           return "Failed to confirm task.";
@@ -801,11 +851,17 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
     get_task_tree: tool({
       description: `Get the full ancestor chain for a task, from root down to the task itself. Use this to understand the hierarchy context — e.g. which epic/parent a task belongs to. Returns each ancestor's displayId and title in order.`,
       inputSchema: z.object({
-        taskId: z.string().describe("The task ID to get the tree for"),
+        taskId: z
+          .string()
+          .describe(
+            "The displayId of the task to get the tree for (e.g. tk-abcde)",
+          ),
       }),
       execute: async ({ taskId }) => {
         try {
-          const tree = await getTaskTree(taskId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+          const tree = await getTaskTree(resolved);
           if (tree.length === 0) return `Task ${taskId} not found.`;
           return tree
             .map((t, i) => {

--- a/apps/webapp/app/services/agent/types/decision-agent.ts
+++ b/apps/webapp/app/services/agent/types/decision-agent.ts
@@ -87,8 +87,6 @@ export interface ScheduledTaskTriggerData {
   previousResponses: ResponseSummary[];
   unrespondedCount: number;
   confirmedActive: boolean;
-  skillId?: string;
-  skillName?: string;
   isRecurring?: boolean;
 }
 

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -186,6 +186,38 @@ export async function getTaskById(id: string): Promise<Task | null> {
   return prisma.task.findUnique({ where: { id } });
 }
 
+/**
+ * Resolve a user-facing task identifier to its internal UUID.
+ *
+ * Accepts either a UUID (passed through after a workspace-scoped existence
+ * check) or a `tk-…` displayId (looked up via the `(workspaceId, displayId)`
+ * unique index). Returns null if no task in this workspace matches.
+ *
+ * Agent tools take displayIds from the model and call this at the boundary;
+ * everything downstream keeps working with UUIDs.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function resolveTaskId(
+  input: string,
+  workspaceId: string,
+): Promise<string | null> {
+  if (!input) return null;
+  if (UUID_RE.test(input)) {
+    const task = await prisma.task.findFirst({
+      where: { id: input, workspaceId },
+      select: { id: true },
+    });
+    return task?.id ?? null;
+  }
+  const task = await prisma.task.findUnique({
+    where: { workspaceId_displayId: { workspaceId, displayId: input } },
+    select: { id: true },
+  });
+  return task?.id ?? null;
+}
+
 export type TaskWithRelations = Task & {
   subtasks: Pick<Task, "id" | "status" | "source">[];
   parentTask: Pick<Task, "id" | "title"> | null;

--- a/integrations/github/src/index.ts
+++ b/integrations/github/src/index.ts
@@ -107,6 +107,8 @@ class GitHubCLI extends IntegrationCLI {
       schedule: {
         frequency: '*/5 * * * *',
       },
+      toolUISupported: true,
+      enableAutoRead: true,
       auth: {
         OAuth2: {
           token_url: 'https://github.com/login/oauth/access_token',

--- a/integrations/granola/package.json
+++ b/integrations/granola/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core/granola",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Granola integration for Core",
   "main": "./bin/index.cjs",
   "type": "module",
@@ -40,7 +40,7 @@
   "dependencies": {
     "axios": "^1.7.9",
     "commander": "^12.0.0",
-    "@redplanethq/sdk": "0.1.13",
+    "@redplanethq/sdk": "0.1.21",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^3.25.4",
     "zod-to-json-schema": "^3.25.1"

--- a/integrations/granola/pnpm-lock.yaml
+++ b/integrations/granola/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.26.0
         version: 1.27.1(zod@3.25.76)
       '@redplanethq/sdk':
-        specifier: 0.1.13
-        version: 0.1.13
+        specifier: 0.1.21
+        version: 0.1.21
       axios:
         specifier: ^1.7.9
         version: 1.13.6
@@ -459,8 +459,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@redplanethq/sdk@0.1.13':
-    resolution: {integrity: sha512-Tb2/MZPdj8HpN2i7HVUQ9ploDWWnm7Cm2Dbk+Sw9Woqy/qs0815h7lNOaHc5W7K7KLEGINGdo1dnATEp9aIVow==}
+  '@redplanethq/sdk@0.1.21':
+    resolution: {integrity: sha512-9mXCt/46NcCCxa9b6dZ2Q0Gf7dW9DzRTUA++w/2szybvHFFLBQZr9PzjFlan73zFzhqeSPiWbI8zBGVLmIFrBA==}
     engines: {node: '>=18.0.0'}
 
   '@rtsao/scc@1.1.0':
@@ -2167,7 +2167,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@redplanethq/sdk@0.1.13':
+  '@redplanethq/sdk@0.1.21':
     dependencies:
       commander: 14.0.0
       zod: 3.25.76

--- a/integrations/granola/src/index.ts
+++ b/integrations/granola/src/index.ts
@@ -69,6 +69,7 @@ class GranolaCLI extends IntegrationCLI {
           server_url: "https://mcp.granola.ai/mcp",
         } as McpAuthParams,
       },
+      enableAutoRead: true,
     };
   }
 }

--- a/integrations/granola/src/schedule.ts
+++ b/integrations/granola/src/schedule.ts
@@ -1,15 +1,15 @@
-import { callGranolaToolRPC } from './utils';
+import { callGranolaToolRPC } from "./utils";
 
 function getDefaultSyncTime(): string {
   return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 }
 
 function parseMeetingContent(content: any[]): string {
-  if (!content || content.length === 0) return '';
+  if (!content || content.length === 0) return "";
   return content
-    .filter((c: any) => c.type === 'text')
+    .filter((c: any) => c.type === "text")
     .map((c: any) => c.text)
-    .join('\n');
+    .join("\n");
 }
 
 interface Meeting {
@@ -45,10 +45,10 @@ function parseMeetingDetail(raw: string): Partial<Meeting> {
 
 async function fetchMeetingDetail(
   config: Record<string, any>,
-  meetingId: string,
+  meetingId: string
 ): Promise<Partial<Meeting>> {
   try {
-    const result = await callGranolaToolRPC(config, 'get_meeting', { id: meetingId });
+    const result = await callGranolaToolRPC(config, "get_meeting", { id: meetingId });
     const rawText = parseMeetingContent(result?.content ?? []);
     return parseMeetingDetail(rawText);
   } catch {
@@ -57,9 +57,9 @@ async function fetchMeetingDetail(
 }
 
 function formatMeetingActivity(meeting: Meeting, detail: Partial<Meeting>): string {
-  const title = meeting.title || 'Untitled Meeting';
-  const date = meeting.date ? new Date(meeting.date).toLocaleString() : '';
-  const attendees = (meeting.attendees ?? []).join(', ');
+  const title = meeting.title || "Untitled Meeting";
+  const date = meeting.date ? new Date(meeting.date).toLocaleString() : "";
+  const attendees = (meeting.attendees ?? []).join(", ");
 
   const lines: string[] = [`## Meeting: ${title}`];
 
@@ -68,33 +68,33 @@ function formatMeetingActivity(meeting: Meeting, detail: Partial<Meeting>): stri
 
   const notes = detail.notes ?? meeting.summary;
   if (notes) {
-    lines.push('');
-    lines.push('### Notes');
+    lines.push("");
+    lines.push("### Notes");
     lines.push(notes);
   }
 
   const actionItems = detail.action_items ?? [];
   if (actionItems.length > 0) {
-    lines.push('');
-    lines.push('### Action Items');
+    lines.push("");
+    lines.push("### Action Items");
     for (const item of actionItems) {
       lines.push(`- ${item}`);
     }
   }
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 export async function handleSchedule(
   config: Record<string, any>,
-  state: Record<string, any>,
+  state: Record<string, any>
 ): Promise<any[]> {
   const lastSyncTime = state?.lastSyncTime ?? getDefaultSyncTime();
   const activities: any[] = [];
   let latestMeetingTime = 0;
 
   try {
-    const listResult = await callGranolaToolRPC(config, 'list_meetings', {
+    const listResult = await callGranolaToolRPC(config, "list_meetings", {
       after: lastSyncTime,
     });
 
@@ -111,15 +111,15 @@ export async function handleSchedule(
       const text = formatMeetingActivity(meeting, detail);
 
       activities.push({
-        type: 'activity',
+        type: "activity",
         data: {
           text,
-          sourceURL: meeting.url ?? '',
+          sourceURL: meeting.url ?? "",
         },
       });
     }
   } catch (error: any) {
-    console.error('Granola schedule sync error:', error.message);
+    console.error("Granola schedule sync error:", error.message);
   }
 
   // Only advance lastSyncTime if we actually found meetings (mirrors Gmail behavior)
@@ -129,7 +129,7 @@ export async function handleSchedule(
       : new Date().toISOString();
 
   activities.push({
-    type: 'state',
+    type: "state",
     data: { lastSyncTime: newSyncTime },
   });
 

--- a/integrations/ynab/package.json
+++ b/integrations/ynab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core/ynab",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "YNAB integration for CORE",
   "main": "./bin/index.js",
   "module": "./bin/index.mjs",
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@redplanethq/sdk": "0.1.9",
+    "@redplanethq/sdk": "0.1.21",
     "axios": "^1.7.9",
     "commander": "^12.0.0",
     "zod": "^3.22.4",

--- a/integrations/ynab/pnpm-lock.yaml
+++ b/integrations/ynab/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@redplanethq/sdk':
-        specifier: 0.1.9
-        version: 0.1.9
+        specifier: 0.1.21
+        version: 0.1.21
       axios:
         specifier: ^1.7.9
         version: 1.13.6
@@ -69,6 +69,9 @@ importers:
       typescript:
         specifier: ^4.7.2
         version: 4.9.5
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@18.19.130)
 
 packages:
 
@@ -201,16 +204,34 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -219,16 +240,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -237,10 +276,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -249,10 +300,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -261,10 +324,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -273,10 +348,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -285,16 +372,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -309,6 +414,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -319,6 +430,12 @@ packages:
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -333,11 +450,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -345,10 +474,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -411,6 +552,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -443,12 +588,153 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@redplanethq/sdk@0.1.9':
-    resolution: {integrity: sha512-fi+mtKTTdKPp1E6gCl9W8Ri7ZuULs0J/s5Hy5am1mg/lQ1foX+mLoBE08kr4p1LTNXJYJFsY7J4PHMe16AcN/g==}
+  '@redplanethq/sdk@0.1.21':
+    resolution: {integrity: sha512-9mXCt/46NcCCxa9b6dZ2Q0Gf7dW9DzRTUA++w/2szybvHFFLBQZr9PzjFlan73zFzhqeSPiWbI8zBGVLmIFrBA==}
     engines: {node: '>=18.0.0'}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -495,10 +781,29 @@ packages:
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -511,6 +816,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -542,6 +851,9 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -577,6 +889,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -596,9 +912,16 @@ packages:
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -621,6 +944,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -658,6 +984,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -672,6 +1002,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -715,6 +1049,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -848,9 +1187,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -933,6 +1279,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -940,6 +1289,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -1002,6 +1355,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1102,6 +1459,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -1134,6 +1495,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -1169,6 +1533,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1176,12 +1544,21 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1199,20 +1576,36 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1241,6 +1634,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1252,6 +1649,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -1273,12 +1674,25 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -1321,9 +1735,16 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -1354,6 +1775,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -1363,6 +1788,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1391,6 +1819,11 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -1453,13 +1886,30 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1481,9 +1931,16 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1496,6 +1953,17 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1525,6 +1993,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -1546,6 +2018,9 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -1561,6 +2036,67 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -1583,6 +2119,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -1600,6 +2141,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -1797,52 +2342,103 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -1851,10 +2447,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1863,13 +2465,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -1932,6 +2546,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1965,11 +2583,89 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@redplanethq/sdk@0.1.9':
+  '@redplanethq/sdk@0.1.21':
     dependencies:
       commander: 14.0.0
+      zod: 3.25.76
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@sinclair/typebox@0.27.10': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2030,7 +2726,40 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
 
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -2046,6 +2775,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   argparse@2.0.1: {}
 
@@ -2101,6 +2832,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@1.1.0: {}
+
   async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
@@ -2138,6 +2871,8 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2159,10 +2894,24 @@ snapshots:
 
   caniuse-lite@1.0.30001777: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   color-convert@2.0.1:
     dependencies:
@@ -2179,6 +2928,8 @@ snapshots:
   commander@14.0.0: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2214,6 +2965,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2229,6 +2984,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -2327,6 +3084,32 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2501,7 +3284,23 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -2579,6 +3378,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2596,6 +3397,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -2663,6 +3466,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  human-signals@5.0.0: {}
 
   ignore@5.3.2: {}
 
@@ -2768,6 +3573,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@3.0.0: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -2800,6 +3607,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -2827,17 +3636,32 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 1.3.1
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
+
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -2852,17 +3676,32 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@4.0.0: {}
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
   minimist@1.2.8: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
   node-releases@2.0.36: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   object-inspect@1.13.4: {}
 
@@ -2901,6 +3740,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2920,6 +3763,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -2934,9 +3781,17 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-type@4.0.0: {}
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -2977,7 +3832,19 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
 
@@ -2997,11 +3864,19 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  react-is@18.3.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3038,6 +3913,37 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -3122,9 +4028,19 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
   slash@3.0.0: {}
 
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -3156,7 +4072,13 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   supports-color@7.2.0:
     dependencies:
@@ -3167,6 +4089,12 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tinybench@2.9.0: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3198,6 +4126,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.1.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -3234,6 +4164,8 @@ snapshots:
 
   typescript@4.9.5: {}
 
+  ufo@1.6.4: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -3252,6 +4184,67 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vite-node@1.6.1(@types/node@18.19.130):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@18.19.130)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@18.19.130):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.60.4
+    optionalDependencies:
+      '@types/node': 18.19.130
+      fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@18.19.130):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@18.19.130)
+      vite-node: 1.6.1(@types/node@18.19.130)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.130
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -3298,6 +4291,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
@@ -3307,6 +4305,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary
- Agent tools now accept `tk-…` displayIds (e.g. `tk-abcde`, `tk-abcde.1`) for every task lookup, in addition to UUIDs. New `resolveTaskId(input, workspaceId)` helper auto-detects the format and returns the canonical UUID via the existing `(workspaceId, displayId)` unique index — no schema or PK changes.
- Threaded through `task-tools` (`get_task`, `update_task`, `unblock_task`, `delete_task`, `confirm_task`, `get_task_tree`, plus `parentTaskId`/`newParentId` on `create_task`/`update_task`) and `session-tools` (`get_task_coding_session`, `list_task_coding_sessions`, `list_task_browser_sessions`).
- Tool outputs render `displayId ?? id` so the agent has a stable, human-readable handle to round-trip. `reschedule_self` untouched (uses server-injected UUID).
- Bundled unrelated WIP at the user's request: decision-agent prompt cleanup, granola/ynab SDK bumps, GitHub integration tool-UI flags, granola schedule formatting.

## Test plan
- [x] `tsc --noEmit` — zero new errors introduced in the changed files (verified by stashing and re-running; same 12 pre-existing errors)
- [x] `vitest run app/services/agent/__tests__/session-tools.test.ts` — 7/7 passing
- [ ] Manual: confirm an agent invocation passing `tk-xxxxx` to `get_task` returns the task; confirm `update_task` reparent reports the new displayId
- [ ] Manual: confirm `get_task_coding_session` with a `tk-…` arg resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)