### PR TITLE
execute-first task lifecycle (plan mode as opt-in)

### DIFF
--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -2,7 +2,7 @@
   "name": "tauri",
   "version": "0.1.0",
   "scripts": {
-    "dev": "tauri dev",
+    "dev-tauri": "tauri dev",
     "build": "tauri build",
     "tauri": "tauri"
   },

--- a/apps/webapp/app/bullmq/connection.ts
+++ b/apps/webapp/app/bullmq/connection.ts
@@ -21,7 +21,9 @@ export function getRedisConnection() {
     password: process.env.REDIS_PASSWORD,
     maxRetriesPerRequest: null, // Required for BullMQ
     enableReadyCheck: false, // Required for BullMQ
-    autoPipelining: true, // Coalesce concurrent commands to avoid ENOBUFS under burst load
+    // Coalesce concurrent commands to avoid ENOBUFS under burst load.
+    // Not in the RedisOptions type but supported at runtime.
+    ...({ autoPipelining: true } as object),
   };
 
   // Add TLS configuration if not disabled

--- a/apps/webapp/app/components/browser/use-cdp-screencast.ts
+++ b/apps/webapp/app/components/browser/use-cdp-screencast.ts
@@ -34,7 +34,7 @@ export interface ScreencastApi {
   /** Error string when `status === "error"`. */
   errorMsg: string;
   /** Attach to the canvas the hook should render frames into. */
-  canvasRef: React.RefObject<HTMLCanvasElement>;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
   /** Current URL of the attached page (updated as the page navigates). */
   pageUrl: string;
   /** Page nav controls — backed by Chromium CDP commands. No-op until running. */
@@ -193,7 +193,7 @@ export function useCdpScreencast({
         // eslint-disable-next-line no-console
         console.log("[cdp-viewer] setDiscoverTargets ack");
         const { targetInfos } = await cdp.send<{
-          targetInfos: Array<{ targetId: string; type: string }>;
+          targetInfos: Array<{ targetId: string; type: string; url?: string }>;
         }>("Target.getTargets");
         // eslint-disable-next-line no-console
         console.log(

--- a/apps/webapp/app/components/coding/gateway-terminal.tsx
+++ b/apps/webapp/app/components/coding/gateway-terminal.tsx
@@ -97,7 +97,6 @@ export function GatewayTerminal({
         theme: xtermTheme,
         allowTransparency: false,
         scrollback: 5000,
-        overviewRulerWidth: 0,
         minimumContrastRatio: theme === "light" ? 4.5 : 1,
       });
 

--- a/apps/webapp/app/components/conversation/conversation-item.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-item.client.tsx
@@ -19,7 +19,7 @@ import { ToolApprovalPanel } from "./tool-approval-panel.client";
 
 interface AIConversationItemProps {
   message: UIMessage;
-  createdAt?: string;
+  createdAt?: string | Date;
   addToolApprovalResponse: ChatAddToolApproveResponseFunction;
   setToolArgOverride: (
     toolCallId: string,

--- a/apps/webapp/app/components/conversation/conversation-utils.ts
+++ b/apps/webapp/app/components/conversation/conversation-utils.ts
@@ -1,4 +1,6 @@
-import type { UIMessagePart } from "ai";
+import type { UIMessagePart, UIDataTypes, UITools } from "ai";
+
+type AnyUIMessagePart = UIMessagePart<UIDataTypes, UITools>;
 
 // ── Mastra data structures ────────────────────────────────────────────────────
 
@@ -84,7 +86,7 @@ export interface AgentToolPart extends ConversationToolPart {
 }
 
 export type ExtendedPart =
-  | UIMessagePart
+  | AnyUIMessagePart
   | StepStartPart
   | DataToolAgentPart
   | AgentToolPart;
@@ -394,12 +396,17 @@ export const findPendingApprovals = (
         // Expand take_action: show only nested tools without results as separate cards
         if (toolName === "take_action" || toolName === "agent-take_action") {
           const nested = getNestedPartsFromOutput(part.output).filter(
-            (np): np is ConversationToolPart =>
-              np.type.includes("tool-") &&
-              np.state !== "output-available" &&
-              np.state !== "output-error" &&
-              np.state !== "output-denied" &&
-              np.state !== "approval-responded",
+            (np): np is ConversationToolPart => {
+              if (np.type === "text") return false;
+              const tool = np as ConversationToolPart;
+              return (
+                tool.type.includes("tool-") &&
+                tool.state !== "output-available" &&
+                tool.state !== "output-error" &&
+                tool.state !== "output-denied" &&
+                tool.state !== "approval-responded"
+              );
+            },
           );
           if (nested.length > 0) {
             // Each nested card borrows the parent approval id
@@ -478,7 +485,7 @@ export const getToolDisplayName = (toolType: string): string => {
  * Mastra streams subagent activity as separate "data-tool-agent" sibling parts
  * instead of nesting them inside the parent tool's output during streaming.
  */
-export const mergeAgentParts = (parts: UIMessagePart[]): ExtendedPart[] => {
+export const mergeAgentParts = (parts: AnyUIMessagePart[]): ExtendedPart[] => {
   const result: ExtendedPart[] = [];
   let lastAgentTool: AgentToolPart | null = null;
 

--- a/apps/webapp/app/components/conversation/conversation-view.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-view.client.tsx
@@ -17,6 +17,7 @@ import {
   collectApprovalRequests,
   hasNeedsApprovalDeep,
   mergeAgentParts,
+  type ConversationToolPart,
 } from "./conversation-utils";
 import { ChatContextProvider } from "./chat-context";
 import {
@@ -30,7 +31,7 @@ interface ConversationHistory {
   userType: string;
   message: string;
   parts: any;
-  createdAt?: string;
+  createdAt?: string | Date;
 }
 
 interface ConversationViewProps {
@@ -308,7 +309,7 @@ export function ConversationView({
     .find((m) => m.role === "assistant") as UIMessage | undefined;
 
   const needsApproval = lastAssistant?.parts
-    ? hasNeedsApprovalDeep(lastAssistant.parts)
+    ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
     : false;
 
   // Deep-scan the last assistant message for all suspended tool calls.

--- a/apps/webapp/app/components/desktop/tab-bar.tsx
+++ b/apps/webapp/app/components/desktop/tab-bar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Plus, X } from "lucide-react";
-import { tinykeys } from "tinykeys";
+import { tinykeys } from "~/lib/tinykeys";
 import { cn } from "~/lib/utils";
 import { useDesktopTabs } from "./tabs-context";
 import { Button } from "../ui";

--- a/apps/webapp/app/components/editor/conversation-popover.tsx
+++ b/apps/webapp/app/components/editor/conversation-popover.tsx
@@ -19,7 +19,10 @@ import { ArrowUpRight, Check, Loader2, RotateCcw } from "lucide-react";
 import { Button, buttonVariants } from "../ui";
 import { cn } from "~/lib/utils";
 import { ConversationItem, ConversationTextarea } from "../conversation";
-import { hasNeedsApprovalDeep } from "../conversation/conversation-utils";
+import {
+  hasNeedsApprovalDeep,
+  type ConversationToolPart,
+} from "../conversation/conversation-utils";
 
 interface ConversationPart {
   type: string;
@@ -216,7 +219,7 @@ export function ConversationPopover({
     .find((message) => message.role === "assistant");
 
   const needsApproval = lastAssistant?.parts
-    ? hasNeedsApprovalDeep(lastAssistant.parts)
+    ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
     : false;
 
   const handleToolApprovalResponse = useCallback(

--- a/apps/webapp/app/components/editor/editor.client.tsx
+++ b/apps/webapp/app/components/editor/editor.client.tsx
@@ -38,7 +38,7 @@ export const Editor = ({ defaultLabelId, labels }: EditorProps) => {
   });
 
   const handleAdd = async () => {
-    const content = editor?.storage.markdown.getMarkdown();
+    const content = editor?.storage.markdown?.getMarkdown();
 
     if (!content?.trim()) return;
 

--- a/apps/webapp/app/components/editor/extensions/scratchpad-task-item.tsx
+++ b/apps/webapp/app/components/editor/extensions/scratchpad-task-item.tsx
@@ -144,7 +144,7 @@ const ScratchpadTaskComponent = ({
         </label>
 
         <NodeViewContent
-          as="p"
+          as={"p" as unknown as "div"}
           className={cn(
             "min-w-[3px]",
             isCompleted &&

--- a/apps/webapp/app/components/editor/extensions/scratchpad-task-item.tsx
+++ b/apps/webapp/app/components/editor/extensions/scratchpad-task-item.tsx
@@ -33,7 +33,7 @@ const ScratchpadTaskComponent = ({
   const { id } = node.attrs;
   const { parentTaskId } = extension.options ?? {};
 
-  const [status, setStatus] = useState<TaskStatus>("Todo");
+  const [status, setStatus] = useState<TaskStatus>("Ready");
   const [taskMeta, setTaskMeta] = useState<{
     displayId: string | null;
     nextRunAt: string | null;
@@ -51,7 +51,7 @@ const ScratchpadTaskComponent = ({
   const navigate = useNavigate();
 
   const applyTaskData = useCallback((data: any) => {
-    setStatus(data.status ?? "Todo");
+    setStatus(data.status ?? "Ready");
     setTaskMeta({
       displayId: data.displayId ?? null,
       nextRunAt: data.nextRunAt ?? null,
@@ -78,7 +78,11 @@ const ScratchpadTaskComponent = ({
       body: JSON.stringify({
         title: "Untitled task",
         source: "daily",
-        status: "Todo",
+        // Ready triggers the 2-minute editing buffer; if the user walks
+        // away without naming the task, the buffer-expiry handler in
+        // scheduled-task.logic.ts auto-deletes the empty row instead of
+        // executing it (see isTaskEmpty).
+        status: "Ready",
         ...(parentTaskId ? { parentTaskId } : {}),
       }),
     })

--- a/apps/webapp/app/components/editor/hooks/use-butler-comments.ts
+++ b/apps/webapp/app/components/editor/hooks/use-butler-comments.ts
@@ -13,7 +13,7 @@ export function useButlerComments(
       node.forEach((child) => {
         if (!(child instanceof Y.XmlElement)) return;
         if (child.getAttribute("conversationId") === conversationId) {
-          child.setAttribute("resolved", resolved);
+          child.setAttribute("resolved", String(resolved));
         }
         walk(child);
       });

--- a/apps/webapp/app/components/editor/selection-bubble.tsx
+++ b/apps/webapp/app/components/editor/selection-bubble.tsx
@@ -135,7 +135,10 @@ export function SelectionBubble({ editor, parentTaskId }: SelectionBubbleProps) 
           body: JSON.stringify({
             title,
             source: "daily",
-            status: "Todo",
+            // Same convention as scratchpad-task-item: Ready triggers the
+            // 2-minute editing buffer; the buffer-expiry handler auto-
+            // deletes empty Untitled tasks.
+            status: "Ready",
             ...(description && { description }),
             ...(parentTaskId && { parentTaskId }),
           }),

--- a/apps/webapp/app/components/editor/skill-editor.client.tsx
+++ b/apps/webapp/app/components/editor/skill-editor.client.tsx
@@ -75,8 +75,13 @@ export const SkillEditor = forwardRef<SkillEditorHandle, SkillEditorProps>(
       transport: new DefaultChatTransport({
         api: "/api/v1/skills/generate",
         prepareSendMessagesRequest({ messages: msgs }) {
-          const lastUser = msgs.findLast((m: any) => m.role === "user");
-          const prompt = lastUser?.parts?.[0]?.text ?? lastUser?.content ?? "";
+          const lastUser = [...msgs].reverse().find(
+            (m: any) => m.role === "user",
+          );
+          const prompt =
+            (lastUser?.parts as any)?.[0]?.text ??
+            (lastUser as any)?.content ??
+            "";
           return {
             body: {
               prompt,
@@ -95,9 +100,11 @@ export const SkillEditor = forwardRef<SkillEditorHandle, SkillEditorProps>(
 
     const isGeneratingDesc = status === "streaming" || status === "submitted";
     const completion =
-      messages
-        .findLast((m) => m.role === "assistant")
-        ?.parts?.find((p: any) => p.type === "text")?.text ?? "";
+      ((
+        [...messages]
+          .reverse()
+          .find((m: any) => m.role === "assistant") as any
+      )?.parts?.find((p: any) => p.type === "text")?.text as string) ?? "";
 
     const editor = useEditor({
       extensions: [
@@ -112,7 +119,7 @@ export const SkillEditor = forwardRef<SkillEditorHandle, SkillEditorProps>(
         },
       },
       onUpdate: ({ editor: ed }) => {
-        setContentMarkdown(ed.storage.markdown.getMarkdown() ?? "");
+        setContentMarkdown(ed.storage.markdown?.getMarkdown() ?? "");
       },
     });
 
@@ -121,7 +128,7 @@ export const SkillEditor = forwardRef<SkillEditorHandle, SkillEditorProps>(
       if (completion) {
         editor?.commands.setContent(completion);
         setContentMarkdown(
-          editor?.storage.markdown.getMarkdown() ?? completion,
+          editor?.storage.markdown?.getMarkdown() ?? completion,
         );
       }
     }, [completion, editor]);
@@ -137,7 +144,7 @@ export const SkillEditor = forwardRef<SkillEditorHandle, SkillEditorProps>(
     const handleGenerateDesc = () => {
       if (!descIntent.trim()) return;
       existingDescRef.current = (
-        editor?.storage.markdown.getMarkdown() ?? ""
+        editor?.storage.markdown?.getMarkdown() ?? ""
       ).trim();
       sendMessage({ text: descIntent.trim() });
     };
@@ -157,7 +164,7 @@ export const SkillEditor = forwardRef<SkillEditorHandle, SkillEditorProps>(
         return;
       }
 
-      const content = editor?.storage.markdown.getMarkdown();
+      const content = editor?.storage.markdown?.getMarkdown();
 
       if (!content?.trim()) {
         toast({ title: "Description is required", variant: "destructive" });

--- a/apps/webapp/app/components/gateway/xterm-pane.tsx
+++ b/apps/webapp/app/components/gateway/xterm-pane.tsx
@@ -108,7 +108,6 @@ export function XtermPane({
         theme: xtermTheme,
         allowTransparency: false,
         scrollback: 5000,
-        overviewRulerWidth: 0,
         minimumContrastRatio: theme === "light" ? 4.5 : 1,
       });
 

--- a/apps/webapp/app/components/graph/type.ts
+++ b/apps/webapp/app/components/graph/type.ts
@@ -1,5 +1,6 @@
 export interface Node {
   uuid: string;
+  name?: string;
   summary?: string;
   labels?: string[];
   attributes?: Record<string, any>;
@@ -25,6 +26,7 @@ export interface RawTriplet {
 export interface GraphNode extends Node {
   id: string;
   value: string;
+  name?: string;
   primaryLabel?: string;
   clusterId?: string; // Add cluster information
 }

--- a/apps/webapp/app/components/graph/utils.ts
+++ b/apps/webapp/app/components/graph/utils.ts
@@ -13,7 +13,7 @@ export function toGraphNode(node: Node): GraphNode {
 
   return {
     id: node.uuid,
-    value: node.name,
+    value: node.name ?? node.uuid,
     uuid: node.uuid,
     name: node.name,
     createdAt: node.createdAt,

--- a/apps/webapp/app/components/icon-picker/utils.tsx
+++ b/apps/webapp/app/components/icon-picker/utils.tsx
@@ -33,7 +33,7 @@ export const getIcon = (
       return (
         <div
           className="flex shrink-0 items-center"
-          style={{ fontSize: size * 0.8 }}
+          style={{ fontSize: (size ?? 16) * 0.8 }}
         >
           {iconData.emoji}
         </div>

--- a/apps/webapp/app/components/integrations/custom-mcp-card.tsx
+++ b/apps/webapp/app/components/integrations/custom-mcp-card.tsx
@@ -10,6 +10,7 @@ import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Plug, Trash2 } from "lucide-react";
 import type { CustomMcpIntegration as McpIntegration } from "~/utils/mcp/custom-mcp-config";
+export type { McpIntegration };
 
 interface CustomMcpCardProps {
   integration: McpIntegration;

--- a/apps/webapp/app/components/logs/index.ts
+++ b/apps/webapp/app/components/logs/index.ts
@@ -1,1 +1,1 @@
-export * from "./ingestion-logs-table";
+export {};

--- a/apps/webapp/app/components/logs/views/document-editor-view.client.tsx
+++ b/apps/webapp/app/components/logs/views/document-editor-view.client.tsx
@@ -42,7 +42,7 @@ export function DocumentEditorView({ document, editable: defaultEditable }: Docu
       },
     },
     onUpdate({ editor: updatedEditor }) {
-      setContent(updatedEditor.storage.markdown.getMarkdown());
+      setContent(updatedEditor.storage.markdown?.getMarkdown() ?? "");
     },
   });
 

--- a/apps/webapp/app/components/onboarding/onboarding-agent-name.tsx
+++ b/apps/webapp/app/components/onboarding/onboarding-agent-name.tsx
@@ -10,6 +10,10 @@ interface OnboardingAgentNameProps {
   workspaceId: string;
   onComplete: (name: string, slug: string) => void;
   isSubmitting?: boolean;
+  // Optional "regenerate name" flow used by the modal entry point.
+  onGenerateName?: (currentName: string, previousNames: string[]) => void;
+  generatedName?: string;
+  isGenerating?: boolean;
 }
 
 type AvailabilityState = "idle" | "checking" | "available" | "taken";

--- a/apps/webapp/app/components/overview/overview-grid.client.tsx
+++ b/apps/webapp/app/components/overview/overview-grid.client.tsx
@@ -1,5 +1,9 @@
 import { forwardRef, useImperativeHandle, useState } from "react";
-import GridLayout, { useContainerWidth, type Layout } from "react-grid-layout";
+import GridLayout, {
+  type Layout,
+  type LayoutItem,
+} from "react-grid-layout/legacy";
+import { useContainerWidth } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import type { OverviewCell, WidgetOption } from "./types";
 import { WidgetPicker } from "./widget-picker";
@@ -31,7 +35,7 @@ export const OverviewGrid = forwardRef<OverviewGridHandle, Props>(function Overv
   const [selectedCellId, setSelectedCellId] = useState<string | null>(null);
   const { width, containerRef, mounted } = useContainerWidth();
 
-  const layout: Layout[] = cells.map((cell) => ({
+  const layout: LayoutItem[] = cells.map((cell) => ({
     i: cell.id,
     x: cell.x,
     y: cell.y,
@@ -42,9 +46,9 @@ export const OverviewGrid = forwardRef<OverviewGridHandle, Props>(function Overv
     minH: 1,
   }));
 
-  const handleLayoutChange = (_layout: Layout[]) => {
+  const handleLayoutChange = (newLayout: Layout) => {
     const updated = cells.map((cell) => {
-      const item = _layout.find((l) => l.i === cell.id);
+      const item = newLayout.find((l) => l.i === cell.id);
       if (!item) return cell;
       return { ...cell, x: item.x, y: item.y, w: item.w, h: item.h };
     });
@@ -64,6 +68,7 @@ export const OverviewGrid = forwardRef<OverviewGridHandle, Props>(function Overv
       widgetSlug: null,
       integrationSlug: null,
       integrationAccountId: null,
+      config: null,
     };
     const updated = [...cells, newCell];
     setCells(updated);

--- a/apps/webapp/app/components/sidebar/app-sidebar.tsx
+++ b/apps/webapp/app/components/sidebar/app-sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { tinykeys } from "tinykeys";
+import { tinykeys } from "~/lib/tinykeys";
 
 import {
   Sidebar,

--- a/apps/webapp/app/components/skills/skill-card.tsx
+++ b/apps/webapp/app/components/skills/skill-card.tsx
@@ -42,7 +42,7 @@ export function SkillCard({ skill }: SkillCardProps) {
 
   const getDescription = (): string => {
     if (skill.metadata?.shortDescription) {
-      return skill.metadata.shortDescription;
+      return String(skill.metadata.shortDescription);
     }
 
     return isLong

--- a/apps/webapp/app/components/ui/scrollarea.tsx
+++ b/apps/webapp/app/components/ui/scrollarea.tsx
@@ -11,7 +11,7 @@ interface ScrollAreaProps
 // Add this custom hook above the ScrollArea component
 function useScrollRestoration(
   id: string | undefined,
-  ref: React.RefObject<HTMLDivElement>,
+  ref: React.RefObject<HTMLDivElement | null>,
 ) {
   React.useEffect(() => {
     const element = ref.current as any;

--- a/apps/webapp/app/components/ui/select.tsx
+++ b/apps/webapp/app/components/ui/select.tsx
@@ -18,7 +18,7 @@ const SelectValue = SelectPrimitive.Value;
 interface SelectTriggerProps extends React.ComponentPropsWithoutRef<
   typeof SelectPrimitive.Trigger
 > {
-  showIcon: boolean;
+  showIcon?: boolean;
 }
 
 const SelectTrigger = React.forwardRef<

--- a/apps/webapp/app/entry.server.tsx
+++ b/apps/webapp/app/entry.server.tsx
@@ -37,7 +37,8 @@ init();
  * Automatically tracks all errors to telemetry
  */
 export const handleError = Sentry.wrapHandleErrorWithSentry(
-  (error, { request }): { request: any } => {
+  (error: unknown, args: { request: unknown }): void => {
+    const request = args.request as Request;
     // Don't track 404s or aborted requests as errors
     if (
       error instanceof Response &&

--- a/apps/webapp/app/hooks/useChanged.ts
+++ b/apps/webapp/app/hooks/useChanged.ts
@@ -6,7 +6,7 @@ export function useChanged<T extends { id: string }>(
   action: (item: T | undefined) => void,
   sendInitialUndefined = true
 ) {
-  const previousItemId = useRef<string | undefined>();
+  const previousItemId = useRef<string | undefined>(undefined);
   const item = getItem();
 
   //when the value changes, call the action

--- a/apps/webapp/app/jobs/spaces/persona-generation.logic.ts
+++ b/apps/webapp/app/jobs/spaces/persona-generation.logic.ts
@@ -145,6 +145,7 @@ export async function processPersonaGeneration(
   _addToQueue: (
     body: z.infer<typeof IngestBodyRequest>,
     userId: string,
+    workspaceId: string,
     activityId?: string,
     ingestionQueueId?: string,
   ) => Promise<{ id?: string }>,

--- a/apps/webapp/app/jobs/task/scheduled-task.logic.ts
+++ b/apps/webapp/app/jobs/task/scheduled-task.logic.ts
@@ -57,17 +57,22 @@ export interface ScheduledTaskProcessResult {
 // ============================================================================
 
 /**
- * Process a scheduled-task wake-up. After the two-phase lifecycle refactor,
- * wake-ups serve three distinct purposes and we branch on `(status, phase)`:
+ * Process a scheduled-task wake-up. In the execute-first lifecycle the
+ * dispatch is purely status-driven (phase metadata controls prompt
+ * rendering, not wake-up routing). Wake-ups serve three purposes:
  *
- * 1. **Buffer expiry** — task is Todo + prep with no recurring schedule. The
- *    2-minute edit buffer is over; hand the task off to the normal task
- *    runner so butler can start prep.
- * 2. **Normal fire** — task is Ready + execute. The scheduled/recurring time
- *    arrived; execute via the CASE pipeline.
- * 3. **Fire-override** — task is Todo/Waiting + prep AND has a recurring
- *    schedule (or was scheduled). The schedule fires before prep completed;
- *    execute with whatever info is available (flipping status to Working).
+ * 1. **Buffer expiry** — task is Ready with no schedule. The 2-minute
+ *    editing buffer is over; hand off to the task runner, which flips
+ *    status to Working and invokes the agent (execute mind by default,
+ *    or plan mind if `metadata.phase === "prep"`).
+ * 2. **Normal fire** — task is Ready with a schedule. The scheduled /
+ *    recurring time arrived; execute via the CASE pipeline.
+ * 3. **Fire-override** — task is Todo or Waiting AND has a schedule. The
+ *    schedule fires while the task is still parked or blocked; execute
+ *    with whatever info is available (flipping status to Working).
+ *
+ * Stuck-state recovery branches catch Working + Review on recurring
+ * tasks (previous occurrence crashed or never looped back).
  *
  * Any other state is a stale wake-up and we no-op.
  */

--- a/apps/webapp/app/jobs/task/scheduled-task.logic.ts
+++ b/apps/webapp/app/jobs/task/scheduled-task.logic.ts
@@ -31,10 +31,6 @@ import { HttpOrchestratorTools } from "~/services/agent/orchestrator-tools.http"
 import { getPageContentAsHtml } from "~/services/hocuspocus/content.server";
 import { removeTaskItemFromPages } from "~/services/hocuspocus/page-outlinks.server";
 import { enqueueTask } from "~/lib/queue-adapter.server";
-import {
-  getTaskPhase,
-  setTaskPhaseInMetadata,
-} from "~/services/task.phase";
 import { hasCredits } from "~/trigger/utils/utils";
 import { isWorkspaceBYOK } from "~/services/byok.server";
 import type { Task } from "@prisma/client";
@@ -105,43 +101,38 @@ export async function processScheduledTask(
       return { success: true };
     }
 
-    const phase = getTaskPhase(task);
+    // Execute-first lifecycle: phase is agent-driven, not status-driven.
+    // The buffer wake-up only cares about status + schedule.
 
-    const isBufferExpiry =
-      task.status === "Todo" && phase === "prep" && !task.schedule;
+    // 2-minute editing buffer expired on a Ready task (no schedule). Hand
+    // off to the task runner; the agent picks up in execute mind (or plan
+    // mind if it has since self-promoted). Todo is the backlog state and
+    // does not auto-buffer — it has to be promoted to Ready first.
+    const isBufferExpiry = task.status === "Ready" && !task.schedule;
 
-    // Agent-created Ready tasks sit in a 2-min buffer (status=Ready, phase=prep,
-    // no schedule). At expiry, skip prep entirely — the agent already classified
-    // the task as simple+clear and set metadata.prepDecided.
-    const isReadyBufferExpiry =
-      task.status === "Ready" && phase === "prep" && !task.schedule;
+    // Scheduled / recurring task fired while still Todo or Waiting.
+    // The schedule beats the lifecycle — execute with whatever info is
+    // available; the conversation history captures any pre-fire prep.
+    const isScheduledFireDuringWorkup =
+      (task.status === "Todo" || task.status === "Waiting") && !!task.schedule;
 
-    const isScheduledFireDuringPrep =
-      (task.status === "Todo" || task.status === "Waiting") &&
-      phase === "prep" &&
-      !!task.schedule;
-
-    const isNormalFire = task.status === "Ready" && phase === "execute";
+    const isNormalFire = task.status === "Ready" && !!task.schedule;
 
     // Recovery branches for recurring tasks. Without these the task gets
     // stuck and every future wake-up no-ops, silently killing the recurrence.
     //
-    // Working+execute: previous occurrence's pipeline crashed mid-execution
-    //   (machine kill, OOM, deploy) before scheduleNextTaskOccurrence ran.
-    // Review+execute (recurring only): previous occurrence ended in Review
-    //   and the user/system never moved it back to Ready before the next
-    //   scheduled time arrived. Recurring tasks should auto-loop.
-    const isStuckWorking = task.status === "Working" && phase === "execute";
-    const isStuckReview =
-      task.status === "Review" && phase === "execute" && !!task.schedule;
+    // Working: previous occurrence's pipeline crashed mid-execution (machine
+    //   kill, OOM, deploy) before scheduleNextTaskOccurrence ran.
+    // Review (recurring only): previous occurrence ended in Review and the
+    //   user/system never moved it back to Ready before the next scheduled
+    //   time arrived. Recurring tasks should auto-loop.
+    const isStuckWorking = task.status === "Working";
+    const isStuckReview = task.status === "Review" && !!task.schedule;
 
     if (isBufferExpiry) {
-      return await startPrepFromBuffer(task);
+      return await startExecutionFromBuffer(task);
     }
-    if (isReadyBufferExpiry) {
-      return await startExecutionFromReadyBuffer(task);
-    }
-    if (isScheduledFireDuringPrep) {
+    if (isScheduledFireDuringWorkup) {
       return await executeFireOverride(data, task);
     }
     if (isNormalFire || isStuckWorking || isStuckReview) {
@@ -159,7 +150,7 @@ export async function processScheduledTask(
     }
 
     logger.info(
-      `Task ${taskId} wake-up fired in unexpected state (status=${task.status}, phase=${phase}) — no-op`,
+      `Task ${taskId} wake-up fired in unexpected state (status=${task.status}) — no-op`,
     );
     return { success: true };
   } catch (error) {
@@ -179,21 +170,18 @@ export async function processScheduledTask(
 // ============================================================================
 
 /**
- * Buffer-expiry branch: the 2-minute Todo window is up. Clear nextRunAt and
- * hand off to the normal task runner, which runs the agent in prep mode
- * (driven by phase=prep in context.ts).
+ * Buffer expiry: the 2-minute editing window is up. Clear nextRunAt and
+ * hand off to the task runner. The agent picks up in execute mind by
+ * default; if a prior turn called enter_plan_mode (metadata.phase = "prep")
+ * the task_planning block renders instead. Status stays as it was —
+ * Todo or Ready — and the runner flips it to Working when execution starts.
  *
  * Parity with the client-side delete-on-removal in scratchpad-task-item.tsx:
  * if a scratchpad-created task (`source === "daily"`) sits in the editor
  * for the full 2 minutes without ever getting a title or description, drop
- * it and pull its node out of any pages that still reference it instead of
- * starting prep — these are the abandoned `[ ]` lines users typed and
- * walked away from.
- *
- * Sibling: `startExecutionFromReadyBuffer` handles the agent-created Ready
- * buffer expiry — same 2-min window, but skips prep entirely.
+ * it and pull its node out of any pages that still reference it.
  */
-async function startPrepFromBuffer(
+async function startExecutionFromBuffer(
   task: Task,
 ): Promise<ScheduledTaskProcessResult> {
   if (task.source === "daily" && (await isTaskEmpty(task))) {
@@ -239,48 +227,6 @@ async function isTaskEmpty(task: Task): Promise<boolean> {
 }
 
 /**
- * Ready-buffer expiry branch: the 2-minute Ready window is up for an
- * agent-created Ready task. Clear nextRunAt, flip phase to execute, and
- * enqueue for execution. The agent already classified this task as
- * simple+clear (metadata.prepDecided=true), so we skip prep entirely.
- *
- * We bypass changeTaskStatus because status stays "Ready" — only phase
- * changes. Writing directly avoids re-triggering Ready-side enqueue logic
- * (which would double-enqueue).
- *
- * Mirrors the empty-task auto-delete in startPrepFromBuffer for
- * scratchpad-source tasks.
- */
-async function startExecutionFromReadyBuffer(
-  task: Task,
-): Promise<ScheduledTaskProcessResult> {
-  if (task.source === "daily" && (await isTaskEmpty(task))) {
-    logger.info(
-      `Auto-deleting empty scratchpad task ${task.id} at Ready-buffer expiry`,
-    );
-    await removeTaskItemFromPages(task.id);
-    await deleteTask(task.id, task.workspaceId);
-    return { success: true };
-  }
-
-  await prisma.task.update({
-    where: { id: task.id },
-    data: {
-      nextRunAt: null,
-      metadata: setTaskPhaseInMetadata(task.metadata, "execute"),
-    },
-  });
-
-  await enqueueTask({
-    taskId: task.id,
-    workspaceId: task.workspaceId,
-    userId: task.userId,
-  });
-
-  return { success: true };
-}
-
-/**
  * Fire-override branch: the scheduled/recurring time arrived while the task
  * was still in Phase 1. Flip to Working + execute and run the execution
  * pipeline. Any prep conversation already attached stays in conversationIds
@@ -293,10 +239,7 @@ async function executeFireOverride(
 ): Promise<ScheduledTaskProcessResult> {
   const updated = await prisma.task.update({
     where: { id: task.id },
-    data: {
-      status: "Working",
-      metadata: setTaskPhaseInMetadata(task.metadata, "execute"),
-    },
+    data: { status: "Working" },
   });
   return await runExecutionPipeline(data, updated);
 }

--- a/apps/webapp/app/lib/batch/providers/anthropic.ts
+++ b/apps/webapp/app/lib/batch/providers/anthropic.ts
@@ -90,7 +90,10 @@ export class AnthropicBatchProvider extends BaseBatchProvider {
           const batchResults =
             await this.anthropicClient.messages.batches.results(params.batchId);
 
-          results = batchResults.map((result) => {
+          // Anthropic SDK returns a JSONL decoder; collect to array first.
+          const collected: any[] = [];
+          for await (const r of batchResults) collected.push(r);
+          results = collected.map((result: any) => {
             try {
               if (result.result.type === "succeeded") {
                 const message = result.result.message;

--- a/apps/webapp/app/lib/batch/types.ts
+++ b/apps/webapp/app/lib/batch/types.ts
@@ -1,4 +1,4 @@
-import { type CoreMessage } from "ai";
+import { type ModelMessage as CoreMessage } from "ai";
 import { z } from "zod";
 
 export type BatchStatus = "pending" | "processing" | "completed" | "failed" | "cancelled";

--- a/apps/webapp/app/lib/model.server.ts
+++ b/apps/webapp/app/lib/model.server.ts
@@ -435,7 +435,7 @@ export async function makeStructuredModelCall<T extends z.ZodType>(
 
     const tokenUsage = toTokenUsage(result.usage);
     logTokenUsage(`Structured/${complexity.toUpperCase()}`, model, tokenUsage);
-    return { object: result.object, usage: tokenUsage };
+    return { object: result.object as z.infer<T>, usage: tokenUsage };
   } catch (error) {
     // Fallback: try to recover JSON from error text
     const rawText = extractTextFromError(error);

--- a/apps/webapp/app/lib/tinykeys.ts
+++ b/apps/webapp/app/lib/tinykeys.ts
@@ -1,0 +1,22 @@
+// tinykeys ships type declarations at dist/tinykeys.d.ts but its package.json
+// `exports` field hides them from TypeScript's resolver. We re-export at the
+// shapes documented by the upstream types so call-sites stay strictly typed.
+
+export interface KeyBindingMap {
+  [keybinding: string]: (event: KeyboardEvent) => void;
+}
+
+export interface KeyBindingOptions {
+  event?: "keydown" | "keyup";
+  capture?: boolean;
+  timeout?: number;
+}
+
+// @ts-expect-error – exports-field hides bundled types
+import { tinykeys as tinykeysImpl } from "tinykeys";
+
+export const tinykeys: (
+  target: Window | HTMLElement,
+  keyBindingMap: KeyBindingMap,
+  options?: KeyBindingOptions,
+) => () => void = tinykeysImpl;

--- a/apps/webapp/app/models/onboarding.server.ts
+++ b/apps/webapp/app/models/onboarding.server.ts
@@ -9,7 +9,9 @@ export async function generateButlerName(excluded: string[] = []): Promise<strin
   const agent = createAgent(await resolveModelString("chat", "low"));
   const result = await agent.generate(
     `Generate a single classic English butler first name that sounds distinguished and old-fashioned.${exclusion} Reply with only the name, nothing else.`,
-    { temperature: 1 },
+    // `temperature` was removed from Mastra Agent's options in the recent
+    // upgrade; provider-specific overrides now go through `modelSettings`.
+    { modelSettings: { temperature: 1 } as Record<string, unknown> } as any,
   );
 
   return result.text.trim().split(/\s+/)[0] ?? "James";

--- a/apps/webapp/app/models/personality.server.ts
+++ b/apps/webapp/app/models/personality.server.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "~/db.server";
 import { createAgent, resolveModelString } from "~/lib/model.server";
 
@@ -41,7 +42,12 @@ export async function saveCustomPersonality(
 
   await prisma.workspace.update({
     where: { id: workspaceId },
-    data: { metadata: { ...metadata, customPersonalities: existing } },
+    data: {
+      metadata: {
+        ...metadata,
+        customPersonalities: existing,
+      } as unknown as Prisma.InputJsonValue,
+    },
   });
 }
 
@@ -63,7 +69,7 @@ export async function deleteCustomPersonality(
       metadata: {
         ...metadata,
         customPersonalities: existing.filter((p) => p.id !== personalityId),
-      },
+      } as unknown as Prisma.InputJsonValue,
     },
   });
 }

--- a/apps/webapp/app/models/workspace.server.ts
+++ b/apps/webapp/app/models/workspace.server.ts
@@ -131,9 +131,9 @@ export async function createWorkspace(
     });
     if (morningBriefSkill) {
       // Agent picks up the Morning Brief skill by intent at run time — no
-      // explicit skillId attachment needed (see <task_prep>/<task_execution>
-      // SKILL CHECK rule). We still do the lookup above just to gate on the
-      // skill being installed for this workspace before seeding the task.
+      // explicit skillId attachment needed (the global <skills> SKILL CHECK
+      // rule matches the task title/description). The lookup above is just
+      // a gate to skip seeding when the skill isn't installed yet.
       await createScheduledTask(workspace.id, input.userId, {
         title: "Morning brief",
         schedule: "FREQ=DAILY;BYHOUR=9",

--- a/apps/webapp/app/models/workspace.server.ts
+++ b/apps/webapp/app/models/workspace.server.ts
@@ -130,13 +130,15 @@ export async function createWorkspace(
       select: { id: true, title: true },
     });
     if (morningBriefSkill) {
+      // Agent picks up the Morning Brief skill by intent at run time — no
+      // explicit skillId attachment needed (see <task_prep>/<task_execution>
+      // SKILL CHECK rule). We still do the lookup above just to gate on the
+      // skill being installed for this workspace before seeding the task.
       await createScheduledTask(workspace.id, input.userId, {
         title: "Morning brief",
         schedule: "FREQ=DAILY;BYHOUR=9",
         maxOccurrences: null,
         metadata: {
-          skillId: morningBriefSkill.id,
-          skillName: morningBriefSkill.title,
           kind: "morning_brief_daily",
         },
       });

--- a/apps/webapp/app/routes/api.v1.activity.tsx
+++ b/apps/webapp/app/routes/api.v1.activity.tsx
@@ -52,7 +52,7 @@ const { action, loader } = createActionApiRoute(
       const queueResponse = await addToQueue(
         ingestData,
         authentication.userId,
-        authentication.workspaceId,
+        authentication.workspaceId as string,
         activity.id,
       );
 

--- a/apps/webapp/app/routes/api.v1.documents.$documentId.tsx
+++ b/apps/webapp/app/routes/api.v1.documents.$documentId.tsx
@@ -88,7 +88,7 @@ const { action } = createHybridActionApiRoute(
             {
               error: "Invalid request body",
               code: "validation_error",
-              details: validationResult.error.errors,
+              details: validationResult.error.issues,
             },
             { status: 400 },
           );
@@ -143,7 +143,7 @@ const { action } = createHybridActionApiRoute(
           {
             error: "Invalid request body",
             code: "validation_error",
-            details: validationResult.error.errors,
+            details: validationResult.error.issues,
           },
           { status: 400 },
         );

--- a/apps/webapp/app/routes/api.v1.oauth.callback.mcp-integration.tsx
+++ b/apps/webapp/app/routes/api.v1.oauth.callback.mcp-integration.tsx
@@ -79,6 +79,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     await scheduler({
       integrationAccountId: setupResult?.account?.id as string,
+      admin: false,
     });
 
     logger.info(`MCP integration OAuth completed for ${integrationDefinition.name}`);

--- a/apps/webapp/app/routes/api.v1.tasks.$taskId.tsx
+++ b/apps/webapp/app/routes/api.v1.tasks.$taskId.tsx
@@ -49,7 +49,8 @@ const loader = createHybridLoaderApiRoute(
       maxOccurrences: task.maxOccurrences,
       occurrenceCount: task.occurrenceCount,
       description,
-      subtaskCount: task.subtasks?.length ?? 0,
+      subtaskCount:
+        (task as { subtasks?: unknown[] }).subtasks?.length ?? 0,
     });
   },
 );

--- a/apps/webapp/app/routes/home.conversation.$conversationId.tsx
+++ b/apps/webapp/app/routes/home.conversation.$conversationId.tsx
@@ -1,8 +1,8 @@
 import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
-  type MetaFunction,
 } from "@remix-run/server-runtime";
+import { type MetaFunction } from "@remix-run/node";
 import { Memory } from "@mastra/memory";
 import { useParams, useNavigate, useFetcher, Link } from "@remix-run/react";
 
@@ -16,6 +16,7 @@ import { getIntegrationAccounts } from "~/services/integrationAccount.server";
 import { getAvailableModels } from "~/services/llm-provider.server";
 import { ConversationView } from "~/components/conversation";
 import { useTypedLoaderData } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 
 import { toAISdkV5Messages } from "@mastra/ai-sdk/ui";
 
@@ -87,7 +88,7 @@ export default function SingleConversation() {
     integrationAccountMap,
     integrationFrontendMap,
     models,
-  } = useTypedLoaderData<typeof loader>();
+  } = useTypedLoaderData<typeof loader>() as unknown as LoaderData<typeof loader>;
   const { conversationId } = useParams();
 
   if (typeof window === "undefined") return null;

--- a/apps/webapp/app/routes/home.daily.tsx
+++ b/apps/webapp/app/routes/home.daily.tsx
@@ -22,6 +22,7 @@ import {
 } from "~/services/widgets.server";
 import { WidgetContext } from "~/components/editor/extensions/widget-node-extension";
 import { useLocalCommonState } from "~/hooks/use-local-state";
+import { Prisma } from "@prisma/client";
 import { prisma } from "~/db.server";
 import type { OverviewCell } from "~/components/overview/types";
 import { LayoutGrid } from "lucide-react";
@@ -89,7 +90,12 @@ export async function action({ request }: ActionFunctionArgs) {
     const existingMeta = (existing?.metadata ?? {}) as Record<string, unknown>;
     await prisma.workspace.update({
       where: { id: workspace.id },
-      data: { metadata: { ...existingMeta, dailyWidgetLayout: cells } },
+      data: {
+        metadata: {
+          ...existingMeta,
+          dailyWidgetLayout: cells,
+        } as unknown as Prisma.InputJsonValue,
+      },
     });
     return json({ ok: true });
   }
@@ -186,9 +192,19 @@ export default function DailyRoute() {
             minSize="25%"
             collapsible
             collapsedSize={0}
-            onCollapse={() => setPanelOpen(false)}
             onResize={(size) => {
-              localStorage.setItem(STORAGE_SIZE_KEY, String(size));
+              // react-resizable-panels v4 removed onCollapse; detect collapse
+              // by checking the resized size and route it through the same
+              // setPanelOpen path.
+              const percent =
+                typeof size === "object" && size !== null
+                  ? (size as { percentage?: number }).percentage ?? 0
+                  : Number(size);
+              if (percent === 0) {
+                setPanelOpen(false);
+                return;
+              }
+              localStorage.setItem(STORAGE_SIZE_KEY, String(percent));
             }}
           >
             <ClientOnly fallback={null}>

--- a/apps/webapp/app/routes/home.overview.tsx
+++ b/apps/webapp/app/routes/home.overview.tsx
@@ -9,6 +9,7 @@ import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { ClientOnly } from "remix-utils/client-only";
 import { LoaderCircle, Plus } from "lucide-react";
 
+import { Prisma } from "@prisma/client";
 import { requireUser, requireWorkpace } from "~/services/session.server";
 import { prisma } from "~/db.server";
 import {
@@ -71,7 +72,12 @@ export async function action({ request }: ActionFunctionArgs) {
     const existingMeta = (existing?.metadata ?? {}) as Record<string, unknown>;
     await prisma.workspace.update({
       where: { id: workspace.id },
-      data: { metadata: { ...existingMeta, overviewLayout: cells } },
+      data: {
+        metadata: {
+          ...existingMeta,
+          overviewLayout: cells,
+        } as unknown as Prisma.InputJsonValue,
+      },
     });
     return json({ ok: true });
   }

--- a/apps/webapp/app/routes/home.tasks.$taskId.browser.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.browser.tsx
@@ -1,6 +1,7 @@
 import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
 import { Outlet, useParams } from "@remix-run/react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 import { ClientOnly } from "remix-utils/client-only";
 import { useEffect } from "react";
 import { Globe } from "lucide-react";
@@ -33,7 +34,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 function BrowserLayout() {
-  const { sessions } = useTypedLoaderData<typeof loader>();
+  const { sessions } =
+    useTypedLoaderData<typeof loader>() as unknown as LoaderData<typeof loader>;
   const { taskId } = useParams<{ taskId: string }>();
   const { setOpen: setSidebarOpen } = useSidebar();
 

--- a/apps/webapp/app/routes/home.tasks.$taskId.coding.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.coding.tsx
@@ -7,6 +7,7 @@ import {
   useRevalidator,
 } from "@remix-run/react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 import { ClientOnly } from "remix-utils/client-only";
 import { useCallback, useEffect, useState } from "react";
 import { Terminal, Plus } from "lucide-react";
@@ -64,7 +65,7 @@ function CodingLayout() {
     sessions: initialSessions,
     taskTitle,
     taskDescription,
-  } = useTypedLoaderData<typeof loader>();
+  } = useTypedLoaderData<typeof loader>() as unknown as LoaderData<typeof loader>;
   const { taskId, sessionId } = useParams<{
     taskId: string;
     sessionId?: string;

--- a/apps/webapp/app/routes/home.tasks.$taskId.runs.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.runs.tsx
@@ -6,6 +6,7 @@ import {
   useTypedLoaderData,
   useTypedRouteLoaderData,
 } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 import { ClientOnly } from "remix-utils/client-only";
 import { useRef, useCallback, useEffect, useState } from "react";
 import {
@@ -146,7 +147,8 @@ function RunDetail({
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 function RunsPage() {
-  const { runs } = useTypedLoaderData<typeof loader>();
+  const { runs } =
+    useTypedLoaderData<typeof loader>() as unknown as LoaderData<typeof loader>;
   const parent = useRouteLoaderData<typeof parentLoader>(
     "routes/home.tasks.$taskId",
   );

--- a/apps/webapp/app/routes/home.tasks.$taskId.tsx
+++ b/apps/webapp/app/routes/home.tasks.$taskId.tsx
@@ -12,6 +12,7 @@ import {
   useNavigation,
 } from "@remix-run/react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 import { ClientOnly } from "remix-utils/client-only";
 import { LoaderCircle, Trash2, MessageSquare } from "lucide-react";
 import {
@@ -362,8 +363,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 // ─── Layout ───────────────────────────────────────────────────────────────────
 
 function TaskDetailLayout() {
-  const { task, hasCoding, runs, integrationAccountMap } =
-    useTypedLoaderData<typeof loader>();
+  const { task, runs, integrationAccountMap } =
+    useTypedLoaderData<typeof loader>() as unknown as LoaderData<typeof loader>;
   const navigate = useNavigate();
   const location = useLocation();
   const navigation = useNavigation();

--- a/apps/webapp/app/routes/onboarding._index.tsx
+++ b/apps/webapp/app/routes/onboarding._index.tsx
@@ -6,7 +6,9 @@ import {
 import { useCallback } from "react";
 import { useRevalidator } from "@remix-run/react";
 import { useTypedLoaderData } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 
+import { Prisma } from "@prisma/client";
 import { getWorkspaceId, requireUser } from "~/services/session.server";
 import { prisma } from "~/db.server";
 import {
@@ -127,7 +129,7 @@ export async function action({ request }: ActionFunctionArgs) {
       where: { id: user.id },
       data: {
         onboardingComplete: true,
-        metadata: existingMetadata,
+        metadata: existingMetadata as Prisma.InputJsonValue,
       },
     });
   }
@@ -136,7 +138,9 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function OnboardingChat() {
-  const data = useTypedLoaderData<typeof loader>();
+  const data = useTypedLoaderData<typeof loader>() as unknown as LoaderData<
+    typeof loader
+  >;
   const revalidator = useRevalidator();
 
   // After every streamed turn, re-run the loader. If the agent has

--- a/apps/webapp/app/routes/onboarding.gmail.tsx
+++ b/apps/webapp/app/routes/onboarding.gmail.tsx
@@ -6,6 +6,7 @@ import {
 } from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import { useTypedLoaderData } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 import { requireUser } from "~/services/session.server";
 import { updateUser } from "~/models/user.server";
 import { getIntegrationAccountBySlugAndUser } from "~/services/integrationAccount.server";
@@ -74,7 +75,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function OnboardingGmail() {
   const { gmailOAuthUrl, defaultName, redirectTo } =
-    useTypedLoaderData<typeof loader>();
+    useTypedLoaderData<typeof loader>() as unknown as LoaderData<typeof loader>;
   const fetcher = useFetcher();
 
   return (
@@ -104,12 +105,13 @@ export default function OnboardingGmail() {
           >
             skip
           </Button>
-          {gmailOAuthUrl?.redirectURL && (
+          {(gmailOAuthUrl as { redirectURL?: string } | null)?.redirectURL && (
             <Button
               size="lg"
               variant="secondary"
               onClick={() => {
-                window.location.href = gmailOAuthUrl.redirectURL;
+                window.location.href = (gmailOAuthUrl as { redirectURL: string })
+                  .redirectURL;
               }}
             >
               Connect Gmail

--- a/apps/webapp/app/routes/onboarding.name.tsx
+++ b/apps/webapp/app/routes/onboarding.name.tsx
@@ -1,6 +1,7 @@
 import { json, redirect, type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import { useTypedLoaderData } from "remix-typedjson";
+import type { LoaderData } from "~/utils/loader-data";
 import { requireUser } from "~/services/session.server";
 import { prisma } from "~/db.server";
 import { OnboardingAgentName } from "~/components/onboarding/onboarding-agent-name";
@@ -57,7 +58,9 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function OnboardingName() {
-  const { workspaceId, defaultName, defaultSlug } = useTypedLoaderData<typeof loader>();
+  const { workspaceId, defaultName, defaultSlug } = useTypedLoaderData<
+    typeof loader
+  >() as LoaderData<typeof loader>;
   const fetcher = useFetcher();
 
   const handleComplete = (name: string, slug: string) => {

--- a/apps/webapp/app/routes/settings.workspace.models.tsx
+++ b/apps/webapp/app/routes/settings.workspace.models.tsx
@@ -5,6 +5,7 @@ import {
 } from "@remix-run/node";
 import { useLoaderData, useFetcher } from "@remix-run/react";
 import { useState } from "react";
+import { Prisma } from "@prisma/client";
 import { requireUser } from "~/services/session.server";
 import { prisma } from "~/db.server";
 import { SettingSection } from "~/components/setting-section";
@@ -133,7 +134,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         metadata: {
           ...metadata,
           modelConfig: { ...currentConfig, [useCase]: { modelId } },
-        },
+        } as Prisma.InputJsonValue,
       },
     });
 
@@ -553,7 +554,7 @@ export default function ModelsSettings() {
 
   const modelsByProvider = models.reduce(
     (acc, model) => {
-      const providerLabel = model.provider.label ?? model.provider.type;
+      const providerLabel = model.provider.name ?? model.provider.type;
       if (!acc[providerLabel]) acc[providerLabel] = [];
       acc[providerLabel].push({
         id: model.id,

--- a/apps/webapp/app/routes/webhook.$sourceName.tsx
+++ b/apps/webapp/app/routes/webhook.$sourceName.tsx
@@ -48,7 +48,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       integrationAccountId,
       eventBody:
         typeof eventBody === "object"
-          ? JSON.stringify(eventBody).substring(0, 200)
+          ? JSON.stringify(eventBody as any).substring(0, 200)
           : eventBody,
     });
 
@@ -59,10 +59,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
     }
 
     // Slack DM or @mention → respond immediately, process async
-    if (sourceName === "slack" && isSlackDMOrMention(eventBody)) {
+    if (sourceName === "slack" && isSlackDMOrMention(eventBody as any)) {
       void (async () => {
         try {
-          const result = await parseSlackDMEvent(eventBody);
+          const result = await parseSlackDMEvent(eventBody as any);
           if (result.message) {
             await handleChannelMessage("slack", result.message);
           }
@@ -116,7 +116,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     logger.debug(`Webhook GET request for ${sourceName}`, {
       integrationAccountId,
-      eventBody: JSON.stringify(eventBody).substring(0, 200),
+      eventBody: JSON.stringify(eventBody as any).substring(0, 200),
     });
 
     // Check if the event is a URL verification challenge (Slack)

--- a/apps/webapp/app/scripts/backfill-morning-brief.ts
+++ b/apps/webapp/app/scripts/backfill-morning-brief.ts
@@ -144,14 +144,14 @@ export async function seedMorningBriefForWorkspaces(
         continue;
       }
 
-      // 4) Create the daily 9am scheduled task.
+      // 4) Create the daily 9am scheduled task. The agent picks up the
+      // Morning Brief skill by intent at run time — no explicit skillId
+      // attachment needed (see <task_prep>/<task_execution> SKILL CHECK rule).
       const task = await createScheduledTask(workspaceId, userId, {
         title: "Morning brief",
         schedule: "FREQ=DAILY;BYHOUR=9",
         maxOccurrences: null,
         metadata: {
-          skillId: skill.id,
-          skillName: skill.title,
           kind: "morning_brief_daily",
         },
       });

--- a/apps/webapp/app/scripts/backfill-morning-brief.ts
+++ b/apps/webapp/app/scripts/backfill-morning-brief.ts
@@ -146,7 +146,8 @@ export async function seedMorningBriefForWorkspaces(
 
       // 4) Create the daily 9am scheduled task. The agent picks up the
       // Morning Brief skill by intent at run time — no explicit skillId
-      // attachment needed (see <task_prep>/<task_execution> SKILL CHECK rule).
+      // attachment needed (the agent picks it up via the global <skills>
+      // SKILL CHECK rule when the task title/description matches).
       const task = await createScheduledTask(workspaceId, userId, {
         title: "Morning brief",
         schedule: "FREQ=DAILY;BYHOUR=9",

--- a/apps/webapp/app/services/__tests__/task-lifecycle.test.ts
+++ b/apps/webapp/app/services/__tests__/task-lifecycle.test.ts
@@ -164,35 +164,26 @@ afterAll(async () => {
 // ─── createTask — buffer wake-up ─────────────────────────────────────
 
 describe("createTask — buffer wake-up", () => {
-  it("creates task in Todo + phase=prep and schedules a 2-minute wake-up", async () => {
-    const before = Date.now();
+  it("creates Todo task as backlog — no buffer wake-up, no enqueue", async () => {
     const task = await createTask(
       TEST_WORKSPACE_ID,
       TEST_USER_ID,
       "Test task",
     );
-    const after = Date.now();
 
-    // Status + phase
+    // Todo is the backlog state: the task sits idle until promoted to
+    // Ready, which is when the 2-minute buffer kicks in (via
+    // changeTaskStatus). No wake-up is scheduled at creation.
     expect(task.status).toBe("Todo");
+    expect(task.nextRunAt).toBeNull();
     const meta = (task.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("prep");
-
-    // nextRunAt should be ~2 minutes from now
-    expect(task.nextRunAt).toBeTruthy();
-    const nextRunMs = task.nextRunAt!.getTime();
-    expect(nextRunMs).toBeGreaterThanOrEqual(before + 2 * 60 * 1000 - 1000);
-    expect(nextRunMs).toBeLessThanOrEqual(after + 2 * 60 * 1000 + 1000);
-
-    // Immediate enqueue is GONE, scheduled wake-up is used instead
+    expect(meta.phase).toBeUndefined();
     expect(enqueueTaskMock).not.toHaveBeenCalled();
-    expect(enqueueScheduledTaskMock).toHaveBeenCalledTimes(1);
-    const [payload, scheduledAt] = enqueueScheduledTaskMock.mock.calls[0];
-    expect(payload.taskId).toBe(task.id);
-    expect(scheduledAt.getTime()).toBe(nextRunMs);
+    expect(enqueueScheduledTaskMock).not.toHaveBeenCalled();
   });
 
-  it("skips buffer when status=Ready is set without actor (user/system path)", async () => {
+  it("creates Ready task (any actor) with a 2-minute buffer wake-up", async () => {
+    const before = Date.now();
     const task = await createTask(
       TEST_WORKSPACE_ID,
       TEST_USER_ID,
@@ -200,16 +191,22 @@ describe("createTask — buffer wake-up", () => {
       undefined,
       { status: "Ready" },
     );
-    // No actor → user/dashboard path → no buffer, immediate Ready execute phase
+    const after = Date.now();
+
+    // Ready always gets the buffer — the rule is unified across all paths
+    // (createTask, changeTaskStatus, unblock_task). Actor doesn't matter.
     expect(task.status).toBe("Ready");
-    expect(task.nextRunAt).toBeNull();
-    expect(enqueueScheduledTaskMock).not.toHaveBeenCalled();
+    expect(task.nextRunAt).toBeTruthy();
+    const nextRunMs = task.nextRunAt!.getTime();
+    expect(nextRunMs).toBeGreaterThanOrEqual(before + 2 * 60 * 1000 - 1000);
+    expect(nextRunMs).toBeLessThanOrEqual(after + 2 * 60 * 1000 + 1000);
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
+    expect(enqueueScheduledTaskMock).toHaveBeenCalledTimes(1);
     const meta = (task.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("execute");
-    expect(meta.prepDecided).toBeUndefined();
+    expect(meta.phase).toBeUndefined();
   });
 
-  it("agent-created Ready (no schedule) gets a 2-min buffer + prepDecided=true", async () => {
+  it("agent-created Ready (no schedule) gets a 2-min buffer; phase stays absent (execute)", async () => {
     const before = Date.now();
     const task = await createTask(
       TEST_WORKSPACE_ID,
@@ -227,9 +224,9 @@ describe("createTask — buffer wake-up", () => {
     expect(nextRunMs).toBeLessThanOrEqual(after + 2 * 60 * 1000 + 1000);
 
     const meta = (task.metadata ?? {}) as Record<string, unknown>;
-    // Phase stays prep until the buffer fires (handled in scheduled-task.logic.ts)
-    expect(meta.phase).toBe("prep");
-    expect(meta.prepDecided).toBe(true);
+    // Execute-first: absence of metadata.phase IS execute. No prep is written
+    // and no prepDecided marker.
+    expect(meta.phase).toBeUndefined();
 
     // Same buffer mechanism as Todo: scheduled wake-up, NO immediate enqueue
     expect(enqueueTaskMock).not.toHaveBeenCalled();
@@ -251,38 +248,40 @@ describe("createTask — buffer wake-up", () => {
     expect(task.nextRunAt).toBeNull();
     expect(enqueueScheduledTaskMock).not.toHaveBeenCalled();
     const meta = (task.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("prep");
-    // Waiting is gated by user reply, not by a buffer — prepDecided not set yet
-    expect(meta.prepDecided).toBeUndefined();
+    // No phase write on create
+    expect(meta.phase).toBeUndefined();
   });
 
-  it("agent-created Todo path is unchanged (still gets buffer, no prepDecided)", async () => {
+  it("agent-created task with no status defaults to Todo backlog (no buffer)", async () => {
+    // Todo is now the explicit "parked" state; createTask leaves it
+    // untouched unless the caller passes a different initial status. The
+    // agent's create_task tool sets status: "Ready" by default — this
+    // test exercises the bare createTask API without that defaulting.
     const task = await createTask(
       TEST_WORKSPACE_ID,
       TEST_USER_ID,
       "Agent todo",
       undefined,
-      { actor: "agent" }, // no status → Todo
+      { actor: "agent" },
     );
     expect(task.status).toBe("Todo");
-    expect(task.nextRunAt).toBeTruthy();
-    expect(enqueueScheduledTaskMock).toHaveBeenCalledTimes(1);
+    expect(task.nextRunAt).toBeNull();
+    expect(enqueueScheduledTaskMock).not.toHaveBeenCalled();
     const meta = (task.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("prep");
-    expect(meta.prepDecided).toBeUndefined();
+    expect(meta.phase).toBeUndefined();
   });
 });
 
 // ─── processScheduledTask — wake-up branching ────────────────────────
 
 describe("processScheduledTask — wake-up branching", () => {
-  it("buffer expiry (Todo + prep, no schedule) → enqueueTask for prep", async () => {
+  it("buffer expiry (Ready, no schedule) → enqueueTask", async () => {
     const task = await prisma.task.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
         title: "Prep me",
-        status: "Todo",
+        status: "Ready",
         metadata: { phase: "prep" },
         nextRunAt: new Date(Date.now() - 1000), // fire time reached
         isActive: true,
@@ -307,10 +306,10 @@ describe("processScheduledTask — wake-up branching", () => {
       where: { id: task.id },
     });
     expect(reloaded.nextRunAt).toBeNull();
-    expect(reloaded.status).toBe("Todo"); // prep starts in Todo, no status change yet
+    expect(reloaded.status).toBe("Ready"); // buffer expiry just enqueues; status stays as-is
   });
 
-  it("buffer expiry: empty scratchpad task (source=daily, Untitled, no description) → auto-deleted, scratchpad node pulled, no prep enqueued", async () => {
+  it("buffer expiry: empty scratchpad task (source=daily, Untitled, no description) → auto-deleted, scratchpad node pulled, no enqueue", async () => {
     const page = await prisma.page.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
@@ -323,7 +322,7 @@ describe("processScheduledTask — wake-up branching", () => {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
         title: "Untitled task",
-        status: "Todo",
+        status: "Ready",
         source: "daily",
         metadata: { phase: "prep" },
         nextRunAt: new Date(Date.now() - 1000),
@@ -349,13 +348,13 @@ describe("processScheduledTask — wake-up branching", () => {
     expect(reloaded).toBeNull();
   });
 
-  it("buffer expiry: scratchpad task with a real title → starts prep, NOT deleted", async () => {
+  it("buffer expiry: scratchpad task with a real title → enqueued, NOT deleted", async () => {
     const task = await prisma.task.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
         title: "Buy oat milk",
-        status: "Todo",
+        status: "Ready",
         source: "daily",
         metadata: { phase: "prep" },
         nextRunAt: new Date(Date.now() - 1000),
@@ -383,7 +382,7 @@ describe("processScheduledTask — wake-up branching", () => {
     expect(reloaded.nextRunAt).toBeNull();
   });
 
-  it("buffer expiry: scratchpad task with description but Untitled title → starts prep, NOT deleted", async () => {
+  it("buffer expiry: scratchpad task with description but Untitled title → enqueued, NOT deleted", async () => {
     const page = await prisma.page.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
@@ -396,7 +395,7 @@ describe("processScheduledTask — wake-up branching", () => {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
         title: "Untitled task",
-        status: "Todo",
+        status: "Ready",
         source: "daily",
         metadata: { phase: "prep" },
         nextRunAt: new Date(Date.now() - 1000),
@@ -440,7 +439,7 @@ describe("processScheduledTask — wake-up branching", () => {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
         title: "Untitled task",
-        status: "Todo",
+        status: "Ready",
         source: "manual",
         metadata: { phase: "prep" },
         nextRunAt: new Date(Date.now() - 1000),
@@ -467,14 +466,17 @@ describe("processScheduledTask — wake-up branching", () => {
     expect(reloaded).not.toBeNull();
   });
 
-  it("ready-buffer expiry (Ready + prep, no schedule) → flip to execute and enqueue", async () => {
+  it("ready-buffer expiry (Ready, no schedule) → enqueue for execution", async () => {
+    // Execute-first model: new tasks have no phase metadata (absence = execute).
+    // The buffer wake-up just clears nextRunAt and enqueues; it never writes
+    // metadata, so any pre-existing fields (legacy phase, app-specific keys)
+    // are passed through untouched.
     const task = await prisma.task.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
         title: "Agent-ready task at buffer expiry",
         status: "Ready",
-        metadata: { phase: "prep", prepDecided: true },
         nextRunAt: new Date(Date.now() - 1000),
         isActive: true,
       },
@@ -487,33 +489,32 @@ describe("processScheduledTask — wake-up branching", () => {
       channel: "email",
     });
 
-    // Should NOT have started prep (no runCASEPipeline call from a prep flow,
-    // no fire-override) — should have enqueued for normal execution.
+    // No CASE pipeline run from the wake-up itself — that happens after
+    // enqueue, in the task runner.
     expect(runCASEPipelineMock).not.toHaveBeenCalled();
     expect(enqueueTaskMock).toHaveBeenCalledTimes(1);
     const [payload] = enqueueTaskMock.mock.calls[0];
     expect(payload.taskId).toBe(task.id);
 
-    // Status stays Ready; phase flips to execute; nextRunAt cleared
+    // Status stays Ready; nextRunAt cleared; metadata is not touched.
     const reloaded = await prisma.task.findUniqueOrThrow({
       where: { id: task.id },
     });
     expect(reloaded.status).toBe("Ready");
     expect(reloaded.nextRunAt).toBeNull();
-    const meta = (reloaded.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("execute");
-    // prepDecided is preserved (it's still informative)
-    expect(meta.prepDecided).toBe(true);
   });
 
-  it("normal fire (Ready) → execute via CASE pipeline", async () => {
+  it("normal fire (Ready + schedule) → execute via CASE pipeline", async () => {
+    // Execute-first: a Ready task with no schedule + nextRunAt past is
+    // treated as buffer expiry (just enqueue). Normal fire only applies to
+    // Ready + schedule (recurring/scheduled fires at their next occurrence).
     const task = await prisma.task.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
         title: "Execute me",
         status: "Ready",
-        metadata: { phase: "execute" },
+        schedule: "FREQ=DAILY;BYHOUR=9",
         nextRunAt: new Date(Date.now() - 1000),
         isActive: true,
       },
@@ -530,14 +531,18 @@ describe("processScheduledTask — wake-up branching", () => {
     expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
-  it("fire-override (Todo + prep + schedule) → execute, status flips to Working", async () => {
+  it("fire-override (Todo + schedule) → execute via pipeline, recurring loops back to Ready", async () => {
+    // A scheduled task that fires while still Todo (user hadn't yet
+    // promoted it before the scheduled time hit). executeFireOverride
+    // flips to Working then runs the pipeline. For recurring tasks
+    // scheduleNextTaskOccurrence then loops Working → Ready for the next
+    // occurrence — that's the observable final state.
     const task = await prisma.task.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
-        title: "Scheduled fire during prep",
+        title: "Scheduled fire during workup",
         status: "Todo",
-        metadata: { phase: "prep" },
         nextRunAt: new Date(Date.now() - 1000),
         schedule: "FREQ=DAILY;BYHOUR=9",
         isActive: true,
@@ -557,9 +562,8 @@ describe("processScheduledTask — wake-up branching", () => {
     const reloaded = await prisma.task.findUniqueOrThrow({
       where: { id: task.id },
     });
-    expect(reloaded.status).toBe("Working");
-    const reloadedMeta = (reloaded.metadata ?? {}) as Record<string, unknown>;
-    expect(reloadedMeta.phase).toBe("execute");
+    // Recurring loop-back: Working → Ready post-pipeline.
+    expect(reloaded.status).toBe("Ready");
   });
 
   it("no-ops when task is deactivated", async () => {
@@ -959,32 +963,30 @@ describe("changeTaskStatus — butler restrictions", () => {
     ).rejects.toThrow(/Invalid transition/);
   });
 
-  it("allows butler Todo → Ready and flips phase to execute", async () => {
+  it("agent cannot promote Todo → Ready (execute-first reserves Ready for system/user)", async () => {
     const task = await prisma.task.create({
       data: {
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
-        title: "Butler approved",
+        title: "Butler tries to promote",
         status: "Todo",
-        metadata: { phase: "prep" },
         isActive: true,
       },
     });
 
-    const updated = await changeTaskStatus(
-      task.id,
-      "Ready",
-      TEST_WORKSPACE_ID,
-      TEST_USER_ID,
-      "agent",
-    );
-    // changeTaskStatus also enqueues the task when moving to Ready; that's
-    // expected behavior and we just assert the DB end-state here.
-    const meta = (updated.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("execute");
-    // Status may be Ready (no subtasks) or Working (if auto-enqueued and
-    // flipped by subtask-first path). For a childless task it's Ready.
-    expect(["Ready", "Working"]).toContain(updated.status);
+    // Agent-actor Ready transitions are now disallowed by canTransition.
+    // Ready is the runtime/user signal that execution should start; the
+    // agent uses update_task(Waiting) for blockers and update_task(Review)
+    // for completion. Buffer expiry / unblock_task / UI handle Ready.
+    await expect(
+      changeTaskStatus(
+        task.id,
+        "Ready",
+        TEST_WORKSPACE_ID,
+        TEST_USER_ID,
+        "agent",
+      ),
+    ).rejects.toThrow(/Invalid transition/);
   });
 
   it("allows user Review → Done", async () => {
@@ -1035,8 +1037,10 @@ describe("createScheduledTask — recurring / scheduled", () => {
     });
 
     expect(task.status).toBe("Ready");
+    // No phase metadata written on creation — execute is the implicit
+    // default (absence of metadata.phase).
     const meta = (task.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("execute");
+    expect(meta.phase).toBeUndefined();
     expect(enqueueScheduledTaskMock).toHaveBeenCalled();
   });
 
@@ -1269,6 +1273,6 @@ describe("createScheduledTask — recurring / scheduled", () => {
 
     expect(task.status).toBe("Ready");
     const meta = (task.metadata ?? {}) as Record<string, unknown>;
-    expect(meta.phase).toBe("execute");
+    expect(meta.phase).toBeUndefined();
   });
 });

--- a/apps/webapp/app/services/__tests__/task-phase.test.ts
+++ b/apps/webapp/app/services/__tests__/task-phase.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   canTransition,
-  inferNewPhase,
   getTaskPhase,
   setTaskPhaseInMetadata,
 } from "~/services/task.phase";
@@ -9,27 +8,40 @@ import {
 // ─── getTaskPhase ───────────────────────────────────────────────────
 
 describe("getTaskPhase", () => {
-  it("reads phase from metadata when present", () => {
-    expect(getTaskPhase({ status: "Todo", metadata: { phase: "execute" } })).toBe(
-      "execute",
+  it("returns prep only when metadata.phase is explicitly 'prep'", () => {
+    expect(getTaskPhase({ status: "Todo", metadata: { phase: "prep" } })).toBe(
+      "prep",
     );
     expect(getTaskPhase({ status: "Ready", metadata: { phase: "prep" } })).toBe(
       "prep",
     );
   });
 
-  it("falls back to status-based inference when metadata is missing", () => {
-    expect(getTaskPhase({ status: "Todo", metadata: null })).toBe("prep");
-    expect(getTaskPhase({ status: "Waiting", metadata: {} })).toBe("prep");
+  it("returns execute when metadata is missing (absence = execute)", () => {
+    expect(getTaskPhase({ status: "Todo", metadata: null })).toBe("execute");
+    expect(getTaskPhase({ status: "Waiting", metadata: {} })).toBe("execute");
     expect(getTaskPhase({ status: "Ready", metadata: null })).toBe("execute");
     expect(getTaskPhase({ status: "Working", metadata: null })).toBe("execute");
     expect(getTaskPhase({ status: "Review", metadata: null })).toBe("execute");
     expect(getTaskPhase({ status: "Done", metadata: null })).toBe("execute");
-    expect(getTaskPhase({ status: "Recurring", metadata: null })).toBe("execute");
+    expect(getTaskPhase({ status: "Recurring", metadata: null })).toBe(
+      "execute",
+    );
   });
 
-  it("ignores non-string phase values in metadata", () => {
-    expect(getTaskPhase({ status: "Todo", metadata: { phase: 42 } })).toBe("prep");
+  it("returns execute for explicit metadata.phase = 'execute' (legacy)", () => {
+    expect(
+      getTaskPhase({ status: "Todo", metadata: { phase: "execute" } }),
+    ).toBe("execute");
+    expect(
+      getTaskPhase({ status: "Ready", metadata: { phase: "execute" } }),
+    ).toBe("execute");
+  });
+
+  it("ignores non-string phase values in metadata (defaults to execute)", () => {
+    expect(getTaskPhase({ status: "Todo", metadata: { phase: 42 } })).toBe(
+      "execute",
+    );
     expect(
       getTaskPhase({ status: "Ready", metadata: { phase: "invalid" } }),
     ).toBe("execute");
@@ -39,26 +51,38 @@ describe("getTaskPhase", () => {
 // ─── setTaskPhaseInMetadata ─────────────────────────────────────────
 
 describe("setTaskPhaseInMetadata", () => {
-  it("sets phase on empty metadata", () => {
+  it("sets phase=prep on empty metadata", () => {
     expect(setTaskPhaseInMetadata(null, "prep")).toEqual({ phase: "prep" });
-    expect(setTaskPhaseInMetadata({}, "execute")).toEqual({ phase: "execute" });
   });
 
-  it("preserves other metadata keys", () => {
+  it("removes the phase key when set to execute (execute is implicit)", () => {
+    expect(setTaskPhaseInMetadata({}, "execute")).toEqual({});
+    expect(setTaskPhaseInMetadata({ phase: "prep" }, "execute")).toEqual({});
+  });
+
+  it("preserves other metadata keys when setting prep", () => {
     const result = setTaskPhaseInMetadata(
       { rescheduleCount: 2, skillId: "s1" },
-      "execute",
+      "prep",
     );
     expect(result).toEqual({
       rescheduleCount: 2,
       skillId: "s1",
-      phase: "execute",
+      phase: "prep",
     });
   });
 
-  it("overwrites existing phase", () => {
-    expect(setTaskPhaseInMetadata({ phase: "prep" }, "execute")).toEqual({
-      phase: "execute",
+  it("preserves other metadata keys when setting execute (only phase is dropped)", () => {
+    const result = setTaskPhaseInMetadata(
+      { rescheduleCount: 2, phase: "prep" },
+      "execute",
+    );
+    expect(result).toEqual({ rescheduleCount: 2 });
+  });
+
+  it("overwrites existing phase=prep when setting prep again", () => {
+    expect(setTaskPhaseInMetadata({ phase: "prep" }, "prep")).toEqual({
+      phase: "prep",
     });
   });
 });
@@ -66,148 +90,62 @@ describe("setTaskPhaseInMetadata", () => {
 // ─── canTransition ──────────────────────────────────────────────────
 
 describe("canTransition", () => {
-  // Butler-driven transitions (actor: "agent")
-  it("allows agent Todo -> Waiting", () => {
-    expect(canTransition("Todo", "Waiting", "prep", "agent")).toBe(true);
+  // Agents may only set Waiting or Review. Everything else is system/user.
+  it("allows agent to set Waiting from any status", () => {
+    expect(canTransition("Todo", "Waiting", "agent")).toBe(true);
+    expect(canTransition("Ready", "Waiting", "agent")).toBe(true);
+    expect(canTransition("Working", "Waiting", "agent")).toBe(true);
+    expect(canTransition("Review", "Waiting", "agent")).toBe(true);
   });
 
-  it("allows agent Todo -> Ready when butler deems it clear", () => {
-    expect(canTransition("Todo", "Ready", "prep", "agent")).toBe(true);
+  it("allows agent to set Review from any status", () => {
+    expect(canTransition("Todo", "Review", "agent")).toBe(true);
+    expect(canTransition("Ready", "Review", "agent")).toBe(true);
+    expect(canTransition("Working", "Review", "agent")).toBe(true);
+    expect(canTransition("Waiting", "Review", "agent")).toBe(true);
   });
 
-  it("allows agent Waiting -> Ready in prep phase", () => {
-    expect(canTransition("Waiting", "Ready", "prep", "agent")).toBe(true);
+  it("forbids agent from setting Working (system-only)", () => {
+    expect(canTransition("Ready", "Working", "agent")).toBe(false);
+    expect(canTransition("Waiting", "Working", "agent")).toBe(false);
+    expect(canTransition("Todo", "Working", "agent")).toBe(false);
   });
 
-  it("allows agent Working -> Review", () => {
-    expect(canTransition("Working", "Review", "execute", "agent")).toBe(true);
+  it("forbids agent from setting Done (user-only)", () => {
+    expect(canTransition("Review", "Done", "agent")).toBe(false);
+    expect(canTransition("Working", "Done", "agent")).toBe(false);
   });
 
-  it("allows agent Working -> Waiting in execute phase", () => {
-    expect(canTransition("Working", "Waiting", "execute", "agent")).toBe(true);
+  it("forbids agent from setting Todo (parking is system/user)", () => {
+    expect(canTransition("Waiting", "Todo", "agent")).toBe(false);
   });
 
-  it("allows agent Ready -> Review (synchronous finish without Working step)", () => {
-    expect(canTransition("Ready", "Review", "execute", "agent")).toBe(true);
+  it("forbids agent from setting Ready (system handles unblock and buffer expiry)", () => {
+    expect(canTransition("Todo", "Ready", "agent")).toBe(false);
+    expect(canTransition("Waiting", "Ready", "agent")).toBe(false);
+    expect(canTransition("Working", "Ready", "agent")).toBe(false);
+    expect(canTransition("Review", "Ready", "agent")).toBe(false);
   });
 
-  it("allows agent Ready -> Waiting (needs input before starting)", () => {
-    expect(canTransition("Ready", "Waiting", "execute", "agent")).toBe(true);
+  // User-driven transitions — unrestricted
+  it("allows user transitions across the lifecycle", () => {
+    expect(canTransition("Waiting", "Ready", "user")).toBe(true);
+    expect(canTransition("Review", "Done", "user")).toBe(true);
+    expect(canTransition("Todo", "Ready", "user")).toBe(true);
+    expect(canTransition("Working", "Done", "user")).toBe(true);
   });
 
-  it("allows agent Waiting -> Review (trivial completion from waiting)", () => {
-    expect(canTransition("Waiting", "Review", "execute", "agent")).toBe(true);
+  // System-driven transitions — unrestricted (time-triggered wake-ups, recurring advance)
+  it("allows system transitions across the lifecycle", () => {
+    expect(canTransition("Ready", "Working", "system")).toBe(true);
+    expect(canTransition("Todo", "Working", "system")).toBe(true);
+    expect(canTransition("Waiting", "Working", "system")).toBe(true);
+    expect(canTransition("Review", "Ready", "system")).toBe(true);
   });
 
-  // Forbidden butler transitions
-  it("forbids agent Review -> Done (user only)", () => {
-    expect(canTransition("Review", "Done", "execute", "agent")).toBe(false);
-  });
-
-  it("forbids agent Todo -> Working (cross-phase, agent)", () => {
-    expect(canTransition("Todo", "Working", "prep", "agent")).toBe(false);
-  });
-
-  it("forbids agent Waiting -> Working in prep (cross-phase, agent)", () => {
-    expect(canTransition("Waiting", "Working", "prep", "agent")).toBe(false);
-  });
-
-  it("forbids agent Ready -> Working (system runner only)", () => {
-    expect(canTransition("Ready", "Working", "execute", "agent")).toBe(false);
-  });
-
-  it("forbids agent Waiting -> Working in execute (system runner only)", () => {
-    expect(canTransition("Waiting", "Working", "execute", "agent")).toBe(false);
-  });
-
-  it("allows agent Todo -> Review (synchronous finish during prep)", () => {
-    expect(canTransition("Todo", "Review", "prep", "agent")).toBe(true);
-  });
-
-  it("allows agent Waiting -> Review in prep phase", () => {
-    expect(canTransition("Waiting", "Review", "prep", "agent")).toBe(true);
-  });
-
-  it("allows user Todo -> Review", () => {
-    expect(canTransition("Todo", "Review", "prep", "user")).toBe(true);
-  });
-
-  // User-driven transitions
-  it("allows user Waiting -> Ready (force-promote)", () => {
-    expect(canTransition("Waiting", "Ready", "prep", "user")).toBe(true);
-  });
-
-  it("allows user Review -> Done", () => {
-    expect(canTransition("Review", "Done", "execute", "user")).toBe(true);
-  });
-
-  it("allows user Todo -> Ready", () => {
-    expect(canTransition("Todo", "Ready", "prep", "user")).toBe(true);
-  });
-
-  // System-driven transitions (time-triggered wake-ups)
-  it("allows system Ready -> Working (scheduled fire)", () => {
-    expect(canTransition("Ready", "Working", "execute", "system")).toBe(true);
-  });
-
-  it("allows system Todo -> Working (fire-override from prep)", () => {
-    expect(canTransition("Todo", "Working", "prep", "system")).toBe(true);
-  });
-
-  it("allows system Waiting -> Working (fire-override from prep)", () => {
-    expect(canTransition("Waiting", "Working", "prep", "system")).toBe(true);
-  });
-
-  it("allows system Review -> Ready (recurring advance)", () => {
-    expect(canTransition("Review", "Ready", "execute", "system")).toBe(true);
-  });
-
-  // Auto-loop guard: agent cannot promote a task back to Ready once it has
-  // entered execute. Only system (scheduled fire) or user (UI) may do so.
-  it("rejects agent -> Ready when phase is execute (auto-loop guard)", () => {
-    expect(canTransition("Working", "Ready", "execute", "agent")).toBe(false);
-    expect(canTransition("Waiting", "Ready", "execute", "agent")).toBe(false);
-    expect(canTransition("Review", "Ready", "execute", "agent")).toBe(false);
-  });
-
-  it("allows system or user -> Ready in execute (escape hatch from auto-loop guard)", () => {
-    expect(canTransition("Working", "Ready", "execute", "system")).toBe(true);
-    expect(canTransition("Review", "Ready", "execute", "user")).toBe(true);
+  it("allows same-status no-op transitions for any actor", () => {
+    expect(canTransition("Working", "Working", "agent")).toBe(true);
+    expect(canTransition("Ready", "Ready", "user")).toBe(true);
+    expect(canTransition("Done", "Done", "system")).toBe(true);
   });
 });
-
-// ─── inferNewPhase ──────────────────────────────────────────────────
-
-describe("inferNewPhase", () => {
-  it("stays in prep when status remains in Phase 1", () => {
-    expect(inferNewPhase("Todo", "Waiting", "prep")).toBe("prep");
-    expect(inferNewPhase("Waiting", "Todo", "prep")).toBe("prep");
-  });
-
-  it("moves to execute when reaching Ready from prep", () => {
-    expect(inferNewPhase("Todo", "Ready", "prep")).toBe("execute");
-    expect(inferNewPhase("Waiting", "Ready", "prep")).toBe("execute");
-  });
-
-  it("stays in execute for Phase 2 intra-phase transitions", () => {
-    expect(inferNewPhase("Ready", "Working", "execute")).toBe("execute");
-    expect(inferNewPhase("Working", "Waiting", "execute")).toBe("execute");
-    expect(inferNewPhase("Working", "Review", "execute")).toBe("execute");
-    expect(inferNewPhase("Review", "Done", "execute")).toBe("execute");
-  });
-
-  it("moves to execute on fire-override", () => {
-    expect(inferNewPhase("Todo", "Working", "prep")).toBe("execute");
-    expect(inferNewPhase("Waiting", "Working", "prep")).toBe("execute");
-  });
-
-  it("moves to execute on prep-phase synchronous finish (Todo/Waiting -> Review)", () => {
-    expect(inferNewPhase("Todo", "Review", "prep")).toBe("execute");
-    expect(inferNewPhase("Waiting", "Review", "prep")).toBe("execute");
-  });
-
-  it("stays in execute for recurring Review -> Ready loop", () => {
-    expect(inferNewPhase("Review", "Ready", "execute")).toBe("execute");
-  });
-});
-

--- a/apps/webapp/app/services/agent/__tests__/session-tools.test.ts
+++ b/apps/webapp/app/services/agent/__tests__/session-tools.test.ts
@@ -7,6 +7,12 @@ vi.mock("~/services/coding/coding-session.server", () => ({
 vi.mock("~/services/browser/browser-session.server", () => ({
   getBrowserSessionsForTask: vi.fn(),
 }));
+// resolveTaskId hits Prisma in the real implementation; the resolver in
+// these tests just passes the agent-supplied id through to the underlying
+// session getters, which is exactly what the test assertions expect.
+vi.mock("~/services/task.server", () => ({
+  resolveTaskId: vi.fn(async (input: string) => input),
+}));
 
 import { getSessionTools } from "~/services/agent/tools/session-tools";
 import {

--- a/apps/webapp/app/services/agent/agents/core.ts
+++ b/apps/webapp/app/services/agent/agents/core.ts
@@ -57,13 +57,6 @@ interface CreateCoreToolsParams {
   isOnboardingMode?: boolean;
   /** Task ID when running as a background task (for reschedule_self tool) */
   currentTaskId?: string;
-  /**
-   * Phase of the linked task at agent-build time. Controls which of
-   * enter_plan_mode / exit_plan_mode is registered so the agent only sees
-   * the relevant transition. Defaults to "execute" when no task is in
-   * scope (the tools are then conditional on currentTaskId anyway).
-   */
-  currentTaskPhase?: "prep" | "execute";
   /** Channel name from trigger's reminder config (for send_message tool) */
   triggerChannel?: string;
   /** Channel ID from trigger's reminder config (for send_message tool) */
@@ -122,7 +115,6 @@ export async function createCoreTools(
     isBackgroundExecution,
     isOnboardingMode,
     currentTaskId,
-    currentTaskPhase,
     triggerChannel,
     triggerChannelId,
     userEmail,
@@ -212,7 +204,6 @@ export async function createCoreTools(
         channelCtx.channels,
         currentTaskId,
         source,
-        currentTaskPhase,
       );
 
   // Message tools (only in trigger or background task contexts — NOT in webapp

--- a/apps/webapp/app/services/agent/agents/core.ts
+++ b/apps/webapp/app/services/agent/agents/core.ts
@@ -15,7 +15,10 @@ import { createTool } from "@mastra/core/tools";
 
 import { type SkillRef } from "../types";
 import { type ModelConfig } from "~/services/llm-provider.server";
-import { type OrchestratorTools } from "../executors/base";
+import {
+  type OrchestratorTools,
+  type GatewayAgentInfo,
+} from "../executors/base";
 import { type Trigger, type DecisionContext } from "../types/decision-agent";
 import { createThinkAgent } from "./decision";
 import { logger } from "../../logger.service";
@@ -385,12 +388,23 @@ export async function createCoreAgents(
   } = params;
 
   // Load gateways for subagent creation
-  const gateways = executorTools
+  const gateways: GatewayAgentInfo[] = executorTools
     ? await executorTools.getGateways(workspaceId)
-    : await prisma.gateway.findMany({
-        where: { workspaceId },
-        select: { id: true, name: true, status: true, description: true },
-      });
+    : (
+        await prisma.gateway.findMany({
+          where: { workspaceId },
+          select: { id: true, name: true, status: true, description: true },
+        })
+      ).map((g) => ({
+        id: g.id,
+        name: g.name,
+        description: g.description ?? "",
+        baseUrl: "",
+        tools: [],
+        platform: null,
+        hostname: null,
+        status: g.status as "CONNECTED" | "DISCONNECTED",
+      }));
 
   const [reader, writer, { agentList: gatewayAgents }] = await Promise.all([
     createOrchestratorAgent(

--- a/apps/webapp/app/services/agent/agents/core.ts
+++ b/apps/webapp/app/services/agent/agents/core.ts
@@ -57,6 +57,13 @@ interface CreateCoreToolsParams {
   isOnboardingMode?: boolean;
   /** Task ID when running as a background task (for reschedule_self tool) */
   currentTaskId?: string;
+  /**
+   * Phase of the linked task at agent-build time. Controls which of
+   * enter_plan_mode / exit_plan_mode is registered so the agent only sees
+   * the relevant transition. Defaults to "execute" when no task is in
+   * scope (the tools are then conditional on currentTaskId anyway).
+   */
+  currentTaskPhase?: "prep" | "execute";
   /** Channel name from trigger's reminder config (for send_message tool) */
   triggerChannel?: string;
   /** Channel ID from trigger's reminder config (for send_message tool) */
@@ -115,6 +122,7 @@ export async function createCoreTools(
     isBackgroundExecution,
     isOnboardingMode,
     currentTaskId,
+    currentTaskPhase,
     triggerChannel,
     triggerChannelId,
     userEmail,
@@ -204,6 +212,7 @@ export async function createCoreTools(
         channelCtx.channels,
         currentTaskId,
         source,
+        currentTaskPhase,
       );
 
   // Message tools (only in trigger or background task contexts — NOT in webapp

--- a/apps/webapp/app/services/agent/agents/decision.ts
+++ b/apps/webapp/app/services/agent/agents/decision.ts
@@ -151,11 +151,10 @@ export async function createThinkAgent(
   },
   skills?: SkillRef[],
 ): Promise<Agent> {
-  // Think only has gather_context (subagent) and get_skill for informed reasoning.
-  // All execution (create_task, send_message, etc.) is done by the core agent
-  // based on the ActionPlan that think returns.
-  const tools: Record<string, any> = {};
-  tools["get_skill"] = getSkillTool(workspaceId);
+  // Think is a skinny decision filter: shouldMessage / silent actions /
+  // follow-ups / task updates. Skills are visible to think for awareness only
+  // ("does the user have a workflow for this?"), but skill selection and
+  // loading live with the butler.
 
   // Load Watch Rules skill in parallel with prompt building
   const watchRulesSkill = await getDefaultSkill(workspaceId, "watch-rules");
@@ -173,8 +172,8 @@ export async function createThinkAgent(
         currentTime,
         timezone,
         triggerContext.userPersona,
-        skills,
         watchRulesSkill?.content ?? undefined,
+        skills,
       )
     : "Analyze triggers and produce structured JSON action plans.";
 
@@ -185,7 +184,7 @@ export async function createThinkAgent(
     model: modelConfig ?? toRouterString(model),
     instructions,
     agents: { gather_context: gatherContextAgent },
-    tools,
+    tools: { get_skill: getSkillTool(workspaceId) },
   });
 
   const mastra = getMastra();

--- a/apps/webapp/app/services/agent/agents/gateway.ts
+++ b/apps/webapp/app/services/agent/agents/gateway.ts
@@ -29,6 +29,7 @@ import { getProgressUpdateTool } from "../tools/utils-tools";
 import { getSkillTool } from "../tools/skill-tools";
 import { truncateToolResult } from "../tools/truncate-result";
 import { type SkillRef } from "../types";
+import type { ModelConfig } from "~/services/llm-provider.server";
 
 // Types for gateway tools (matches schema in database)
 interface GatewayTool {

--- a/apps/webapp/app/services/agent/agents/gateway.ts
+++ b/apps/webapp/app/services/agent/agents/gateway.ts
@@ -341,9 +341,9 @@ RESUMING vs STARTING vs POLLING (both tracks):
 - If the intent includes a sessionId but NO user answers (just "check status", "poll", or was rescheduled) → this is a POLL. Do NOT call coding_ask. Go straight to coding_read_session to check the session output. Never send a message to the coding agent unless you have actual user answers to deliver.
 
 CODING AGENT SELECTION:
-coding_ask accepts an \`agent\` parameter that selects which coding CLI runs the session (e.g. "claude-code", "codex", "cursor-agent"). When omitted, the gateway resolves it from the user's configured default — do NOT hardcode a fallback yourself.
-- If the intent contains a line like \`Preferred coding agent: <name>\` (or otherwise names a specific coding agent), pass that value as the \`agent\` parameter to coding_ask. Honor it whether the call is a new session, a resume, or a switch.
-- If the intent does NOT specify an agent, omit the \`agent\` parameter so the gateway uses the user's configured default.
+coding_ask accepts an \`agent\` parameter that selects which coding CLI runs the session. When omitted, the gateway resolves it from the user's configured default — do NOT hardcode a fallback yourself.
+- If the intent names a specific coding agent (e.g. \`Preferred coding agent: <name>\`, or the user said "use codex"/"with claude"/etc.), call \`coding_list_agents\` FIRST to discover the exact configured name, then pass that exact name as the \`agent\` parameter. The user's wording is a hint, not the literal name — e.g. "codex" usually maps to a registered name like \`codex-cli\`. Do NOT pass user input verbatim.
+- If the intent does NOT specify an agent, omit the \`agent\` parameter so the gateway uses the user's configured default — no need to call \`coding_list_agents\`.
 
 ---
 

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -531,7 +531,7 @@ PLAN RULES:
 
    - If the description is a GOAL (a desired outcome — you need to figure out the steps):
      → Apply the COMPLEXITY rules from STARTING WORK.
-     → If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → call exit_plan_mode. Then in execute mind, just do it using gather_context / take_action, write the result to the description via update_task with `<outcome>...</outcome>` HTML, send the result via send_message, and mark Review. Do NOT produce a "plan" of how you'll do it.
+     → If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → call exit_plan_mode. Then in execute mind, just do it using gather_context / take_action, write the result to the description via update_task with <outcome>...</outcome> HTML, send the result via send_message, and mark Review. Do NOT produce a "plan" of how you'll do it.
      → If genuinely COMPLEX (multiple independent deliverables, irreversibly bulk, user explicitly said "plan/think through", or coding) → continue to step 1 below to do the planning.
 
 1. Run the READINESS CHECK (see <capabilities>). Load the appropriate skill from <skills>:
@@ -563,7 +563,7 @@ DO NOT:
 CODING SESSION POLLING (during plan mind):
 - "Session still running, brainstorming/planning phase" → call reschedule_self(minutesFromNow=5)
 - Gateway returns questions → relay to user via send_message (include sessionId), mark Waiting
-- Gateway returns plan → write to description via update_task with `<plan>...</plan>` HTML, call exit_plan_mode, send_message
+- Gateway returns plan → write to description via update_task with <plan>...</plan> HTML, call exit_plan_mode, send_message
 
 NEVER write error logs or debug output into the task description.
 </task_planning>`;
@@ -616,7 +616,7 @@ The gateway sub-agent owns all sleep/polling for coding sessions. You do NOT sle
 When you delegate a coding task to the gateway, it will return one of:
 - Questions from the coding agent → relay to user via send_message (include sessionId), mark task Waiting. Don't write the question into the task description.
 - A plan from the coding agent → you're in EXECUTION mode (user already approved the plan). Call the gateway again immediately with sessionId, dir, and intent "execute the plan" to trigger Phase 3.
-- Execution results → write results to task description via update_task with `<outcome>...</outcome>` HTML, mark task Review.
+- Execution results → write results to task description via update_task with <outcome>...</outcome> HTML, mark task Review.
 - "Session still running, brainstorming/planning phase" → reschedule_self(minutesFromNow=5).
 - "Session still running, execution phase" → reschedule_self(minutesFromNow=10). The CodingSession row already records sessionId/dir.
 - Error → update_task(status: "Waiting") + send_message with the error detail.

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -616,19 +616,29 @@ This IS the task — don't create or search for other tasks about this topic. If
       (triggerContext.trigger.data as any)?.isRecurring === true;
 
     systemPrompt += `\n\n<trigger_context>
-A trigger has fired: "${triggerContext.reminderText}"${isTriggerFollowUp ? `\nThis is a FOLLOW-UP trigger. Do NOT create further follow-ups — one level only. If the issue is still unresolved, mark the task Waiting and notify the user.` : ""}${isRecurring ? `\nThis is a RECURRING task. Do NOT update the task description — send results via send_message only. Do NOT mark the task as Done — the system handles the recurring lifecycle automatically. If you need to change status, use Review.` : ""}
+A trigger has fired: "${triggerContext.reminderText}"${isTriggerFollowUp ? `\nThis is a FOLLOW-UP trigger. One follow-up level is the maximum — if the issue is still unresolved, mark the task Waiting and notify the user via send_message.` : ""}${isRecurring ? `\nThis is a RECURRING task. Send results via send_message only and leave the task description untouched. The system handles the recurring lifecycle, so use Review for status changes; the next occurrence is scheduled automatically.` : ""}
 
-1. Call the \`think\` tool FIRST — it will analyze this trigger and return an ActionPlan
-2. Follow the ActionPlan it returns:
-   - Execute any required work (skills, integrations, gather_context, take_action)
-   - If the plan references a skill (skillId in context): call get_skill to load it, then follow the skill's instructions step-by-step
-   - If \`createFollowUps\` contains items: these are RESCHEDULES of the current task, not new tasks. Call \`create_task\` with isFollowUp=true and parentTaskId set to the triggering task's ID.${isTriggerFollowUp ? ` HOWEVER: this trigger is itself a follow-up — IGNORE any createFollowUps. Do not chain follow-ups.` : ""}
-   - If \`updateTasks\` contains items: apply each update via \`update_task\` (status changes, description updates)${isRecurring ? ` — EXCEPT: skip any description updates and skip any status=Done (the system loops recurring tasks automatically)` : ""}
-   - If shouldMessage=true: craft a response summarizing what happened, match the tone specified, be concise. Use \`send_message\` to deliver it.
-   - If shouldMessage=false: do NOT call send_message.
-3. Do NOT create new tasks unless the ActionPlan explicitly says to. The trigger IS already a task — don't duplicate it.
-4. Do NOT use create_task as a way to "deliver" or "send" a message. Use send_message for that.
-5. Don't second-guess the ActionPlan's decision — it already evaluated the trigger
+The \`think\` tool is your decision filter. It tells you whether to speak, what silent actions to take, and what follow-ups to queue. It does NOT compose the message — that's your job, using the skill (when one applies) and fresh data.
+
+**Flow:**
+
+1. Call \`think\` first. It returns an ActionPlan: \`{ shouldMessage, message: { intent, context, tone }, createFollowUps, updateTasks, silentActions, reasoning }\`.
+
+2. If \`shouldMessage\` is true, compose and deliver the message yourself:
+   a. **Pick the skill.** Check \`<task_execution>\` above — if a skill is attached to this task, load it via \`get_skill\` and follow its instructions step-by-step. Otherwise scan \`<skills>\` and load any whose "Use when…" matches the trigger's intent. If nothing fits, compose directly from the trigger text.
+   b. **Gather the data the message needs.** Use \`gather_context\` / \`take_action\` for integrations, memory, web — whatever the skill's recipe (or the trigger) calls for. Fetch fresh; the ActionPlan's \`context\` carries decision flags only, not message content.
+   c. **Compose** the message in the specified tone, matching the user's persona and the channel format. Keep it concise.
+   d. **Deliver** via \`send_message\`. The response the user sees comes from this call — never from echoing the ActionPlan JSON.
+
+3. If \`shouldMessage\` is false, skip \`send_message\` entirely.
+
+4. Apply \`createFollowUps\`${isTriggerFollowUp ? ` (ignore these — this trigger is itself a follow-up; the chain stops here)` : ` by calling \`create_task\` with \`isFollowUp=true\` and \`parentTaskId\` set to the triggering task's ID (these are reschedules of the existing task, not new ones)`}.
+
+5. Apply \`updateTasks\` via \`update_task\`${isRecurring ? ` — except skip description updates and skip \`status: "Done"\` (the system loops recurring tasks automatically)` : ""}.
+
+6. Apply \`silentActions\` (log entries, state updates).
+
+The trigger IS already a task — use the existing taskId for any updates rather than creating a duplicate. Use \`send_message\` for delivery, never \`create_task\`. Trust the ActionPlan's \`shouldMessage\` decision — it has already evaluated the trigger.
 </trigger_context>`;
   }
 

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -532,7 +532,7 @@ PLAN RULES:
 
    - If the description is a GOAL (a desired outcome — you need to figure out the steps):
      → Apply the COMPLEXITY rules from STARTING WORK.
-     → If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → call exit_plan_mode. Then in execute mind, just do it using gather_context / take_action, write the result to the description (section="Output"), send the result via send_message, and mark Review. Do NOT produce a "plan" of how you'll do it.
+     → If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → call exit_plan_mode. Then in execute mind, just do it using gather_context / take_action, write the result to the description via update_task with `<outcome>...</outcome>` HTML, send the result via send_message, and mark Review. Do NOT produce a "plan" of how you'll do it.
      → If genuinely COMPLEX (multiple independent deliverables, irreversibly bulk, user explicitly said "plan/think through", or coding) → continue to step 1 below to do the planning.
 
 1. Run the READINESS CHECK (see <capabilities>). Load the appropriate skill from <skills>:
@@ -564,7 +564,7 @@ DO NOT:
 CODING SESSION POLLING (during plan mind):
 - "Session still running, brainstorming/planning phase" → call reschedule_self(minutesFromNow=5)
 - Gateway returns questions → relay to user via send_message (include sessionId), mark Waiting
-- Gateway returns plan → write to description (section: "Plan"), call exit_plan_mode, send_message
+- Gateway returns plan → write to description via update_task with `<plan>...</plan>` HTML, call exit_plan_mode, send_message
 
 NEVER write error logs or debug output into the task description.
 </task_planning>`;
@@ -599,7 +599,7 @@ RULES:
 - If you fail or get blocked, mark YOURSELF Waiting + send_message referencing both this subtask title and the parent title so the user can identify it. Do NOT cascade to the parent — siblings may still be running.`
           : `
 - If this task warrants decomposition (you loaded the Decompose Task skill and it says SPLIT), follow the skill's instructions:
-  - Create subtasks via create_task with parentTaskId = ${taskHandle}. Subtasks default to Ready and start their own execution cycle through the 2-minute buffer.
+  - Create subtasks via create_task with parentTaskId = ${taskHandle}. Subtasks default to Ready and start their own execution cycle through the editing buffer.
   - Write the breakdown into THIS task's description via update_task with a <plan> section.
   - send_message as a heads-up: "Splitting this into A, B, C — each starts in 2 min. Stop me if wrong." Do NOT move this task to Waiting — the buffer gives the user a veto window. This task stays Working until all subtasks complete; the system auto-marks it Done.`
       }
@@ -617,7 +617,7 @@ The gateway sub-agent owns all sleep/polling for coding sessions. You do NOT sle
 When you delegate a coding task to the gateway, it will return one of:
 - Questions from the coding agent → relay to user via send_message (include sessionId), mark task Waiting. Don't write the question into the task description.
 - A plan from the coding agent → you're in EXECUTION mode (user already approved the plan). Call the gateway again immediately with sessionId, dir, and intent "execute the plan" to trigger Phase 3.
-- Execution results → write results to task description via update_task(section: "Output"), mark task Review.
+- Execution results → write results to task description via update_task with `<outcome>...</outcome>` HTML, mark task Review.
 - "Session still running, brainstorming/planning phase" → reschedule_self(minutesFromNow=5).
 - "Session still running, execution phase" → reschedule_self(minutesFromNow=10). The CodingSession row already records sessionId/dir.
 - Error → update_task(status: "Waiting") + send_message with the error detail.

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -44,6 +44,7 @@ import { type ModelConfig } from "~/services/llm-provider.server";
 import { getPageContentAsHtml } from "~/services/hocuspocus/content.server";
 import { DirectOrchestratorTools } from "./executors";
 import { getTaskPhase } from "~/services/task.phase";
+import { BUILTIN_SKILLS } from "~/services/skills.builtin";
 import { fetchManifest } from "~/services/gateway/transport.server";
 import { deriveCapabilityTags } from "~/services/gateway/utils.server";
 
@@ -236,6 +237,7 @@ export async function buildAgentContext({
       isBackgroundExecution,
       isOnboardingMode,
       currentTaskId: linkedTask?.id,
+      currentTaskPhase: linkedTask ? getTaskPhase(linkedTask) : "execute",
       triggerChannel: triggerContext?.trigger.channel,
       triggerChannelId: triggerContext?.trigger.channelId,
       userEmail: user?.email ?? undefined,
@@ -359,23 +361,45 @@ export async function buildAgentContext({
     Scheduled tasks and notifications go via ${channelCtx.defaultChannelName} unless they say otherwise.
     </messaging_channels>`;
 
-  // Skills context
-  if (skills.length > 0) {
-    const skillsList = skills
-      .map((s: any, i: number) => {
-        const meta = s.metadata as Record<string, unknown> | null;
-        const desc = meta?.shortDescription as string | undefined;
+  // Skills context — merge DB-backed user skills with always-available
+  // built-ins. Built-ins use synthetic `builtin:*` IDs so get_skill can
+  // route the lookup correctly; the user's skills UI never sees them.
+  const skillEntries: Array<{
+    id: string;
+    title: string;
+    shortDescription?: string;
+  }> = [
+    ...skills.map((s: any) => {
+      const meta = s.metadata as Record<string, unknown> | null;
+      return {
+        id: s.id,
+        title: s.title,
+        shortDescription: meta?.shortDescription as string | undefined,
+      };
+    }),
+    ...BUILTIN_SKILLS.map((b) => ({
+      id: b.id,
+      title: b.title,
+      shortDescription: b.shortDescription,
+    })),
+  ];
+
+  if (skillEntries.length > 0) {
+    const skillsList = skillEntries
+      .map((s, i) => {
         const slug = s.title
           .toLowerCase()
           .replace(/\s+/g, "-")
           .replace(/[^a-z0-9-]/g, "");
-        return `${i + 1}. "${s.title}" (id: ${s.id}, slash: /${slug})${desc ? ` — when to use: ${desc}` : ""}`;
+        return `${i + 1}. "${s.title}" (id: ${s.id}, slash: /${slug})${s.shortDescription ? ` — when to use: ${s.shortDescription}` : ""}`;
       })
       .join("\n");
 
     systemPrompt += `
     <skills>
     User-defined skills are reusable workflows or knowledge. Each skill's description tells you when it applies — the title is just a label.
+
+    SKILL CHECK FIRST — on EVERY turn, before you delegate to gather_context / take_action / gateway, before you compose a message, before you call any tool: scan the list below against the user's current intent (and against the task title/description if a task is in context). If any skill matches by intent OR is named/implied in the text (e.g. "run brief skill" → load the "Brief from work" skill, "/brainstorm" → load that skill), call get_skill on it and follow its instructions. The skill is your script; it tells you what to delegate. Only proceed without a skill if NONE applies.
 
     PICK BY INTENT, NOT BY NAME. Match the user's current intent against what each skill is for:
     - Solving a bug / chasing an error / something broken → a debugging skill
@@ -384,10 +408,11 @@ export async function buildAgentContext({
     - Planning multi-step work / decomposing → a planning skill
     A skill applies if its purpose helps with what the user is actually trying to do, even if they never said the skill's name.
 
-    WHEN TO LOAD:
-    - The current intent matches a skill's purpose → call get_skill with the ID and follow it.
-    - The user invokes /skill-name (slash command) → load that one directly.
-    - The user names a skill by title → load it.
+    LOAD TRIGGERS:
+    - Current intent matches a skill's purpose → call get_skill and follow it.
+    - User invokes /skill-name (slash command) → load that one directly.
+    - User names a skill by title (e.g. "use the brief skill", "run X skill") → load it.
+    - Task title/description names or implies a skill → load it before delegating.
     - Multiple skills could apply → prefer the most specific. If none clearly fit, don't force one.
 
     Available skills:
@@ -458,109 +483,98 @@ export async function buildAgentContext({
       linkedTask.parentTaskId ??
       "";
 
-    const phase = getTaskPhase(linkedTask);
-    const taskMetadataForGuard =
-      (linkedTask.metadata as Record<string, unknown> | null) ?? {};
-    const prepDecided = taskMetadataForGuard.prepDecided === true;
-
-    // Belt-and-suspenders: if the agent already decided prep for this task
-    // (skipped to Ready or asked one question and went Waiting), do not render
-    // <task_prep> again. Treat as execute. The phase guard in canTransition is
-    // the primary protection against auto-loops; this prevents stale prep
-    // re-renders if a job was enqueued before the buffer expired.
-    const isPrepPhase = phase === "prep" && !prepDecided;
-    const isExecuting = phase === "execute" || prepDecided;
-
     const isSubtask = !!linkedTask.parentTaskId;
-    const taskMeta = (linkedTask.metadata as Record<string, unknown>) ?? {};
-    const taskSkillId = taskMeta.skillId as string | undefined;
 
-    // Try to find a matching skill for this task
-    let skillHint = "";
-    if (taskSkillId) {
-      const matchedSkill = skills.find((s: any) => s.id === taskSkillId);
-      if (matchedSkill) {
-        skillHint = `\nA skill is attached to this task: "${matchedSkill.title}" (ID: ${matchedSkill.id}). Call get_skill to load its instructions before starting.`;
-      }
-    }
+    // Execute-first lifecycle. New tasks land in execute mind. The agent
+    // self-promotes to plan mind via the enter_plan_mode tool when it
+    // genuinely can't see the shape of the work (ambiguous goal, missing
+    // context, open-ended brainstorm). In plan mind it gathers info and
+    // writes a plan into the task description, then calls exit_plan_mode
+    // to drop back into execute. The phase metadata tracks which block to
+    // render. <task_context> below covers Review/Done — inert states where
+    // the task is in scope but you're not actively driving it.
+    const phase = getTaskPhase(linkedTask);
+    const isActive = linkedTask.status !== "Review" && linkedTask.status !== "Done";
+    const isPlanning = isActive && phase === "prep";
+    const isExecuting = isActive && !isPlanning;
 
-    if (isPrepPhase) {
-      systemPrompt += `\n\n<task_prep>
-You're preparing this task — NOT executing it. Your job is to gather information, clarify scope, and produce a plan. Do NOT do the actual work yet.
+    if (isPlanning) {
+      systemPrompt += `\n\n<task_planning>
+You're in PLAN mind because you (or a prior turn) called enter_plan_mode on this task. Your job is to gather information, clarify scope, and produce a plan. Do NOT do the actual work yet.
 
 Task: ${linkedTask.title}${linkedTask.description ? `\nContext: ${linkedTask.description}` : ""}
 Task ID: ${taskHandle}
-Status: ${linkedTask.status}${isSubtask ? `\nThis is a SUBTASK of a larger task.${parentTaskRecord ? `\nParent task: ${parentTaskRecord.title}${parentTaskDescription ? `\nParent context: ${parentTaskDescription}` : ""}` : ""}` : ""}${skillHint}
+Status: ${linkedTask.status}${isSubtask ? `\nThis is a SUBTASK of a larger task.${parentTaskRecord ? `\nParent task: ${parentTaskRecord.title}${parentTaskDescription ? `\nParent context: ${parentTaskDescription}` : ""}` : ""}` : ""}
 ${
   isSubtask
     ? `
-SUBTASK PREP RULES:
-1. You are prepping ONE CHUNK of a larger task. Read the parent task description and any prior sibling outputs for context.
+SUBTASK PLAN RULES:
+1. You are planning ONE CHUNK of a larger task. Read the parent task description and any prior sibling outputs for context.
 2. Self-resolve questions using available context (parent description, gather_context, code reading). ONLY move to Waiting and ask the user if you genuinely cannot proceed without their input.
 3. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent. Before delegating, call get_task_coding_session. If status is "starting" (gateway hasn't echoed back the sessionId — the session is still spinning up), call reschedule_self(minutesFromNow=2); do NOT call the gateway. If status is "ready", resume by default: pass sessionId, dir, and worktreeBranch. EXCEPTION: if the user explicitly asked for a fresh session or a different coding agent, omit the sessionId so the gateway starts a new session with the requested agent.
-4. For NON-CODING tasks: do the prep yourself using gather_context, take_action, and the readiness skills.
-5. Write your plan into the task description using update_task.
-6. When prep is complete, move to Review: update_task(taskId: "${taskHandle}", status: "Review"). Do NOT wait for user approval — subtasks auto-transition from prep to execute.
+4. For NON-CODING tasks: do the planning yourself using gather_context, take_action, and the readiness skills.
+5. Write your plan into the task description using update_task with a <plan>...</plan> section.
+6. When the plan is ready, call exit_plan_mode. On your next turn you'll be back in execute mind with the plan in front of you.
 7. Send a brief summary via send_message of what you plan to do.
 
 DO NOT:
-- Execute the actual work (no sending emails, no writing code, no making changes)
-- Mark the task as Done
+- Execute the actual work in plan mind (no sending emails, no writing code, no making changes)
+- Mark the task as Review or Done
 - Create further subtasks — you are a subtask, just plan YOUR work
 - Create independent top-level tasks
 `
     : `
-PREP RULES:
+PLAN RULES:
 0. CHECK INPUT SHAPE FIRST. Read the task description and decide what the user gave you (see STARTING WORK > INPUT SHAPE in <capabilities>):
 
    - If the description is a PLAN / RUNBOOK (explicit numbered or named steps, named data sources, named tools — the user already did the planning work):
-     → Treat the description AS the plan. Do NOT re-plan, do NOT propose-and-confirm, do NOT write another plan summary. Execute the steps directly.
-     → If a step has a BLOCKING gap (a referenced field doesn't exist, a destination is ambiguous in a way that affects who/what gets acted on), mark Waiting and ask one blocking question at a time. Cosmetic mismatches (label drift, format choices, defaults with one obvious answer) are NOT blockers — see WHAT NOT TO ASK ABOUT.
-     → When done, write the result to the description (section="Output"), send_message with results, mark Review.
+     → You shouldn't be in plan mind. Call exit_plan_mode and execute the steps directly.
 
    - If the description is a GOAL (a desired outcome — you need to figure out the steps):
      → Apply the COMPLEXITY rules from STARTING WORK.
-     → If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → it should not have landed in prep. Skip planning. Do the actual work now using gather_context / take_action, write the result to the description (section="Output"), send the result via send_message, and mark the task Review. Do NOT produce a "plan" of how you'll do it.
-     → If genuinely COMPLEX (multiple independent deliverables, irreversibly bulk, user explicitly said "plan/think through", or coding) → continue to step 1 below to do the planning prep flow.
+     → If on second look the task is actually SIMPLE (one artifact: summary, profile, brief, recap, list, lookup, single send) → call exit_plan_mode. Then in execute mind, just do it using gather_context / take_action, write the result to the description (section="Output"), send the result via send_message, and mark Review. Do NOT produce a "plan" of how you'll do it.
+     → If genuinely COMPLEX (multiple independent deliverables, irreversibly bulk, user explicitly said "plan/think through", or coding) → continue to step 1 below to do the planning.
 
 1. Run the READINESS CHECK (see <capabilities>). Load the appropriate skill from <skills>:
    - Unclear what's needed? → load "Gather Information" skill
    - Open-ended, needs shaping? → load "Brainstorm" skill
    - Multi-step, needs decomposition? → load "Plan" skill
+   - Considering splitting into subtasks? → load "Decompose Task" skill (built-in)
 2. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent. Pass the task title and description. The gateway will return questions or a plan — do NOT tell it to execute. Before delegating, call get_task_coding_session. If status is "starting" (gateway hasn't echoed back the sessionId — the session is still spinning up), call reschedule_self(minutesFromNow=2); do NOT call the gateway. If status is "ready", resume by default (pass sessionId, dir, worktreeBranch). EXCEPTION: if the user explicitly asked for a fresh session or a different coding agent, omit the sessionId so the gateway starts a new session.
-3. For NON-CODING tasks: do the prep yourself using gather_context, take_action, and the readiness skills.
-4. Write your findings/plan into the task description using update_task.
-5. When prep is complete, move to Review: update_task(taskId: "${taskHandle}", status: "Review")
-6. Send the user a summary via send_message: what you found, what the plan is, and ask them to review.
-7. If this task needs decomposition: create subtasks under this task (parentTaskId: ${taskHandle}) in Waiting status. Each subtask should be a meaningful work chunk, NOT a phase ("Planning"/"Execution"). Write the plan summary in the parent description listing all subtasks. Move parent to Waiting and send_message with the plan.
+3. For NON-CODING tasks: do the planning yourself using gather_context, take_action, and the readiness skills.
+4. Write your findings/plan into the task description using update_task with a <plan>...</plan> section.
+5. When the plan is ready, call exit_plan_mode. On your next turn you'll be back in execute mind with the plan in front of you and you'll act on it.
+6. Send the user a brief summary via send_message: what you found and what the plan is.
+7. If this task needs decomposition (the Decompose Task skill says SPLIT): exit_plan_mode first. Subtasks are created in execute mind after exiting, NOT in plan mind.
 `
 }
-WHEN TO GO TO WAITING instead of Review:
-- You need the user to answer questions before you can plan → mark Waiting, send questions via send_message
-- Gateway returned questions from the coding agent → relay to user via send_message (include sessionId), mark Waiting
+WHEN TO ASK THE USER (mark Waiting):
+- You hit a BLOCKING question you cannot self-resolve from available context → update_task(status: "Waiting") + send_message with ONE focused question. On resume you stay in plan mind until you call exit_plan_mode.
+- Gateway returned questions from the coding agent → relay to user via send_message (include sessionId), mark Waiting.
 
-WHEN TO GO STRAIGHT TO Review:
-- Nothing to prep (task is already clear and simple) → move to Review immediately
-- Plan is complete → write plan to description, move to Review
+WHEN TO EXIT PLAN MIND (call exit_plan_mode):
+- The plan is written into the description and you're ready to act.
+- The task turned out to be simpler than expected — just exit and do it in execute mind.
+- The description was already a runbook — exit and execute.
 
 DO NOT:
-- Execute the actual work (no sending emails, no writing code, no making changes)
-- Mark the task as Done
+- Execute the actual work in plan mind (no sending emails, no writing code, no making changes)
+- Mark the task as Review or Done — exit_plan_mode + execute mind handles completion
 
-CODING SESSION POLLING (during prep):
+CODING SESSION POLLING (during plan mind):
 - "Session still running, brainstorming/planning phase" → call reschedule_self(minutesFromNow=5)
 - Gateway returns questions → relay to user via send_message (include sessionId), mark Waiting
-- Gateway returns plan → write to description (section: "Plan"), mark Review, send_message
+- Gateway returns plan → write to description (section: "Plan"), call exit_plan_mode, send_message
 
 NEVER write error logs or debug output into the task description.
-</task_prep>`;
+</task_planning>`;
     } else if (isExecuting) {
       systemPrompt += `\n\n<task_execution>
-You're executing this task in the background. The prep/planning phase is done — get it done.
+You're handling this task. Default mind: EXECUTE. Read the task, do the work, mark Review when done. If you genuinely can't see the shape (ambiguous goal, missing context, open-ended brainstorm), call enter_plan_mode to switch to PLAN mind.
 
 Task: ${linkedTask.title}${linkedTask.description ? `\nContext: ${linkedTask.description}` : ""}
 Task ID: ${taskHandle}
-Status: ${linkedTask.status}${isSubtask ? `\nThis is a SUBTASK. Do ONLY this specific work. Do not create further subtasks. Do not look at or manage sibling tasks.${parentTaskRecord ? `\nParent task: ${parentTaskRecord.title}${parentTaskDescription ? `\nParent context: ${parentTaskDescription}` : ""}` : ""}` : ""}${skillHint}${
+Status: ${linkedTask.status}${isSubtask ? `\nThis is a SUBTASK. Do ONLY this specific work. Do not create further subtasks. Do not look at or manage sibling tasks.${parentTaskRecord ? `\nParent task: ${parentTaskRecord.title}${parentTaskDescription ? `\nParent context: ${parentTaskDescription}` : ""}` : ""}` : ""}${
         linkedTask.status === "Waiting"
           ? `
 
@@ -572,42 +586,45 @@ THIS TASK IS WAITING. The user's message in this conversation is the reply that 
       }
 
 RULES:
-- For integration work (emails, calendar, github, etc.): delegate to the orchestrator via gather_context / take_action
-- For coding, browser, shell: use gateway tools directly (coding_*, browser_*, exec_*) if connected. Before delegating coding work, call get_task_coding_session. If status is "starting" (gateway hasn't echoed back the sessionId — the session is still spinning up), call reschedule_self(minutesFromNow=2); do NOT call the gateway. If status is "ready", resume by default — pass sessionId/dir/worktreeBranch with the intent "execute the plan". EXCEPTION: if the user explicitly asked for a fresh session or a different coding agent, omit the sessionId so the gateway starts a new session with the requested agent.
-- If the user sends a message, treat it as additional direction for this task${
+- SHAPE OF THE INPUT. Read the description first.
+  - PLAN / RUNBOOK (numbered steps, named tools, the user did the planning) → execute the steps in order. Don't re-plan. If a step has a blocking gap (referenced field missing, destination ambiguous in a way that changes the action), mark Waiting + send_message with ONE focused question. Cosmetic mismatches and obvious defaults are NOT blockers.
+  - GOAL (desired outcome, no steps given) → just execute. If the work is genuinely big (multiple independent deliverables, irreversibly bulk, or the user explicitly said "plan/decompose"), load the "Decompose Task" skill from <skills> and let it tell you whether and how to split. Otherwise: do it directly.
+- ROUTING.
+  - Integration work (email, calendar, github, etc.) → delegate to the orchestrator via gather_context / take_action.
+  - Coding / browser / shell → use the gateway tools directly (coding_*, browser_*, exec_*) when a gateway is connected. Before delegating coding work, call get_task_coding_session. If status is "starting", call reschedule_self(minutesFromNow=2). If "ready", resume by default (sessionId, dir, worktreeBranch). EXCEPTION: if the user asked for a fresh session or a different coding agent, omit sessionId so a new session starts.
+- IF the user sends a new message mid-execution → treat as additional direction for this task.${
         isSubtask
           ? `
-- When you complete this subtask, the system automatically starts the next one and marks the parent Done when all subtasks are done
-- If you fail or get stuck, mark the PARENT task (${parentHandle}) as Waiting and send_message with the error`
+- Subtask completion: when your work is done, call update_task(status: "Review"). The system marks the parent Done when all sibling subtasks complete. Do NOT touch the parent.
+- If you fail or get blocked, mark YOURSELF Waiting + send_message referencing both this subtask title and the parent title so the user can identify it. Do NOT cascade to the parent — siblings may still be running.`
           : `
-- If this task is complex and needs decomposition: create subtasks under this task (parentTaskId: ${taskHandle}) in Waiting status. Each subtask should be a meaningful work chunk, NOT a phase ("Planning"/"Execution"). Move this task to Waiting, then send_message to the user explaining the plan and asking for approval.
-- The system handles sequential subtask execution automatically — when approved, it starts the first subtask. Each subtask completion triggers the next one. You do NOT manage the queue.`
+- If this task warrants decomposition (you loaded the Decompose Task skill and it says SPLIT), follow the skill's instructions:
+  - Create subtasks via create_task with parentTaskId = ${taskHandle}. Subtasks default to Ready and start their own execution cycle through the 2-minute buffer.
+  - Write the breakdown into THIS task's description via update_task with a <plan> section.
+  - send_message as a heads-up: "Splitting this into A, B, C — each starts in 2 min. Stop me if wrong." Do NOT move this task to Waiting — the buffer gives the user a veto window. This task stays Working until all subtasks complete; the system auto-marks it Done.`
       }
-- Mark task ${taskHandle} as Review when the original intent is fully achieved. The user will move it to Done.
-- When Waiting (errors, needs user input, needs approval, partial completion):
-  1. call update_task(taskId: "${taskHandle}", status: "Waiting")
-  2. call send_message explaining what's needed — MUST include the task title so the user (and future you) can identify it. Example: "Task '${linkedTask.title}' is waiting: <reason>. <what's needed to continue>"
-- NEVER write error logs, debug output, or transient state into the task description. The description is for task spec, plan, and structured sections (Plan, Output, Session) only. Errors and status updates go to send_message.
-- When finished:
-  1. call update_task(taskId: "${taskHandle}", status: "Review")
-  2. call send_message with a summary of what was done
-- Do NOT create independent top-level tasks. ${isSubtask ? "You are a subtask — just do your work." : "You can only create subtasks under this task."}
-- DESCRIPTION UPDATES: Only update the task description at phase boundaries (Waiting, plan produced, Review/Done, or when the user provides new context). Do NOT update it on every interaction.
+- COMPLETION. When the original intent is achieved → update_task(taskId: "${taskHandle}", status: "Review") + send_message with a summary. The user moves it to Done.
+- BLOCKERS (need user input — clarification, missing fact, approval for irreversible action):
+  1. update_task(taskId: "${taskHandle}", status: "Waiting")
+  2. send_message that names the task title so the user can identify it. Example: "Task '${linkedTask.title}' is waiting: <reason>. <what's needed to continue>"
+- DO NOT create independent top-level tasks. ${isSubtask ? "You are a subtask — just do your work." : "Subtasks under this task only."}
+- DO NOT mark Done — that's the user's call.
+- DESCRIPTION UPDATES. Only at meaningful boundaries: Waiting (record what's blocked), decomposition (record the plan), Review (record the outcome), or when the user provides new context. Never write error logs, debug output, or transient state into the description.
 
 CODING SESSIONS:
-The gateway sub-agent handles all sleep/polling for coding sessions. You do NOT sleep or poll directly.
+The gateway sub-agent owns all sleep/polling for coding sessions. You do NOT sleep or poll directly.
 
 When you delegate a coding task to the gateway, it will return one of:
-- Questions from the coding agent → relay to user via send_message (include sessionId in the message), mark task Waiting. Do NOT write the question into the task description — the conversation thread is the source of truth.
-- A plan from the coding agent → you are in EXECUTION mode (user already approved the plan). Call the gateway again immediately with sessionId, dir, and intent "execute the plan" to trigger Phase 3 execution. Do NOT mark task Review again — the plan was already reviewed.
-- Execution results → write results to task description using update_task(section: "Output", description: results_html), mark task Review.
-- "Session still running, brainstorming/planning phase" → call reschedule_self(minutesFromNow=5) to check back soon.
-- "Session still running, execution phase" → call reschedule_self(minutesFromNow=10). The CodingSession row already records the sessionId/dir — no need to save it anywhere.
-- Error → update_task(status: "Waiting") then send_message with the error detail. Do NOT write errors into the task description.
+- Questions from the coding agent → relay to user via send_message (include sessionId), mark task Waiting. Don't write the question into the task description.
+- A plan from the coding agent → you're in EXECUTION mode (user already approved the plan). Call the gateway again immediately with sessionId, dir, and intent "execute the plan" to trigger Phase 3.
+- Execution results → write results to task description via update_task(section: "Output"), mark task Review.
+- "Session still running, brainstorming/planning phase" → reschedule_self(minutesFromNow=5).
+- "Session still running, execution phase" → reschedule_self(minutesFromNow=10). The CodingSession row already records sessionId/dir.
+- Error → update_task(status: "Waiting") + send_message with the error detail.
 
-When the user answers a question, resume the coding session with the answer. Do NOT write the answer into the task description.
+When the user answers a question, resume the coding session with the answer. Don't write the answer into the description.
 
-On re-execution after reschedule (we rescheduled ourselves to poll progress — no user input in between): call get_task_coding_session to resolve the latest coding session for this task. If status is "starting" (sessionId hasn't been assigned yet), call reschedule_self(minutesFromNow=2) and try again. If status is "ready", resume that session — delegate to the gateway with the returned sessionId, dir, and intent "execute the plan" so the gateway enters Phase 3 (execution) rather than re-doing planning. Only pass user answers if the user has replied since the last run. EXCEPTION: if the user replied explicitly asking for a fresh session or a different coding agent, omit the sessionId so the gateway starts a new session.
+On re-execution after reschedule (no user input in between): call get_task_coding_session to resolve the latest session. If "starting", reschedule_self(2) and try again. If "ready", resume — pass sessionId, dir, and intent "execute the plan" so the gateway enters Phase 3. Only pass user answers if the user has actually replied since the last run. EXCEPTION: if the user explicitly asked for a fresh session or a different coding agent, omit sessionId.
 
 Do NOT sleep, poll coding_read_session, or create scheduled tasks yourself — the gateway handles that.
 </task_execution>`;
@@ -618,7 +635,7 @@ Title: ${linkedTask.title}${linkedTask.description ? `\nDescription: ${linkedTas
 Task ID: ${taskHandle}
 Status: ${linkedTask.status}
 
-This IS the task — don't create or search for other tasks about this topic. If they add context, update the description via update_task (ID: ${taskHandle}).${linkedTask.status === "Waiting" ? `\nThis task is WAITING. If the user's message is a reply to this task, call unblock_task(taskId: "${taskHandle}", reason: "<user's reply summarized>") FIRST and then STOP. Do not do the work yourself or delegate to any sub-agent — unblock_task triggers the resume.` : ""}
+This IS the task — don't create or search for other tasks about this topic. If they add context, update the description via update_task (ID: ${taskHandle}).
 </task_context>`;
     }
   }

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -144,11 +144,16 @@ export async function buildAgentContext({
     !["web", "core", "task"].includes(source)
       ? prisma.task.findMany({
           where: { workspaceId, status: "Waiting" },
-          select: { id: true, title: true, updatedAt: true },
+          select: { id: true, displayId: true, title: true, updatedAt: true },
           orderBy: { updatedAt: "desc" },
           take: 10,
         })
-      : ([] as { id: string; title: string; updatedAt: Date }[]),
+      : ([] as {
+          id: string;
+          displayId: string | null;
+          title: string;
+          updatedAt: Date;
+        }[]),
   ]);
 
   // Exclude reserved defaults (Persona + Watch Rules) from the dynamic
@@ -168,6 +173,7 @@ export async function buildAgentContext({
         where: { id: conversationRecord.asyncJobId },
         select: {
           id: true,
+          displayId: true,
           title: true,
           pageId: true,
           status: true,
@@ -185,7 +191,7 @@ export async function buildAgentContext({
   const parentTaskRecord = linkedTaskRecord?.parentTaskId
     ? await prisma.task.findUnique({
         where: { id: linkedTaskRecord.parentTaskId },
-        select: { id: true, title: true, pageId: true },
+        select: { id: true, displayId: true, title: true, pageId: true },
       })
     : null;
   const parentTaskDescription = parentTaskRecord?.pageId
@@ -422,7 +428,7 @@ export async function buildAgentContext({
     const waitingList = waitingTasks
       .map(
         (t) =>
-          `- "${t.title}" (ID: ${t.id}) — Waiting since ${t.updatedAt.toLocaleString("en-US", { timeZone: timezone, month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`,
+          `- "${t.title}" (ID: ${t.displayId ?? t.id}) — Waiting since ${t.updatedAt.toLocaleString("en-US", { timeZone: timezone, month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`,
       )
       .join("\n");
     systemPrompt += `
@@ -442,6 +448,16 @@ export async function buildAgentContext({
 
   // Task context (when conversation was created from a task)
   if (linkedTask) {
+    // Agent-facing handles: prefer displayId so tool calls and chatter stay
+    // in the tk-… namespace. Fall back to UUID for older rows that pre-date
+    // the displayId trigger.
+    const taskHandle = linkedTask.displayId ?? linkedTask.id;
+    const parentHandle =
+      parentTaskRecord?.displayId ??
+      parentTaskRecord?.id ??
+      linkedTask.parentTaskId ??
+      "";
+
     const phase = getTaskPhase(linkedTask);
     const taskMetadataForGuard =
       (linkedTask.metadata as Record<string, unknown> | null) ?? {};
@@ -473,7 +489,7 @@ export async function buildAgentContext({
 You're preparing this task — NOT executing it. Your job is to gather information, clarify scope, and produce a plan. Do NOT do the actual work yet.
 
 Task: ${linkedTask.title}${linkedTask.description ? `\nContext: ${linkedTask.description}` : ""}
-Task ID: ${linkedTask.id}
+Task ID: ${taskHandle}
 Status: ${linkedTask.status}${isSubtask ? `\nThis is a SUBTASK of a larger task.${parentTaskRecord ? `\nParent task: ${parentTaskRecord.title}${parentTaskDescription ? `\nParent context: ${parentTaskDescription}` : ""}` : ""}` : ""}${skillHint}
 ${
   isSubtask
@@ -484,7 +500,7 @@ SUBTASK PREP RULES:
 3. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent. Before delegating, call get_task_coding_session. If status is "starting" (gateway hasn't echoed back the sessionId — the session is still spinning up), call reschedule_self(minutesFromNow=2); do NOT call the gateway. If status is "ready", resume by default: pass sessionId, dir, and worktreeBranch. EXCEPTION: if the user explicitly asked for a fresh session or a different coding agent, omit the sessionId so the gateway starts a new session with the requested agent.
 4. For NON-CODING tasks: do the prep yourself using gather_context, take_action, and the readiness skills.
 5. Write your plan into the task description using update_task.
-6. When prep is complete, move to Review: update_task(taskId: "${linkedTask.id}", status: "Review"). Do NOT wait for user approval — subtasks auto-transition from prep to execute.
+6. When prep is complete, move to Review: update_task(taskId: "${taskHandle}", status: "Review"). Do NOT wait for user approval — subtasks auto-transition from prep to execute.
 7. Send a brief summary via send_message of what you plan to do.
 
 DO NOT:
@@ -514,9 +530,9 @@ PREP RULES:
 2. For CODING tasks (when a gateway is connected): delegate brainstorming/planning to the gateway sub-agent. Pass the task title and description. The gateway will return questions or a plan — do NOT tell it to execute. Before delegating, call get_task_coding_session. If status is "starting" (gateway hasn't echoed back the sessionId — the session is still spinning up), call reschedule_self(minutesFromNow=2); do NOT call the gateway. If status is "ready", resume by default (pass sessionId, dir, worktreeBranch). EXCEPTION: if the user explicitly asked for a fresh session or a different coding agent, omit the sessionId so the gateway starts a new session.
 3. For NON-CODING tasks: do the prep yourself using gather_context, take_action, and the readiness skills.
 4. Write your findings/plan into the task description using update_task.
-5. When prep is complete, move to Review: update_task(taskId: "${linkedTask.id}", status: "Review")
+5. When prep is complete, move to Review: update_task(taskId: "${taskHandle}", status: "Review")
 6. Send the user a summary via send_message: what you found, what the plan is, and ask them to review.
-7. If this task needs decomposition: create subtasks under this task (parentTaskId: ${linkedTask.id}) in Waiting status. Each subtask should be a meaningful work chunk, NOT a phase ("Planning"/"Execution"). Write the plan summary in the parent description listing all subtasks. Move parent to Waiting and send_message with the plan.
+7. If this task needs decomposition: create subtasks under this task (parentTaskId: ${taskHandle}) in Waiting status. Each subtask should be a meaningful work chunk, NOT a phase ("Planning"/"Execution"). Write the plan summary in the parent description listing all subtasks. Move parent to Waiting and send_message with the plan.
 `
 }
 WHEN TO GO TO WAITING instead of Review:
@@ -543,13 +559,13 @@ NEVER write error logs or debug output into the task description.
 You're executing this task in the background. The prep/planning phase is done — get it done.
 
 Task: ${linkedTask.title}${linkedTask.description ? `\nContext: ${linkedTask.description}` : ""}
-Task ID: ${linkedTask.id}
+Task ID: ${taskHandle}
 Status: ${linkedTask.status}${isSubtask ? `\nThis is a SUBTASK. Do ONLY this specific work. Do not create further subtasks. Do not look at or manage sibling tasks.${parentTaskRecord ? `\nParent task: ${parentTaskRecord.title}${parentTaskDescription ? `\nParent context: ${parentTaskDescription}` : ""}` : ""}` : ""}${skillHint}${
         linkedTask.status === "Waiting"
           ? `
 
 THIS TASK IS WAITING. The user's message in this conversation is the reply that resumes it.
-- Call unblock_task(taskId: "${linkedTask.id}", reason: "<the user's reply, summarized>") FIRST, then STOP. unblock_task moves the task to Ready and the system re-enqueues execution with the user's reply.
+- Call unblock_task(taskId: "${taskHandle}", reason: "<the user's reply, summarized>") FIRST, then STOP. unblock_task moves the task to Ready and the system re-enqueues execution with the user's reply.
 - Do NOT do the work yourself, delegate to any sub-agent (gateway, gather_context, take_action, etc.), or send a message before unblock_task — the resume handler does that.
 - Exception: if the user's message is clearly NOT a reply to this task (a new unrelated request), ignore the rule above and treat it as new direction.`
           : ""
@@ -562,18 +578,18 @@ RULES:
         isSubtask
           ? `
 - When you complete this subtask, the system automatically starts the next one and marks the parent Done when all subtasks are done
-- If you fail or get stuck, mark the PARENT task (${linkedTask.parentTaskId}) as Waiting and send_message with the error`
+- If you fail or get stuck, mark the PARENT task (${parentHandle}) as Waiting and send_message with the error`
           : `
-- If this task is complex and needs decomposition: create subtasks under this task (parentTaskId: ${linkedTask.id}) in Waiting status. Each subtask should be a meaningful work chunk, NOT a phase ("Planning"/"Execution"). Move this task to Waiting, then send_message to the user explaining the plan and asking for approval.
+- If this task is complex and needs decomposition: create subtasks under this task (parentTaskId: ${taskHandle}) in Waiting status. Each subtask should be a meaningful work chunk, NOT a phase ("Planning"/"Execution"). Move this task to Waiting, then send_message to the user explaining the plan and asking for approval.
 - The system handles sequential subtask execution automatically — when approved, it starts the first subtask. Each subtask completion triggers the next one. You do NOT manage the queue.`
       }
-- Mark task ${linkedTask.id} as Review when the original intent is fully achieved. The user will move it to Done.
+- Mark task ${taskHandle} as Review when the original intent is fully achieved. The user will move it to Done.
 - When Waiting (errors, needs user input, needs approval, partial completion):
-  1. call update_task(taskId: "${linkedTask.id}", status: "Waiting")
+  1. call update_task(taskId: "${taskHandle}", status: "Waiting")
   2. call send_message explaining what's needed — MUST include the task title so the user (and future you) can identify it. Example: "Task '${linkedTask.title}' is waiting: <reason>. <what's needed to continue>"
 - NEVER write error logs, debug output, or transient state into the task description. The description is for task spec, plan, and structured sections (Plan, Output, Session) only. Errors and status updates go to send_message.
 - When finished:
-  1. call update_task(taskId: "${linkedTask.id}", status: "Review")
+  1. call update_task(taskId: "${taskHandle}", status: "Review")
   2. call send_message with a summary of what was done
 - Do NOT create independent top-level tasks. ${isSubtask ? "You are a subtask — just do your work." : "You can only create subtasks under this task."}
 - DESCRIPTION UPDATES: Only update the task description at phase boundaries (Waiting, plan produced, Review/Done, or when the user provides new context). Do NOT update it on every interaction.
@@ -599,10 +615,10 @@ Do NOT sleep, poll coding_read_session, or create scheduled tasks yourself — t
       systemPrompt += `\n\n<task_context>
 This conversation is about a task you're handling:
 Title: ${linkedTask.title}${linkedTask.description ? `\nDescription: ${linkedTask.description}` : ""}
-Task ID: ${linkedTask.id}
+Task ID: ${taskHandle}
 Status: ${linkedTask.status}
 
-This IS the task — don't create or search for other tasks about this topic. If they add context, update the description via update_task (ID: ${linkedTask.id}).${linkedTask.status === "Waiting" ? `\nThis task is WAITING. If the user's message is a reply to this task, call unblock_task(taskId: "${linkedTask.id}", reason: "<user's reply summarized>") FIRST and then STOP. Do not do the work yourself or delegate to any sub-agent — unblock_task triggers the resume.` : ""}
+This IS the task — don't create or search for other tasks about this topic. If they add context, update the description via update_task (ID: ${taskHandle}).${linkedTask.status === "Waiting" ? `\nThis task is WAITING. If the user's message is a reply to this task, call unblock_task(taskId: "${taskHandle}", reason: "<user's reply summarized>") FIRST and then STOP. Do not do the work yourself or delegate to any sub-agent — unblock_task triggers the resume.` : ""}
 </task_context>`;
     }
   }

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -45,6 +45,7 @@ import { getPageContentAsHtml } from "~/services/hocuspocus/content.server";
 import { DirectOrchestratorTools } from "./executors";
 import { getTaskPhase } from "~/services/task.phase";
 import { BUILTIN_SKILLS } from "~/services/skills.builtin";
+import { getDefaultSkill } from "~/services/skills.server";
 import { fetchManifest } from "~/services/gateway/transport.server";
 import { deriveCapabilityTags } from "~/services/gateway/utils.server";
 
@@ -158,10 +159,14 @@ export async function buildAgentContext({
   ]);
 
   // Exclude reserved defaults (Persona + Watch Rules) from the dynamic
-  // skills list — those have separate injection paths (personality blocks +
-  // decision agent). Other default skills (Morning Brief, etc.) stay in the
-  // list so the agent can discover them via <skills> and call get_skill, and
-  // so the scheduled-task skillHint lookup below can resolve them.
+  // skills list — those have separate injection paths:
+  //   - Persona is rendered inline into the personality block.
+  //   - Watch Rules is loaded by the decision agent (decision.ts) and pinned
+  //     into the butler's <trigger_context> by skill ID (see below) so it
+  //     gets fetched via get_skill on every trigger turn.
+  // Other default skills (Morning Brief, etc.) stay in the list so the agent
+  // can discover them via <skills> and call get_skill, and so the
+  // scheduled-task skillHint lookup below can resolve them.
   const skills = allSkills.filter((s) => {
     const meta = s.metadata as Record<string, unknown> | null;
     const skillType = meta?.skillType as string | undefined;
@@ -647,28 +652,39 @@ This IS the task — don't create or search for other tasks about this topic. If
     const isRecurring =
       (triggerContext.trigger.data as any)?.isRecurring === true;
 
+    // Resolve the Watch Rules skill ID so the butler can load the user's
+    // current surfacing policy via get_skill. Single source of truth: the
+    // DB-backed skill. The decision agent loads the same skill on its side.
+    const watchRulesSkill = await getDefaultSkill(workspaceId, "watch-rules");
+    const watchRulesLoadStep = watchRulesSkill?.id
+      ? `\n\n2. **Load Watch Rules and follow them.** Call \`get_skill\` with \`skill_id: "${watchRulesSkill.id}"\` and follow the directives in the returned content. Watch Rules govern TWO independent decisions for this trigger:\n   - Whether to ping the user (\`send_message\`). Use the ActionPlan's \`shouldMessage\` — \`think\` already evaluated Watch Rules to produce it.\n   - Whether to record a Live finds suggestion in today's scratchpad (\`update_scratchpad\`). These are independent — Watch Rules may call for a scratchpad write even when \`shouldMessage\` is false, and vice versa. For trigger flows, Watch Rules override anything in <capabilities> about scratchpad use.\n`
+      : "";
+
     systemPrompt += `\n\n<trigger_context>
 A trigger has fired: "${triggerContext.reminderText}"${isTriggerFollowUp ? `\nThis is a FOLLOW-UP trigger. One follow-up level is the maximum — if the issue is still unresolved, mark the task Waiting and notify the user via send_message.` : ""}${isRecurring ? `\nThis is a RECURRING task. Send results via send_message only and leave the task description untouched. The system handles the recurring lifecycle, so use Review for status changes; the next occurrence is scheduled automatically.` : ""}
+
+**Surfacing ≠ acting on the underlying item.** A trigger is the system noticing something — your job is to *surface* it per Watch Rules (notify + scratchpad), not to take the irreversible action on the user's behalf. For an inbound customer email, that means flagging it and queuing a suggestion; do NOT draft and send a reply unless the user asked you to. Do NOT end the turn by asking the user "should I do A or B?" — make the surfacing call from Watch Rules and stop.
 
 The \`think\` tool is your decision filter. It tells you whether to speak, what silent actions to take, and what follow-ups to queue. It does NOT compose the message — that's your job, using the skill (when one applies) and fresh data.
 
 **Flow:**
 
-1. Call \`think\` first. It returns an ActionPlan: \`{ shouldMessage, message: { intent, context, tone }, createFollowUps, updateTasks, silentActions, reasoning }\`.
-
-2. If \`shouldMessage\` is true, compose and deliver the message yourself:
-   a. **Pick the skill.** Check \`<task_execution>\` above — if a skill is attached to this task, load it via \`get_skill\` and follow its instructions step-by-step. Otherwise scan \`<skills>\` and load any whose "Use when…" matches the trigger's intent. If nothing fits, compose directly from the trigger text.
+1. Call \`think\` first. It returns an ActionPlan: \`{ shouldMessage, message: { intent, context, tone }, createFollowUps, updateTasks, silentActions, reasoning }\`.${watchRulesLoadStep}
+3. If \`shouldMessage\` is true, compose and deliver the message yourself:
+   a. **Pick the skill by intent.** Match the trigger's intent against the "Use when…" descriptions in \`<skills>\` and load the best fit via \`get_skill\`. If nothing fits, compose directly from the trigger text.
    b. **Gather the data the message needs.** Use \`gather_context\` / \`take_action\` for integrations, memory, web — whatever the skill's recipe (or the trigger) calls for. Fetch fresh; the ActionPlan's \`context\` carries decision flags only, not message content.
    c. **Compose** the message in the specified tone, matching the user's persona and the channel format. Keep it concise.
    d. **Deliver** via \`send_message\`. The response the user sees comes from this call — never from echoing the ActionPlan JSON.
 
-3. If \`shouldMessage\` is false, skip \`send_message\` entirely.
+4. If Watch Rules call for a scratchpad entry (Live finds), call \`update_scratchpad\` using the HTML structure the rules specify. Do this whether or not you also messaged.
 
-4. Apply \`createFollowUps\`${isTriggerFollowUp ? ` (ignore these — this trigger is itself a follow-up; the chain stops here)` : ` by calling \`create_task\` with \`isFollowUp=true\` and \`parentTaskId\` set to the triggering task's ID (these are reschedules of the existing task, not new ones)`}.
+5. If \`shouldMessage\` is false AND Watch Rules don't call for a scratchpad write, skip both — handle silently.
 
-5. Apply \`updateTasks\` via \`update_task\`${isRecurring ? ` — except skip description updates and skip \`status: "Done"\` (the system loops recurring tasks automatically)` : ""}.
+6. Apply \`createFollowUps\`${isTriggerFollowUp ? ` (ignore these — this trigger is itself a follow-up; the chain stops here)` : ` by calling \`create_task\` with \`isFollowUp=true\` and \`parentTaskId\` set to the triggering task's ID (these are reschedules of the existing task, not new ones)`}.
 
-6. Apply \`silentActions\` (log entries, state updates).
+7. Apply \`updateTasks\` via \`update_task\`${isRecurring ? ` — except skip description updates and skip \`status: "Done"\` (the system loops recurring tasks automatically)` : ""}.
+
+8. Apply \`silentActions\` (log entries, state updates).
 
 The trigger IS already a task — use the existing taskId for any updates rather than creating a duplicate. Use \`send_message\` for delivery, never \`create_task\`. Trust the ActionPlan's \`shouldMessage\` decision — it has already evaluated the trigger.
 </trigger_context>`;

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -237,7 +237,6 @@ export async function buildAgentContext({
       isBackgroundExecution,
       isOnboardingMode,
       currentTaskId: linkedTask?.id,
-      currentTaskPhase: linkedTask ? getTaskPhase(linkedTask) : "execute",
       triggerChannel: triggerContext?.trigger.channel,
       triggerChannelId: triggerContext?.trigger.channelId,
       userEmail: user?.email ?? undefined,

--- a/apps/webapp/app/services/agent/context/decision-context.ts
+++ b/apps/webapp/app/services/agent/context/decision-context.ts
@@ -179,7 +179,6 @@ export function createReminderTriggerFromDb(reminder: {
   occurrenceCount: number;
   metadata?: Record<string, unknown> | null;
 }): ReminderTrigger {
-  const meta = reminder.metadata;
   const data: ReminderTrigger["data"] = {
     reminderId: reminder.id,
     action: reminder.text,
@@ -188,12 +187,6 @@ export function createReminderTriggerFromDb(reminder: {
     unrespondedCount: reminder.unrespondedCount,
     confirmedActive: reminder.confirmedActive,
   };
-
-  // Attach skill reference if present in reminder metadata
-  if (meta?.skillId) {
-    (data as any).skillId = meta.skillId;
-    (data as any).skillName = meta.skillName || null;
-  }
 
   return {
     type: "reminder_fired",
@@ -253,7 +246,6 @@ export function createTaskTriggerFromDb(task: {
   metadata?: Record<string, unknown> | null;
   schedule?: string | null;
 }): ScheduledTaskTrigger {
-  const meta = task.metadata;
   const data: ScheduledTaskTrigger["data"] = {
     taskId: task.id,
     action: task.description || task.title,
@@ -263,11 +255,6 @@ export function createTaskTriggerFromDb(task: {
     confirmedActive: task.confirmedActive,
     isRecurring: !!task.schedule,
   };
-
-  if (meta?.skillId) {
-    data.skillId = meta.skillId as string;
-    data.skillName = (meta.skillName as string) || undefined;
-  }
 
   return {
     type: "scheduled_task_fired",

--- a/apps/webapp/app/services/agent/executors/direct.ts
+++ b/apps/webapp/app/services/agent/executors/direct.ts
@@ -81,6 +81,7 @@ export class DirectOrchestratorTools extends OrchestratorTools {
         id: gw.id,
         name: gw.name,
         description: gw.description || `Gateway: ${gw.name}`,
+        baseUrl: (gw as { baseUrl?: string }).baseUrl ?? "",
         // Tool names aren't cached on the row anymore; live-fetch happens
         // when the agent is created.
         tools: [],

--- a/apps/webapp/app/services/agent/gateway-operations.ts
+++ b/apps/webapp/app/services/agent/gateway-operations.ts
@@ -103,7 +103,7 @@ USE THIS TOOL to offload tasks like:
           idempotentHint: false,
           destructiveHint: true,
         },
-      } satisfies GatewayMCPTool;
+      } as GatewayMCPTool;
     }),
   );
 

--- a/apps/webapp/app/services/agent/mastra-stream.server.ts
+++ b/apps/webapp/app/services/agent/mastra-stream.server.ts
@@ -113,27 +113,38 @@ export function createUIStreamWithApprovals(
     version: "v6",
   });
 
+  type ApprovalChunk = {
+    type?: string;
+    data?: {
+      toolCallId?: string;
+      toolName?: string;
+      input?: unknown;
+      args?: unknown;
+    };
+  };
+
   return mastraStream.pipeThrough(
     new TransformStream({
       async transform(chunk, controller) {
+        const c = chunk as ApprovalChunk;
         if (
-          chunk?.type === "data-tool-call-approval" &&
-          chunk?.data?.toolCallId
+          c?.type === "data-tool-call-approval" &&
+          c?.data?.toolCallId
         ) {
           const approvalId = generateId();
           logger.info(`[conversation] tool-call-approval:`, {
-            toolCallId: chunk.data.toolCallId,
-            toolName: chunk.data.toolName,
+            toolCallId: c.data.toolCallId,
+            toolName: c.data.toolName,
           });
           if (onApprovalDetected) {
-            await onApprovalDetected(chunk.data.toolCallId, approvalId);
+            await onApprovalDetected(c.data.toolCallId, approvalId);
           }
           controller.enqueue({
             type: "tool-approval-request",
             approvalId,
-            toolCallId: chunk.data.toolCallId,
-            toolName: chunk.data.toolName,
-            input: chunk.data.input ?? chunk.data.args,
+            toolCallId: c.data.toolCallId,
+            toolName: c.data.toolName,
+            input: c.data.input ?? c.data.args,
           });
         } else {
           controller.enqueue(chunk);
@@ -159,9 +170,9 @@ export function streamToUIResponse(
         transform(chunk, controller) {
           controller.enqueue(chunk);
         },
-        cancel() {
-          onCancel();
-        },
+        // `cancel` isn't part of the standard Transformer type but the DOM
+        // implementation invokes it when the readable side is cancelled.
+        ...({ cancel: () => onCancel() } as object),
       }),
     );
   }

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -182,7 +182,7 @@ SELF-AWARENESS:
 You know your own system. When they ask about YOUR features — how to connect an integration, what the gateway does, how memory works, what channels are available — use gather_context to look it up in your own documentation. Don't guess. Give them the actual steps and a link.
 
 TASKS:
-A task is work the user delegated to you. They create it (or you create it for them in conversation), and it starts in Todo for planning/tracking.
+A task is work the user delegated to you. They create it (or you create it for them in conversation), and the default lifecycle is **execute-first**: it lands in Ready with a brief editing buffer, then runs.
 
 Use create_task, list_tasks, update_task, delete_task directly. To find an existing task by topic, call list_tasks (filter by status/type/date) and pick the matching one yourself — there is no keyword search.
 NEVER route CORE task operations through gather_context or take_action — those are for external tools.
@@ -195,19 +195,21 @@ Tasks have three modes:
 - **Recurring**: has a schedule (RRule) with no maxOccurrences limit. Fires on a repeating schedule. Use for "remind me every morning", "check inbox daily", "nudge me every 2 hours".
 
 Status lifecycle:
-- **Todo**: active planning/work item. This is the default when you create a task.
-- **Waiting**: needs user input — approval, clarification, or error. Always send_message explaining what's needed. When the user responds, list_tasks(status: "Waiting") to find the matching Waiting task and call unblock_task — do NOT create a new task.
-- **Ready**: user approved — the system auto-enqueues and moves to Working automatically. You do NOT need to do anything.
-- **Working**: actively being worked on by the background agent.
-- **Review**: work is done, user needs to check. Always send_message with results summary.
+- **Todo**: backlog. Parked — no auto-buffer, no execution. The user (or unblock_task) has to promote it to Ready to start. Use this when you want to capture a task without running it immediately.
+- **Ready**: default for agent-created tasks. The system schedules a brief editing buffer; at expiry the task enqueues and runs. ANY transition to Ready (create_task, unblock_task, dashboard) applies the same buffer — consistent behavior everywhere.
+- **Working**: actively being worked on by the background agent (runner flips status here when execution starts).
+- **Waiting**: blocked on user input — approval, clarification, or error. Always send_message explaining what's needed. When the user responds, list_tasks(status: "Waiting") to find the matching task and call unblock_task → task moves to Ready (buffers briefly, then runs).
+- **Review**: work is done, user needs to check. Always send_message with results summary. The user moves Review → Done.
 - **Done**: closed.
 
 APPROVAL FLOW:
-You never auto-execute irreversible work without user approval. The pattern:
-1. Create the task (or subtasks) in Waiting state
-2. Send message to user explaining what you plan to do and asking for approval
-3. User replies with approval → you call unblock_task → task moves to Ready → auto-executes
-4. User may also approve by moving the task to Ready in the dashboard
+You never auto-execute IRREVERSIBLE BULK work without user approval. The pattern:
+1. Create the task in Waiting state (skip the buffer — Waiting gates on user input).
+2. send_message explaining what you plan to do and asking for approval.
+3. User replies → unblock_task → task moves to Ready → buffer → runs.
+4. User may also approve from the dashboard by moving the task to Ready directly.
+
+For simple/reversible work the default is just create_task(status: "Ready") — the buffer IS the user's veto window.
 
 SUBTASKS:
 Subtasks are for divide-and-conquer ONLY. Consult the built-in "Decompose Task" skill (via get_skill on builtin:decompose-task) for the split decision and the how-to. Quick summary:
@@ -216,7 +218,7 @@ Subtasks are for divide-and-conquer ONLY. Consult the built-in "Decompose Task" 
 - WHEN NOT to split: single artifact, sequential tightly-coupled steps (write those in the description), or "I'm blocked waiting for the user" — that's update_task(status: "Waiting") on the current task, NOT a subtask.
 
 HOW it works in the execute-first lifecycle:
-- create_task with parentTaskId set and no status override. Subtasks default to **Ready** and each gets its own 2-minute buffer before executing in parallel with siblings. The buffer IS the user's veto window — no separate approval gate.
+- create_task with parentTaskId set and no status override. Subtasks default to **Ready** and each buffers briefly before executing in parallel with siblings. The buffer IS the user's veto window — no separate approval gate.
 - After creating subtasks, write the split into the parent description via update_task (<plan> section listing the subtask titles) and send_message as a heads-up. Do NOT move the parent to Waiting.
 - The parent stays Working (it's the coordinator). The system auto-marks the parent Done once every subtask leaves the active set (Todo / Working / Waiting / Ready). You do NOT manage this.
 - Each subtask runs in its own execute mind: independent SKILL CHECK, independent enter_plan_mode if needed, no sibling awareness.
@@ -232,8 +234,8 @@ When they mention a task by topic, list first, then update.
 TASK DESCRIPTION UPDATES:
 Do NOT update the task description on every interaction. Only update it at meaningful phase boundaries:
 - **Blocked/Waiting**: record what was attempted and what's needed from the user
-- **Plan produced**: save the plan to the description (use section="Plan" for coding tasks)
-- **Review/Done**: record the output or results summary
+- **Plan produced**: save the plan to the description as HTML with `<plan>...</plan>` tags (update_task upserts that section)
+- **Review/Done**: record the output as HTML with `<outcome>...</outcome>` tags
 - **User provides new context**: when the user adds requirements or constraints, append their input. EXCEPTION: do NOT append the user's reply when you're about to call unblock_task — unblock_task already records the resolution as "Approved: …" in the description, so a separate append duplicates the same content.
 Do NOT update the description just because you interacted with the task. The description is a living brief, not a log.
 
@@ -280,11 +282,11 @@ THE FOUR CASES:
    - create_task(status="Waiting"). Ask blocking questions one per turn (in the same chat if foreground, in the task conversation if background) until you have enough to plan. Don't ask cosmetic questions. Don't try to ask everything at once. When clear, the user's last reply triggers unblock_task → task moves to Ready → you can plan and execute.
 
 3. PLAN + CLEAR — execute the user's plan, do not re-plan.
-   - create_task(status="Ready"). The task gets a 2-minute buffer (same as Todo) before execution starts. When prep fires, treat the description AS the plan and execute the steps directly. Do NOT produce another plan summary, do NOT ask for approval — the user already approved by writing the plan. Just do the work and report results when done.
+   - create_task (default Ready). The editing buffer applies; at expiry execution starts. Treat the description AS the plan and execute the steps directly. Do NOT produce another plan summary, do NOT ask for approval — the user already approved by writing the plan. Just do the work and report results when done.
    - Exception: if the plan involves IRREVERSIBLE BULK ACTION (mass-send/delete/archive against many records), still respect the CONFIRMATION rule above — confirm scope ONCE before kicking off, then execute.
 
 4. PLAN + UNCLEAR — the user's plan has a blocking gap.
-   - create_task(status="Waiting"). Ask blocking questions one per turn until the gap is filled. Same rules as case 2: blockers only, turn-by-turn, no questionnaire. When clear, execute the plan as in case 3.
+   - create_task(status="Waiting"). Ask blocking questions one per turn until the gap is filled. Same rules as case 2: blockers only, turn-by-turn, no questionnaire. When clear, the user's reply triggers unblock_task → task moves to Ready → buffer + execute the plan as in case 3.
 
 For GOAL + CLEAR (case 1), now apply COMPLEXITY:
 
@@ -300,12 +302,12 @@ If the request would yield ONE message/document/result back to the user → SIMP
 If the request would yield SEVERAL discrete actions to approve/track separately → COMPLEX.
 
 If COMPLEX (GOAL only):
-- TURN 1 (now, in this conversation): create_task with no status param → goes to Todo. Respond ONLY: "I'll look into this in 2 minutes. If you want to add anything, let me know." Do NOT plan, decompose, or send a plan on this turn — the prep wake-up will invoke you again with <task_prep>.
-- If the user sends additional context before the 2-min buffer expires, silently append it to the task description (update_task). Do NOT confirm the addition — just absorb it.
-- TURN 2 (later, when <task_prep> fires after the 2-min buffer): load the appropriate readiness skill, decompose into subtasks if needed, write a plan in the description (section="Plan"), send_message with the plan, mark Waiting for approval, unblock_task on approval.
+- TURN 1 (now, in this conversation): create_task with no status param → defaults to Ready, gets the editing buffer. Respond ONLY: "I'll look into this shortly. If you want to add anything, let me know." Do NOT plan, decompose, or send a plan on this turn — when the buffer fires the background agent picks the task up in execute mind and runs through the same execute-first flow.
+- If the user sends additional context before the buffer expires, silently append it to the task description via update_task. Do NOT confirm the addition — just absorb it.
+- TURN 2 (later, when the background agent picks up the task): if the work genuinely needs gathering info or shaping (open-ended, ambiguous), it calls enter_plan_mode to switch into PLAN mind. In plan mind it loads the appropriate readiness skill, writes a `<plan>` into the description, then calls exit_plan_mode and acts on the plan. If it doesn't need plan mode, it just executes. If the work needs splitting into independent subtasks, it consults the built-in "Decompose Task" skill and creates subtasks (default Ready) — see SUBTASKS above.
 
 If SIMPLE (GOAL only):
-  CLEAR (no schedule) → create_task(status="Ready"). The task gets a 2-minute buffer (same as Todo) before execution starts. Respond: "On it in 2 minutes. Add anything if you want." Silently absorb follow-ups.
+  CLEAR (no schedule) → create_task(status="Ready"). The buffer fires; the background agent picks it up and executes. Respond: "On it shortly. Add anything if you want." Silently absorb follow-ups.
 
   CLEAR + scheduled → create_task(status="Ready") with the schedule. No buffer — the schedule is the timing. Respond confirming the time in the user's timezone.
 

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -220,7 +220,7 @@ Subtasks are for divide-and-conquer ONLY. Consult the built-in "Decompose Task" 
 HOW it works in the execute-first lifecycle:
 - create_task with parentTaskId set and no status override. Subtasks default to **Ready** and each buffers briefly before executing in parallel with siblings. The buffer IS the user's veto window — no separate approval gate.
 - After creating subtasks, write the split into the parent description via update_task (<plan> section listing the subtask titles) and send_message as a heads-up. Do NOT move the parent to Waiting.
-- The parent stays Working (it's the coordinator). The system auto-marks the parent Done once every subtask leaves the active set (Todo / Working / Waiting / Ready). You do NOT manage this.
+- The parent stays Working (it's the coordinator). The system auto-marks the parent Done once every subtask reaches its terminal state — the active set includes Review (the user still has to move Review → Done), so the parent will NOT auto-Done while a sibling is awaiting verification. You do NOT manage this.
 - Each subtask runs in its own execute mind: independent SKILL CHECK, independent enter_plan_mode if needed, no sibling awareness.
 - If a subtask fails or blocks, IT goes to Waiting + send_message naming itself (and the parent for context). Do NOT cascade to the parent — other siblings may still be running.
 - Max depth: 2 levels (epic → task → sub-task). A subtask cannot decompose further; if it feels like it needs to, the parent was scoped wrong.
@@ -367,22 +367,22 @@ The gateway will return either questions, a plan (feature), or a root cause + pr
 - When the gateway returns questions → post them to the user via send_message (include sessionId), mark task Waiting. Do NOT write the questions into the task description — the conversation thread is the source of truth.
 - When re-enqueued after reschedule (no user reply) → pass the sessionId, dir, and tell the gateway you're checking on the status of a previously assigned task.
 - When re-enqueued after user replies → call get_task_coding_session. If status is "starting" (gateway hasn't echoed back the sessionId yet — the session is still spinning up), call reschedule_self(minutesFromNow=2); do NOT call the gateway. If status is "ready", resume by default: pass sessionId, dir, and the user's answers to the gateway. EXCEPTION: if the user's reply explicitly asks for a fresh session or a different coding agent (e.g. "start a new Codex session", "switch to codex", "start over"), omit the sessionId so the gateway starts a new session with the requested agent.
-- When execution/implementation completes → update task description with results. Then create a PR for the branch using the GitHub integration (gather_context/take_action). Include the PR URL in the Output section. After PR is created, mark task Review. The user will verify and move to Done.
+- When execution/implementation completes → update task description with `<outcome>...</outcome>` HTML containing the results. Then create a PR for the branch using the GitHub integration (gather_context/take_action). Include the PR URL in the `<outcome>` block. After PR is created, mark task Review. The user will verify and move to Done.
 - STOP after marking Waiting or Review. Do not proceed further.
 
 **Feature track (gateway returns a plan):**
-- Post plan to the user via send_message, update task description (section="Plan"), mark task Review.
+- Post plan to the user via send_message, update task description with `<plan>...</plan>` HTML, mark task Review.
 - When re-enqueued after user approves the plan (task status: Ready) → pass the sessionId and dir, and tell the gateway to execute.
 
 **Bug-fix track (gateway returns a root cause + proposed fix):**
-- Post root cause and proposed fix to the user via send_message, update task description (section="Plan" with root cause + proposed fix), mark task Review.
+- Post root cause and proposed fix to the user via send_message, update task description with `<plan>...</plan>` HTML containing root cause + proposed fix, mark task Review.
 - When re-enqueued after user approves (task status: Ready) → pass the sessionId and dir, and tell the gateway to implement the fix.
 
 CODING TASK — TASK DESCRIPTION SECTIONS:
-Use the section parameter on update_task to write into named H2 sections. This preserves the user's original description and keeps each section clean.
-- section: "Plan" — update with: the plan summary (feature) or root cause + proposed fix (bug-fix). Replace when plan changes.
-- section: "Output" — update with: final execution results when implementation completes. Written once.
-Do NOT use plain description appends for coding task updates — always use section.
+The update_task tool upserts two structured zones into the description via HTML tags. There is no `section` parameter — pass HTML containing the tags inside the `description` argument and update_task replaces those zones in place. Anything outside the tags is silently dropped, so the user's own prose elsewhere on the page is preserved.
+- `<plan>...</plan>` — the current plan or step-by-step approach. Use for the plan summary (feature) or root cause + proposed fix (bug-fix). Rewrite in full whenever the plan changes.
+- `<outcome>...</outcome>` — the final result the user reads when execution completes. Written once on Review.
+At most ONE `<plan>` and at most ONE `<outcome>` per call. To update both at once, send HTML containing both tags in a single update_task call. Do NOT use plain description appends for coding task updates — always wrap content in `<plan>` or `<outcome>`.
 
 APPROVING vs CREATING — when the user replies and you see <waiting_tasks>:
 - ONLY match a reply to a waiting task if the reply CLEARLY addresses it (mentions the topic, answers the question, says "approved"/"go ahead"/"try again")

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -195,7 +195,7 @@ Tasks have three modes:
 - **Recurring**: has a schedule (RRule) with no maxOccurrences limit. Fires on a repeating schedule. Use for "remind me every morning", "check inbox daily", "nudge me every 2 hours".
 
 Status lifecycle:
-- **Todo**: backlog. Parked — no auto-buffer, no execution. The user (or unblock_task) has to promote it to Ready to start. Use this when you want to capture a task without running it immediately.
+- **Todo**: backlog. Parked — no auto-buffer, no execution. User-only state — only the user parks tasks here from the dashboard. You never create or move tasks into Todo. The user (or unblock_task) promotes them to Ready when ready to run.
 - **Ready**: default for agent-created tasks. The system schedules a brief editing buffer; at expiry the task enqueues and runs. ANY transition to Ready (create_task, unblock_task, dashboard) applies the same buffer — consistent behavior everywhere.
 - **Working**: actively being worked on by the background agent (runner flips status here when execution starts).
 - **Waiting**: blocked on user input — approval, clarification, or error. Always send_message explaining what's needed. When the user responds, list_tasks(status: "Waiting") to find the matching task and call unblock_task → task moves to Ready (buffers briefly, then runs).
@@ -346,7 +346,7 @@ Borderline cases — these are GOAL + CLEAR + SIMPLE, NOT complex:
 - "rate my last 5 cover letters out of 10 and tell me what to fix" → ONE rating with notes (internal structure ≠ multi-deliverable).
 
 Other rules:
-- "Don't forget X" / "add to my list" → create_task (Todo, no status param). Treat as parking, not execution.
+- "Don't forget X" / "add to my list" → create_task(status="Ready"). You always create as Ready; only the user parks things in Todo.
 - Ambiguous timing → create_task in Waiting and ask one question.
 - Do NOT run research or coding work inline — always create a task.
 - After create_task with status="Waiting": STOP immediately after sending the question. Do NOT call gather_context, take_action, or any gateway. The background agent resumes when the user answers.

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -234,8 +234,8 @@ When they mention a task by topic, list first, then update.
 TASK DESCRIPTION UPDATES:
 Do NOT update the task description on every interaction. Only update it at meaningful phase boundaries:
 - **Blocked/Waiting**: record what was attempted and what's needed from the user
-- **Plan produced**: save the plan to the description as HTML with `<plan>...</plan>` tags (update_task upserts that section)
-- **Review/Done**: record the output as HTML with `<outcome>...</outcome>` tags
+- **Plan produced**: save the plan to the description as HTML with \`<plan>...</plan>\` tags (update_task upserts that section)
+- **Review/Done**: record the output as HTML with \`<outcome>...</outcome>\` tags
 - **User provides new context**: when the user adds requirements or constraints, append their input. EXCEPTION: do NOT append the user's reply when you're about to call unblock_task — unblock_task already records the resolution as "Approved: …" in the description, so a separate append duplicates the same content.
 Do NOT update the description just because you interacted with the task. The description is a living brief, not a log.
 
@@ -256,8 +256,6 @@ When to create a scheduled task:
 If create_task rejects a schedule (interval too short), respect that limit. Tell them the minimum and offer an alternative.
 
 When a scheduled task triggers, you'll see <trigger_context>. Execute what it says — gather info, take action, notify, whatever the instruction requires.
-
-Use confirm_task when the user acknowledges a scheduled/recurring task to mark it as confirmed active.
 
 STARTING WORK — research, coding, browser automation, anything that runs in background:
 
@@ -304,7 +302,7 @@ If the request would yield SEVERAL discrete actions to approve/track separately 
 If COMPLEX (GOAL only):
 - TURN 1 (now, in this conversation): create_task with no status param → defaults to Ready, gets the editing buffer. Respond ONLY: "I'll look into this shortly. If you want to add anything, let me know." Do NOT plan, decompose, or send a plan on this turn — when the buffer fires the background agent picks the task up in execute mind and runs through the same execute-first flow.
 - If the user sends additional context before the buffer expires, silently append it to the task description via update_task. Do NOT confirm the addition — just absorb it.
-- TURN 2 (later, when the background agent picks up the task): if the work genuinely needs gathering info or shaping (open-ended, ambiguous), it calls enter_plan_mode to switch into PLAN mind. In plan mind it loads the appropriate readiness skill, writes a `<plan>` into the description, then calls exit_plan_mode and acts on the plan. If it doesn't need plan mode, it just executes. If the work needs splitting into independent subtasks, it consults the built-in "Decompose Task" skill and creates subtasks (default Ready) — see SUBTASKS above.
+- TURN 2 (later, when the background agent picks up the task): if the work genuinely needs gathering info or shaping (open-ended, ambiguous), it calls enter_plan_mode to switch into PLAN mind. In plan mind it loads the appropriate readiness skill, writes a \`<plan>\` into the description, then calls exit_plan_mode and acts on the plan. If it doesn't need plan mode, it just executes. If the work needs splitting into independent subtasks, it consults the built-in "Decompose Task" skill and creates subtasks (default Ready) — see SUBTASKS above.
 
 If SIMPLE (GOAL only):
   CLEAR (no schedule) → create_task(status="Ready"). The buffer fires; the background agent picks it up and executes. Respond: "On it shortly. Add anything if you want." Silently absorb follow-ups.
@@ -367,22 +365,22 @@ The gateway will return either questions, a plan (feature), or a root cause + pr
 - When the gateway returns questions → post them to the user via send_message (include sessionId), mark task Waiting. Do NOT write the questions into the task description — the conversation thread is the source of truth.
 - When re-enqueued after reschedule (no user reply) → pass the sessionId, dir, and tell the gateway you're checking on the status of a previously assigned task.
 - When re-enqueued after user replies → call get_task_coding_session. If status is "starting" (gateway hasn't echoed back the sessionId yet — the session is still spinning up), call reschedule_self(minutesFromNow=2); do NOT call the gateway. If status is "ready", resume by default: pass sessionId, dir, and the user's answers to the gateway. EXCEPTION: if the user's reply explicitly asks for a fresh session or a different coding agent (e.g. "start a new Codex session", "switch to codex", "start over"), omit the sessionId so the gateway starts a new session with the requested agent.
-- When execution/implementation completes → update task description with `<outcome>...</outcome>` HTML containing the results. Then create a PR for the branch using the GitHub integration (gather_context/take_action). Include the PR URL in the `<outcome>` block. After PR is created, mark task Review. The user will verify and move to Done.
+- When execution/implementation completes → update task description with \`<outcome>...</outcome>\` HTML containing the results. Then create a PR for the branch using the GitHub integration (gather_context/take_action). Include the PR URL in the \`<outcome>\` block. After PR is created, mark task Review. The user will verify and move to Done.
 - STOP after marking Waiting or Review. Do not proceed further.
 
 **Feature track (gateway returns a plan):**
-- Post plan to the user via send_message, update task description with `<plan>...</plan>` HTML, mark task Review.
+- Post plan to the user via send_message, update task description with \`<plan>...</plan>\` HTML, mark task Review.
 - When re-enqueued after user approves the plan (task status: Ready) → pass the sessionId and dir, and tell the gateway to execute.
 
 **Bug-fix track (gateway returns a root cause + proposed fix):**
-- Post root cause and proposed fix to the user via send_message, update task description with `<plan>...</plan>` HTML containing root cause + proposed fix, mark task Review.
+- Post root cause and proposed fix to the user via send_message, update task description with \`<plan>...</plan>\` HTML containing root cause + proposed fix, mark task Review.
 - When re-enqueued after user approves (task status: Ready) → pass the sessionId and dir, and tell the gateway to implement the fix.
 
 CODING TASK — TASK DESCRIPTION SECTIONS:
-The update_task tool upserts two structured zones into the description via HTML tags. There is no `section` parameter — pass HTML containing the tags inside the `description` argument and update_task replaces those zones in place. Anything outside the tags is silently dropped, so the user's own prose elsewhere on the page is preserved.
-- `<plan>...</plan>` — the current plan or step-by-step approach. Use for the plan summary (feature) or root cause + proposed fix (bug-fix). Rewrite in full whenever the plan changes.
-- `<outcome>...</outcome>` — the final result the user reads when execution completes. Written once on Review.
-At most ONE `<plan>` and at most ONE `<outcome>` per call. To update both at once, send HTML containing both tags in a single update_task call. Do NOT use plain description appends for coding task updates — always wrap content in `<plan>` or `<outcome>`.
+The update_task tool upserts two structured zones into the description via HTML tags. There is no \`section\` parameter — pass HTML containing the tags inside the \`description\` argument and update_task replaces those zones in place. Anything outside the tags is silently dropped, so the user's own prose elsewhere on the page is preserved.
+- \`<plan>...</plan>\` — the current plan or step-by-step approach. Use for the plan summary (feature) or root cause + proposed fix (bug-fix). Rewrite in full whenever the plan changes.
+- \`<outcome>...</outcome>\` — the final result the user reads when execution completes. Written once on Review.
+At most ONE \`<plan>\` and at most ONE \`<outcome>\` per call. To update both at once, send HTML containing both tags in a single update_task call. Do NOT use plain description appends for coding task updates — always wrap content in \`<plan>\` or \`<outcome>\`.
 
 APPROVING vs CREATING — when the user replies and you see <waiting_tasks>:
 - ONLY match a reply to a waiting task if the reply CLEARLY addresses it (mentions the topic, answers the question, says "approved"/"go ahead"/"try again")

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -455,13 +455,6 @@ Two ways you get invoked from the scratchpad:
 
 2. **Proactive** (system detected actionable content): You receive a clear intent extracted from their writing. Just do the work — gather info, take actions, respond concisely. No add_comment tool here — your response is shown directly on the paragraph they wrote.
 
-SCRATCHPAD vs TASKS — what goes where:
-The scratchpad is the user's own space. Never dump external content into it.
-
-- **External content (emails, webhooks, meeting notes)** → create tasks, not scratchpad entries.
-  - Clear action items → individual tasks.
-  - Meeting notes with action items → one parent task (title = meeting name, notes as description) with subtasks for each action item.
-  - Blocked on something external → create the task as Waiting with a reason in the description.
-- **Scratchpad** is only for things the user wrote themselves. Your role there is to observe and respond, not to populate it.
-- When in doubt: if the content came from outside the user (email, integration, webhook), it becomes a task — never a scratchpad entry.
+SCRATCHPAD:
+The scratchpad is the user's daily page — an unstructured space where they jot thoughts, tasks, and notes throughout the day.
 </capabilities>`;

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -184,7 +184,7 @@ You know your own system. When they ask about YOUR features — how to connect a
 TASKS:
 A task is work the user delegated to you. They create it (or you create it for them in conversation), and it starts in Todo for planning/tracking.
 
-Use create_task, search_tasks, update_task, list_tasks, delete_task directly.
+Use create_task, list_tasks, update_task, delete_task directly. To find an existing task by topic, call list_tasks (filter by status/type/date) and pick the matching one yourself — there is no keyword search.
 NEVER route CORE task operations through gather_context or take_action — those are for external tools.
 
 IMPORTANT: These task tools manage CORE's internal tasks ONLY. If the user asks to create/update/list tasks in an EXTERNAL tool (Todoist, Asana, Linear, Jira, etc.), delegate to the orchestrator via take_action. "Create a task in Todoist" ≠ create_task. "Create a task" or "remind me" = create_task.
@@ -196,7 +196,7 @@ Tasks have three modes:
 
 Status lifecycle:
 - **Todo**: active planning/work item. This is the default when you create a task.
-- **Waiting**: needs user input — approval, clarification, or error. Always send_message explaining what's needed. When the user responds, search_tasks for the Waiting task and call unblock_task — do NOT create a new task.
+- **Waiting**: needs user input — approval, clarification, or error. Always send_message explaining what's needed. When the user responds, list_tasks(status: "Waiting") to find the matching Waiting task and call unblock_task — do NOT create a new task.
 - **Ready**: user approved — the system auto-enqueues and moves to Working automatically. You do NOT need to do anything.
 - **Working**: actively being worked on by the background agent.
 - **Review**: work is done, user needs to check. Always send_message with results summary.
@@ -229,8 +229,8 @@ When a task is complex, decompose it into subtasks (pass parentTaskId to create_
 When to create a task: research, investigations, coding, multi-step work, "don't forget X", anything worth tracking, scheduled notifications, recurring checks.
 When NOT to: quick answers, sending a message, booking a meeting — just do it inline with take_action.
 
-Before creating: search_tasks first — if a matching Todo/Working task already exists, use it.
-When they mention a task by topic, search first, then update.
+Before creating: list_tasks first (filter by status Todo or Working) and scan the titles — if a matching task already exists, reuse it instead of creating a duplicate.
+When they mention a task by topic, list first, then update.
 
 TASK DESCRIPTION UPDATES:
 Do NOT update the task description on every interaction. Only update it at meaningful phase boundaries:

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -210,21 +210,18 @@ You never auto-execute irreversible work without user approval. The pattern:
 4. User may also approve by moving the task to Ready in the dashboard
 
 SUBTASKS:
-When a task is complex, decompose it into subtasks (pass parentTaskId to create_task).
-- Break the task into WORK CHUNKS — each subtask is an independent, meaningful deliverable
-- BAD: "Planning", "Execution" (those are phases, not work). GOOD: "Set up OAuth provider", "Create login UI", "Add session management"
-- Create subtasks in **Waiting** status — they will NOT run until you get approval
-- After creating all subtasks, write a plan summary in the parent description listing them
-- Move the **parent task** to **Waiting** and send_message with the plan: "I've broken this into X subtasks: [list]. Approve to start?"
-- When user approves (unblock_task on parent → moves to Ready):
-  - The system handles sequential execution automatically — it transitions the first Waiting subtask to Todo (which starts it), and when each subtask completes, it starts the next one
-  - Each subtask goes through its own prep → execute lifecycle AUTONOMOUSLY (no per-subtask user approval)
-  - You do NOT need to manage the queue yourself
-- The system automatically marks the parent Done when all subtasks finish — you do NOT need to do this
-- If any subtask fails, it should mark the parent Waiting and send_message with the error
-- Max depth: 2 levels (epic → task → sub-task)
-- Keep subtasks as independent as possible — avoid subtasks that depend on each other's runtime output unless absolutely necessary
-- A subtask agent does ONLY its subtask — no further decomposition, no sibling awareness
+Subtasks are for divide-and-conquer ONLY. Consult the built-in "Decompose Task" skill (via get_skill on builtin:decompose-task) for the split decision and the how-to. Quick summary:
+
+- WHEN to split: multiple independent deliverables that don't share runtime state, irreversibly bulk action that benefits from per-chunk review, or the user explicitly said "plan/decompose/split this".
+- WHEN NOT to split: single artifact, sequential tightly-coupled steps (write those in the description), or "I'm blocked waiting for the user" — that's update_task(status: "Waiting") on the current task, NOT a subtask.
+
+HOW it works in the execute-first lifecycle:
+- create_task with parentTaskId set and no status override. Subtasks default to **Ready** and each gets its own 2-minute buffer before executing in parallel with siblings. The buffer IS the user's veto window — no separate approval gate.
+- After creating subtasks, write the split into the parent description via update_task (<plan> section listing the subtask titles) and send_message as a heads-up. Do NOT move the parent to Waiting.
+- The parent stays Working (it's the coordinator). The system auto-marks the parent Done once every subtask leaves the active set (Todo / Working / Waiting / Ready). You do NOT manage this.
+- Each subtask runs in its own execute mind: independent SKILL CHECK, independent enter_plan_mode if needed, no sibling awareness.
+- If a subtask fails or blocks, IT goes to Waiting + send_message naming itself (and the parent for context). Do NOT cascade to the parent — other siblings may still be running.
+- Max depth: 2 levels (epic → task → sub-task). A subtask cannot decompose further; if it feels like it needs to, the parent was scoped wrong.
 
 When to create a task: research, investigations, coding, multi-step work, "don't forget X", anything worth tracking, scheduled notifications, recurring checks.
 When NOT to: quick answers, sending a message, booking a meeting — just do it inline with take_action.

--- a/apps/webapp/app/services/agent/prompts/decision-prompt.ts
+++ b/apps/webapp/app/services/agent/prompts/decision-prompt.ts
@@ -37,7 +37,7 @@ You are a DECISION FILTER. Answer four questions:
 
 **Skill selection lives entirely with the butler.** The butler reads the task and \`<skills>\` block and picks what fits. Leave skills out of your output — no skill IDs, no skill names, no references in \`intent\` or \`context\`.
 
-**\`message.context\` carries decision-relevant flags only.** Examples of what fits: \`{ unrespondedCount: 8, askAboutKeeping: true }\`, \`{ percentComplete: 93 }\`, \`{ taskId: "...", sessionId: "..." }\`. The butler fetches fresh data when it composes — leave the payload work to it.
+**\`message.context\` carries decision-relevant flags only.** Examples of what fits: \`{ unrespondedCount: 8 }\`, \`{ percentComplete: 93 }\`, \`{ taskId: "...", sessionId: "..." }\`. The butler fetches fresh data when it composes — leave the payload work to it.
 
 ## Default: Handle It Silently
 
@@ -289,12 +289,12 @@ Workflow: call \`gather_context\` first if you need data to decide. Then emit th
 {
   "shouldMessage": true,
   "message": {
-    "intent": "Remind and check if they still want this",
-    "context": { "action": "stand up and stretch", "unrespondedCount": 8, "askAboutKeeping": true },
+    "intent": "Remind",
+    "context": { "action": "stand up and stretch", "unrespondedCount": 8 },
     "tone": "casual"
   },
   "silentActions": [],
-  "reasoning": "8 non-responses. Still remind but check if they want to keep this."
+  "reasoning": "8 non-responses. Still remind; auto-deactivation handles the keep-or-drop decision if they keep ignoring."
 }
 \`\`\`
 

--- a/apps/webapp/app/services/agent/prompts/decision-prompt.ts
+++ b/apps/webapp/app/services/agent/prompts/decision-prompt.ts
@@ -16,13 +16,28 @@ When something happens (a scheduled task fires, a webhook arrives, a scheduled c
 
 When emails, messages, webhooks, or gathered data reference "CORE" (e.g. "CORE has access to gmail", "authorized by CORE"), that refers to this system — not an external entity.
 
-## Your Job
+## Your Job — Decisions Only
 
-For every trigger, produce an action plan:
+You are a DECISION FILTER. Answer four questions:
 1. Should the butler speak? (most of the time: no)
-2. What should the butler say? (intent + context — the butler's voice handles the rest)
-3. What should happen silently? (log, update state, execute actions)
-4. What should be scheduled next? (follow-ups, checks, scheduled tasks)
+2. What silent actions should happen? (log, update state)
+3. What follow-ups or task updates should the butler queue?
+4. A brief \`intent\` hint for the butler — one sentence describing what the message is about (e.g. "Deliver morning brief", "PR has changes requested").
+
+## What Belongs Where
+
+| Decision (yours)                        | Composition (butler's)                                |
+|-----------------------------------------|-------------------------------------------------------|
+| Whether to message at all               | The message text itself                               |
+| Tone hint (casual / neutral / urgent)   | The actual wording, format, voice                     |
+| One-sentence \`intent\`                   | Section ordering, dedup, formatting per skill         |
+| Silent actions / follow-ups / updates   | Gathering integration data for the message            |
+| Decision-relevant flags in \`context\`    | Composing event lists, email summaries, briefings     |
+| —                                       | Selecting and loading any applicable skill            |
+
+**Skill selection lives entirely with the butler.** The butler reads the task and \`<skills>\` block and picks what fits. Leave skills out of your output — no skill IDs, no skill names, no references in \`intent\` or \`context\`.
+
+**\`message.context\` carries decision-relevant flags only.** Examples of what fits: \`{ unrespondedCount: 8, askAboutKeeping: true }\`, \`{ percentComplete: 93 }\`, \`{ taskId: "...", sessionId: "..." }\`. The butler fetches fresh data when it composes — leave the payload work to it.
 
 ## Default: Handle It Silently
 
@@ -39,37 +54,42 @@ Everything else: handle silently, log it, move on.
 ## Tools
 
 ### gather_context
-Pull information from memory, integrations, or web to **inform your decision**. One source per call — make separate calls for calendar vs email vs github.
+Pull information from memory, integrations, or web **to inform your decision**.
 
-Use when: you need data to DECIDE (check conditions, evaluate urgency, assess whether to message).
-Skip when: simple nudges, or the trigger data already has what you need to decide.
+Use it when answering a decision question requires data the trigger doesn't already provide. Typical decision questions:
+- "Is the PR still pending review?" (decides surface vs silent)
+- "Did the user already do this today?" (decides skip vs nudge)
+- "Is it past midnight in their timezone?" (decides skip vs deliver)
 
-Any data you gather here, pass it in the action plan \`context\` so the butler has it and doesn't re-fetch.
+Skip it when the trigger data is already enough to decide, or when the data is only needed to write the message — the butler gathers fresh data when it composes.
 
-Be specific: "find PRs where I'm tagged but haven't responded" not "check github"
+Be specific in your query: "find PRs where I'm tagged but haven't responded" instead of "check github".
 
 ### get_skill
-Load skill instructions by ID — **only when your decision depends on what the skill does.**
+Read a skill's body when your decision depends on what the skill says.
 
-- If the skill has conditions that affect your decision (e.g. "only notify if urgent"), read it, gather context to evaluate, then decide.
-- If it's a straightforward execution skill (e.g. "Morning Brief"), skip reading it — just reference it in the plan. The butler will load and run it.
-- Pass any gathered data in the action plan context so the butler doesn't re-fetch it.
+Use it when the skill carries conditions that change your decision — e.g. quiet hours ("only fire between 9–6"), gating rules ("only notify if urgent"), or scope filters ("only PRs I'm assigned to"). Read the relevant skill, evaluate the condition against the trigger / gathered context, and decide.
 
-You do NOT have task tools (create_task, update_task, etc.). Express follow-ups and task updates in the ActionPlan output — the core agent will execute them.
+Skip it for skills that are straightforward "do this workflow" recipes — the butler loads those when it composes. You don't need to read them to decide \`shouldMessage\`.
 
-**createFollowUps = reschedule, not create new.** Always include \`parentTaskId\` (the triggering task's ID) so the core agent reschedules the existing task instead of creating a duplicate. The trigger data contains the task ID.
+The skill content you read is for your reasoning only. Leave the skill name, ID, and any quoted body text out of the ActionPlan output.
 
-**NEVER chain follow-ups.** If the current trigger has isFollowUp=true in its data, do NOT output createFollowUps. One follow-up level max. If the issue is still unresolved, message the user — don't reschedule again.
+## Output Side-effects (no direct tools)
 
-**When to request a follow-up (high bar):**
-Only when non-response has real consequences AND this is NOT already a follow-up:
+Task creation, updates, and message sending are the butler's job. Express what should happen in the ActionPlan JSON; the butler executes it.
+
+**Follow-ups** (\`createFollowUps\`): these are reschedules of the triggering task, not new tasks. Always include \`parentTaskId\` (the triggering task's ID, available in trigger data) so the butler reschedules the existing task.
+
+**When a follow-up earns its place:**
 - Waiting on a reply that unblocks something
 - A background task or session that needs a status check
 - An important deadline or commitment that could be missed
 
-**NEVER follow up on simple nudges** — water, stretch, stand up, medication, gym. These fire once and that's it. If they didn't respond, they saw it and chose not to. Let it go and wait for the next scheduled occurrence.
+**When to skip the follow-up:**
+- The current trigger already has \`isFollowUp=true\` — let the user decide what to do; leave \`createFollowUps\` empty and rely on \`shouldMessage\` to surface anything urgent.
+- Simple nudges (water, stretch, stand up, medication, gym) — these fire once; the next scheduled occurrence handles itself.
 
-**Follow-up timing (only when warranted):**
+**Follow-up timing:**
 - Status checks (task/session running): ~10 min
 - Pending replies (important): ~1-2 hours
 - Deadlines/commitments: ~2-3 hours before
@@ -106,53 +126,52 @@ Classify first, then decide:
 **Simple Nudge** ("drink water", "stand up", "take medication")
 No data gathering. Message if timing is right, skip if not. Keep intent minimal.
 
-**Daily/Weekly Sync** ("daily sync: check gmail and calendar")
-Always gather data — separate calls per integration. Summarize what matters. Create scheduled tasks for upcoming time-sensitive items. Always message — this is a core handoff.
+**Daily/Weekly Sync** ("daily sync: check gmail and calendar", "morning brief")
+Default \`shouldMessage: true\` — this is a core handoff. The butler gathers the data and composes the brief; your job is to confirm the trigger should fire (timing makes sense, not 2am, the user hasn't muted it).
 
 **Action Execution** ("send weekly report", "log standup notes")
 Irreversible actions (send, post, delete) → message to confirm. Safe actions (log, update, draft) → execute silently.
 
 **Goal-Aware** ("water reminder, goal: 3L daily")
-Gather progress data. Include current vs target in context. Progress makes the nudge useful.
+Gather progress data — it shapes the decision (encourage final push, skip when goal hit). Include the decision-relevant flag (\`percentComplete\`, \`remaining\`) in \`context\`.
 
 **Follow-up** (isFollowUp=true in trigger data)
-High bar. Check if they responded since original. If yes: skip, log "addressed". If no and it matters: brief nudge or reschedule once more. Simple nudges (water, stretch, medication) — never follow up, just skip.
-HARD RULE: A follow-up trigger MUST NEVER produce createFollowUps. No chaining. One level only. If the issue is still unresolved after the follow-up fires, set shouldMessage=true and tell the user it needs their attention. Do not reschedule again.
+Check whether the original was addressed since it fired. Three branches:
+- Already addressed → \`shouldMessage: false\`, log silently.
+- Still pending and it matters → \`shouldMessage: true\` so the user sees it now. Leave \`createFollowUps\` empty; a follow-up trigger resolves at this level.
+- Simple nudge (water, stretch, medication) → skip silently.
 
 **Status Check** ("check if PR review done")
-Gather current state. Changed or action needed → message. No change → silent log, maybe reschedule. Don't report nothing.
+Gather current state. Something changed or action needed → message. Nothing changed → silent log and reschedule a recheck.
 
 **Task Background Start** (task text contains "run task in background [taskId]")
-The butler needs to pick up and execute this task.
+The butler picks up and executes this task silently.
 1. Parse \`taskId\` from the task text
-2. Set \`shouldMessage: false\` — the butler executes silently
-3. Intent should tell the butler to run the task (include taskId)
-Do not create a follow-up — the butler creates session-specific check tasks internally once it starts a session.
+2. Set \`shouldMessage: false\`
+3. \`intent\`: "Run task in background", include \`{ taskId }\` in context
+Skip \`createFollowUps\` — the butler creates session-specific check tasks once it starts the session.
 
 **Session Status Check — Coding** (task text contains \`[taskId:...]\` and \`[sessionId:...]\`)
 A scheduled task is checking on a background coding session.
-1. Parse \`taskId\` and \`sessionId\` from the task text
-2. Include both in intent context so the butler can read session output and evaluate
-3. Achieved → \`shouldMessage: true\`, intent: summarize results. Add \`updateTasks\` to mark the main task (taskId) as Review.
-4. Failed/errored → \`shouldMessage: true\`, intent: report failure. Add \`updateTasks\` to mark the main task as Waiting with error details.
-5. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with the same check text, \`parentTaskId\` set to the main taskId, schedule in 10 min.
-Never report "still running" to the user — just schedule a recheck silently.
+1. Parse \`taskId\` and \`sessionId\` from the task text — pass both in \`context\` so the butler can read session output.
+2. Achieved → \`shouldMessage: true\`, intent: "Summarize coding session results". Add \`updateTasks\` to mark the main task as Review.
+3. Failed/errored → \`shouldMessage: true\`, intent: "Report coding session failure". Add \`updateTasks\` to mark the main task as Waiting.
+4. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with the same check text, \`parentTaskId\` set to the main taskId, schedule in 10 min. Reschedule silently — the user only hears when state changes.
 
 **Session Status Check — Browser** (task text contains \`[taskId:...]\` and \`[sessionName:...]\`)
 Same pattern as coding sessions:
-1. Parse \`taskId\`, \`sessionName\`, and \`intent\` from the task text
-2. Include all in intent context so the butler can check status and evaluate
-3. Achieved → \`shouldMessage: true\`, intent: report result. Add \`updateTasks\` to mark the main task as Review.
-4. Failed/errored → \`shouldMessage: true\`, intent: report failure. Add \`updateTasks\` to mark the main task as Waiting with error details.
-5. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with same check text, \`parentTaskId\`, schedule in 10 min.
+1. Parse \`taskId\`, \`sessionName\`, and \`intent\` from the task text — pass them in \`context\`.
+2. Achieved → \`shouldMessage: true\`, intent: "Report browser session result". Add \`updateTasks\` to mark the main task as Review.
+3. Failed/errored → \`shouldMessage: true\`, intent: "Report browser session failure". Add \`updateTasks\` to mark the main task as Waiting.
+4. Still running → \`shouldMessage: false\`. Add \`createFollowUps\` with same check text, \`parentTaskId\`, schedule in 10 min.
 
 ### Trigger-Specific Defaults
 
-**scheduled_task_fired**: Classify the task type above. Check if already addressed. Consider unrespondedCount. Default for nudges: message. Default for checks/monitoring: silent unless something changed. For recurring tasks: do NOT include description changes in updateTasks — results go via send_message only.
+**scheduled_task_fired**: Classify the task above. Consider whether it was already addressed and the \`unrespondedCount\`. Default for nudges: message. Default for checks/monitoring: silent unless something changed. For recurring tasks: leave description updates out of \`updateTasks\` — results flow via the butler's \`send_message\` only.
 
-**scheduled_task_fired (follow-up)**: They already saw the original. High bar for messaging. If active but chose not to respond — respect that. Simple nudges (water, stretch, etc.): always skip, never escalate. Only reschedule if there are real consequences to non-response.
+**scheduled_task_fired (follow-up)**: They already saw the original. High bar for messaging. If they're active but chose to ignore it, respect that. Simple nudges (water, stretch, etc.) → skip silently. Reschedule only when non-response has real consequences.
 
-**daily_sync**: Always message. Always gather data. Create scheduled tasks for time-sensitive items. This is the butler's morning briefing.
+**daily_sync**: \`shouldMessage: true\` is the default — this is the butler's morning handoff. Leave gathering and composition to the butler.
 
 **integration_webhook**: You are the filter. Most webhooks are noise.
 
@@ -205,14 +224,14 @@ Multiple activities collected over 15 minutes. Analyze together, not individuall
 
 ## Output Format
 
-Use tools FIRST (gather_context, get_skill), THEN output the JSON ActionPlan. No other text before or after the JSON.
+Workflow: call \`gather_context\` first if you need data to decide. Then emit the JSON ActionPlan as your final response. Output only the JSON object — no surrounding prose, no markdown headers, no commentary.
 
 \`\`\`json
 {
   "shouldMessage": boolean,
   "message": {
-    "intent": "what the butler should communicate",
-    "context": { "key": "data for the butler to use" },
+    "intent": "one short sentence: what the message is about",
+    "context": { "decisionFlag1": "value", "decisionFlag2": "value" },
     "tone": "casual" | "urgent" | "encouraging" | "neutral"
   },
   "createFollowUps": [
@@ -237,11 +256,17 @@ Use tools FIRST (gather_context, get_skill), THEN output the JSON ActionPlan. No
       "data": {}
     }
   ],
-  "reasoning": "Brief explanation of your decision"
+  "reasoning": "one short sentence explaining the decision"
 }
 \`\`\`
 
-All task operations go in the JSON output. The core agent executes them.
+**Field semantics:**
+- \`message.intent\`: one short sentence telling the butler *what* the message is about. The butler picks the skill and writes the actual content.
+- \`message.context\`: decision-relevant flags only (counts, percentages, IDs, time markers). The butler does its own data gathering for composition.
+- \`message.tone\`: a hint; the butler's personality layer applies it.
+- Omit \`message\` entirely when \`shouldMessage\` is \`false\`.
+- \`createFollowUps\`, \`updateTasks\`, \`silentActions\`: include only when they apply; otherwise omit or use \`[]\`.
+- The butler executes everything in the ActionPlan. You only emit JSON.
 
 ## Examples
 
@@ -287,27 +312,18 @@ All task operations go in the JSON output. The core agent executes them.
 }
 \`\`\`
 
-### Daily sync
-Call gather_context for calendar and email first, then:
+### Daily sync (e.g. Morning Brief)
+Confirm timing is appropriate, then emit a skinny plan. The butler will load the relevant skill (if any), gather calendar/email/PR/Slack data, and compose the brief.
 \`\`\`json
 {
   "shouldMessage": true,
   "message": {
-    "intent": "Morning briefing with calendar and urgent emails",
-    "context": {
-      "events": [
-        { "title": "1:1 with Sarah", "time": "10:00 AM" },
-        { "title": "Team standup", "time": "2:00 PM" }
-      ],
-      "urgentEmails": [
-        { "from": "boss@company.com", "subject": "Q4 Review - Need input" }
-      ],
-      "lowPriority": "3 newsletters, 2 promotional"
-    },
+    "intent": "Deliver the morning briefing",
+    "context": {},
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "Morning sync. 2 meetings, 1 urgent email."
+  "reasoning": "Scheduled morning sync. Butler handles gathering and composition."
 }
 \`\`\`
 
@@ -331,12 +347,12 @@ Call gather_context for progress data, then:
 {
   "shouldMessage": true,
   "message": {
-    "intent": "Confirm before sending weekly report",
-    "context": { "action": "send weekly report", "destination": "#team-updates", "needsConfirmation": true },
+    "intent": "Confirm before sending the weekly report",
+    "context": { "needsConfirmation": true },
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "Write operation. Confirm before executing."
+  "reasoning": "Write operation. Butler should confirm before executing."
 }
 \`\`\`
 
@@ -344,15 +360,10 @@ Call gather_context for progress data, then:
 \`\`\`json
 {
   "shouldMessage": false,
-  "message": {
-    "intent": "Backup notes to Google Drive",
-    "context": { "action": "backup", "source": "notes", "destination": "google_drive" },
-    "tone": "neutral"
-  },
   "silentActions": [
     { "type": "log", "description": "Scheduled notes backup executed silently" }
   ],
-  "reasoning": "Maintenance task, safe to auto-execute. No need to bother them."
+  "reasoning": "Maintenance task. Butler can execute silently."
 }
 \`\`\`
 
@@ -384,17 +395,17 @@ Call gather_context, then:
 \`\`\`
 
 ### Status check — action needed
-Call gather_context, then:
+Call gather_context to confirm the state changed, then:
 \`\`\`json
 {
   "shouldMessage": true,
   "message": {
-    "intent": "PR has changes requested",
-    "context": { "pr": "Add user auth #42", "status": "changes_requested", "reviewer": "sarah", "requestedAt": "2 hours ago" },
+    "intent": "Surface that the PR has changes requested",
+    "context": { "prId": "42", "stateChanged": true },
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "PR needs attention. They should know."
+  "reasoning": "PR state changed to changes_requested. Butler will fetch details and compose."
 }
 \`\`\`
 
@@ -414,16 +425,12 @@ Call gather_context, then:
 {
   "shouldMessage": true,
   "message": {
-    "intent": "3 PRs need your review",
-    "context": {
-      "summary": "3 PRs waiting for review",
-      "prLinks": ["PR #1", "PR #2", "PR #3"],
-      "lowPriority": "5 CI builds passed, 2 issues closed"
-    },
+    "intent": "Surface pending PR review requests",
+    "context": { "actionableCount": 3 },
     "tone": "neutral"
   },
   "silentActions": [],
-  "reasoning": "3 actionable items in batch. One summary instead of 10 notifications."
+  "reasoning": "3 actionable items in batch. Butler will fetch the PR details and compose one summary."
 }
 \`\`\`
 
@@ -439,13 +446,13 @@ Call gather_context, then:
 \`\`\`
 
 Remember:
-1. **Default: silent.** Only speak when they need to decide, act, or know something time-sensitive.
-2. **Classify first.** What kind of trigger is this? That determines your approach.
-3. **Gather when needed.** Syncs, goals, status checks need data. Nudges don't.
-4. **Follow-ups earn their keep.** Don't nudge blindly. Check if it's been addressed.
-5. **Time matters.** 2am ≠ 2pm. Meeting ≠ idle.
-6. **Output JSON only.** After tool calls, output ONLY the action plan.
-7. **You decide WHAT. The butler decides HOW.**`;
+1. **Default to silent.** Speak only when the user needs to decide, act, or know something time-sensitive.
+2. **Classify first.** Identify the trigger type — it determines the decision.
+3. **Gather only to decide.** Use gather_context when a decision depends on data the trigger doesn't carry; otherwise skip.
+4. **Follow-ups earn their place.** Schedule one only when non-response has real consequences and the original was not addressed.
+5. **Time matters.** 2am ≠ 2pm; meeting ≠ idle.
+6. **Output JSON only.** After any tool calls, emit the ActionPlan object as the final response.
+7. **You decide WHAT, the butler decides HOW.** Leave message wording, data fetching, and skill selection to the butler.`;
 
 /**
  * Build the full prompt with context for Decision Agent
@@ -456,15 +463,14 @@ export function buildDecisionAgentPrompt(
   currentTime: string,
   timezone: string,
   userPersona?: string,
-  skills?: SkillRef[],
   watchRules?: string,
+  skills?: SkillRef[],
 ): string {
   const personaSection = userPersona
     ? `
 ## User Persona & Directives
 
-The following describes the user's preferences, goals, and automation directives.
-**Follow these directives when making decisions** - they override default classification rules.
+These describe the user's preferences, goals, and automation directives. Follow them when making decisions — they override default classification rules.
 
 ${userPersona}
 
@@ -476,7 +482,7 @@ ${userPersona}
     ? `
 ## Watch Rules
 
-The user has defined these rules for how to handle inbound events. These rules are **binding** — when a rule matches an incoming event, you MUST follow it. Do not override Watch Rules with your own judgment. Apply them as step 1 in your decision order for webhooks.
+The user has defined these binding rules for inbound events. When a rule matches an incoming event, follow it exactly (surface or silence). Apply Watch Rules as step 1 of your decision order for webhooks.
 
 ${watchRules}
 
@@ -487,30 +493,13 @@ ${watchRules}
   const skillsSection =
     skills && skills.length > 0
       ? `
-## Available Skills
+## Available Skills (decision-side awareness)
 
-The user has defined these skills (reusable workflows). Use them in two ways:
+The user has these skills (reusable workflows) defined. They are listed so you can:
+1. Recognize when a trigger matches a known workflow — that may shape your \`intent\` sentence and your confidence in \`shouldMessage\`.
+2. Call \`get_skill\` to read a skill's body when its conditions change your decision (quiet hours, gating rules, scope filters).
 
-**1. Attached to a trigger:** Look for \`skillId\` and \`skillName\` in trigger data. When present, you MUST include it in your action plan.
-
-**2. Match to incoming data:** When a webhook or trigger contains data that a skill is designed to handle, include that skill in your action plan. For example, if a github webhook arrives with PR review requests and there's a "PR Triage" skill — use it. Match by intent, not just explicit attachment.
-
-**How to reference a skill in your action plan:**
-- Add \`skillId\` and \`skillName\` to the context object
-- The intent should describe what needs to happen
-- The butler will load the full skill workflow and follow it
-
-**Example:**
-\`\`\`json
-{
-  "shouldMessage": true,
-  "message": {
-    "intent": "Morning brief — check calendar, emails, and priorities",
-    "context": { "skillId": "abc123", "skillName": "Morning Brief" },
-    "tone": "neutral"
-  }
-}
-\`\`\`
+Skill selection for the message itself is the butler's job. Skill name, ID, and quoted body text do not belong in your ActionPlan output.
 
 ${skills
   .map((s, i) => {
@@ -542,5 +531,5 @@ ${triggerJson}
 ${contextJson}
 \`\`\`
 
-Analyze this trigger using the CASE framework and output your ActionPlan as JSON.`;
+Analyze this trigger using the CASE framework and emit your ActionPlan as JSON.`;
 }

--- a/apps/webapp/app/services/agent/prompts/personality.ts
+++ b/apps/webapp/app/services/agent/prompts/personality.ts
@@ -184,8 +184,8 @@ If you search and find nothing, say so. Don't ask them to do your job.
 
 Tool responses are for you, not them. Don't echo their format or tone.
 
-Tasks and scheduling are YOUR built-in features — you manage them with your own tools (create_task, search_tasks, update_task, list_tasks, delete_task, confirm_task, etc.). When they talk about their tasks or reminders, use these directly.
-When they reference an existing task, search for it first before creating a new one.
+Tasks and scheduling are YOUR built-in features — you manage them with your own tools (create_task, update_task, list_tasks, delete_task, confirm_task, etc.). When they talk about their tasks or reminders, use these directly.
+When they reference an existing task, call list_tasks (filter by status/type/date) and pick the matching one before creating a new one — there is no keyword search.
 BUT: if they say "create a task in Todoist/Asana/Linear/etc." — that's an external tool, not yours. Delegate to the orchestrator via take_action for that.
 
 Their daily scratchpad is where they jot down thoughts, tasks, and requests throughout the day. When they @mention you or write something actionable there, you respond with comments anchored to their text — like Google Docs comments. Use add_comment, not send_message, when working from the scratchpad.

--- a/apps/webapp/app/services/agent/prompts/personality.ts
+++ b/apps/webapp/app/services/agent/prompts/personality.ts
@@ -184,7 +184,7 @@ If you search and find nothing, say so. Don't ask them to do your job.
 
 Tool responses are for you, not them. Don't echo their format or tone.
 
-Tasks and scheduling are YOUR built-in features — you manage them with your own tools (create_task, update_task, list_tasks, delete_task, confirm_task, etc.). When they talk about their tasks or reminders, use these directly.
+Tasks and scheduling are YOUR built-in features — you manage them with your own tools (create_task, update_task, list_tasks, delete_task, etc.). When they talk about their tasks or reminders, use these directly.
 When they reference an existing task, call list_tasks (filter by status/type/date) and pick the matching one before creating a new one — there is no keyword search.
 BUT: if they say "create a task in Todoist/Asana/Linear/etc." — that's an external tool, not yours. Delegate to the orchestrator via take_action for that.
 

--- a/apps/webapp/app/services/agent/tools/message-tools.ts
+++ b/apps/webapp/app/services/agent/tools/message-tools.ts
@@ -77,7 +77,7 @@ export function getMessageTools(
                 workspaceId,
                 isActive: true,
               },
-            })) as typeof channelRecord;
+            })) as unknown as typeof channelRecord;
           }
 
           // 2. Try trigger's channel name/type
@@ -89,7 +89,7 @@ export function getMessageTools(
                 OR: [{ name: triggerChannel }, { type: triggerChannel }],
               },
               orderBy: { isDefault: "desc" },
-            })) as typeof channelRecord;
+            })) as unknown as typeof channelRecord;
           }
 
           // 3. Fall back to user's default channel
@@ -99,7 +99,7 @@ export function getMessageTools(
             if (defaultCh) {
               channelRecord = (await prisma.channel.findFirst({
                 where: { id: defaultCh.id, isActive: true },
-              })) as typeof channelRecord;
+              })) as unknown as typeof channelRecord;
             }
           }
 
@@ -114,8 +114,13 @@ export function getMessageTools(
           // ---------------------------------------------------------------
           // Resolve replyTo
           // ---------------------------------------------------------------
-          const config = (channelRecord.config ?? {}) as Record<string, string>;
-          const channelType = channelRecord.type;
+          const cr = channelRecord as {
+            id: string;
+            type: string;
+            config: Record<string, string>;
+          };
+          const config = (cr.config ?? {}) as Record<string, string>;
+          const channelType = cr.type;
           let replyTo: string;
 
           if (channelType === "slack") {
@@ -134,7 +139,7 @@ export function getMessageTools(
           const handler = getChannel(channelType);
           const metadata: Record<string, string> = {
             workspaceId,
-            channelId: channelRecord.id,
+            channelId: cr.id,
           };
 
           if (channelType === "email" && subject) {
@@ -143,7 +148,7 @@ export function getMessageTools(
 
           logger.info(`[send_message] Sending ${channelType} message`, {
             replyTo,
-            channelId: channelRecord.id,
+            channelId: cr.id,
             messageLength: message.length,
             preview: message.slice(0, 100),
           });

--- a/apps/webapp/app/services/agent/tools/reminder-tools.ts
+++ b/apps/webapp/app/services/agent/tools/reminder-tools.ts
@@ -251,18 +251,6 @@ FOLLOW-UP REMINDERS:
           .describe(
             "ID of the parent reminder. Required if isFollowUp is true.",
           ),
-        skillId: z
-          .string()
-          .optional()
-          .describe(
-            "ID of a skill to attach to this reminder. When the reminder fires, the skill's instructions will be loaded and executed.",
-          ),
-        skillName: z
-          .string()
-          .optional()
-          .describe(
-            "Name of the attached skill.",
-          ),
       }),
       execute: async ({
         text,
@@ -273,8 +261,6 @@ FOLLOW-UP REMINDERS:
         endDate,
         isFollowUp,
         parentReminderId,
-        skillId,
-        skillName,
       }) => {
         try {
           // Enforce minimum recurrence interval
@@ -346,17 +332,13 @@ FOLLOW-UP REMINDERS:
             `Creating reminder for workspace ${workspaceId}: ${text} (${schedule}, start: ${startDate}, max: ${maxOcc}, end: ${endDate}, followUp: ${isFollowUp}) on ${targetChannelName}${targetChannelId ? ` [channelId: ${targetChannelId}]` : ""}`,
           );
 
-          // Build metadata for follow-ups and skill attachments
+          // Build metadata for follow-ups
           const metadata: Record<string, unknown> = {};
           if (isFollowUp) {
             metadata.isFollowUp = true;
             metadata.parentReminderId = parentReminderId || null;
             metadata.originalSentAt = new Date().toISOString();
             metadata.followUpAction = text;
-          }
-          if (skillId) {
-            metadata.skillId = skillId;
-            metadata.skillName = skillName || null;
           }
 
           const reminder = await addReminder(workspaceId, {

--- a/apps/webapp/app/services/agent/tools/reminder-tools.ts
+++ b/apps/webapp/app/services/agent/tools/reminder-tools.ts
@@ -7,6 +7,7 @@
 
 import { tool, type Tool } from "ai";
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 import { DateTime } from "luxon";
 import {
   addReminder,
@@ -349,7 +350,10 @@ FOLLOW-UP REMINDERS:
             maxOccurrences: maxOcc,
             endDate: endDate ? new Date(endDate) : null,
             startDate: startDate ? new Date(startDate) : null,
-            metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+            metadata:
+              Object.keys(metadata).length > 0
+                ? (metadata as Prisma.InputJsonValue)
+                : undefined,
           });
 
           let limitInfo = "";

--- a/apps/webapp/app/services/agent/tools/session-tools.ts
+++ b/apps/webapp/app/services/agent/tools/session-tools.ts
@@ -19,6 +19,7 @@ import {
   getCodingSessionsForTask,
 } from "~/services/coding/coding-session.server";
 import { getBrowserSessionsForTask } from "~/services/browser/browser-session.server";
+import { resolveTaskId } from "~/services/task.server";
 
 interface GetSessionToolsParams {
   workspaceId: string;
@@ -26,24 +27,28 @@ interface GetSessionToolsParams {
   currentTaskId?: string;
 }
 
-function resolveTaskId(
-  argTaskId: string | undefined,
-  currentTaskId: string | undefined,
-): string | { error: string } {
-  const taskId = argTaskId ?? currentTaskId;
-  if (!taskId) {
-    return {
-      error:
-        "No taskId provided and no current task in context — pass taskId explicitly.",
-    };
-  }
-  return taskId;
-}
-
 export function getSessionTools(
   params: GetSessionToolsParams,
 ): Record<string, Tool> {
   const { workspaceId, currentTaskId } = params;
+
+  // Agent passes displayId (tk-…); currentTaskId is a server-injected UUID.
+  // Either is acceptable; resolveTaskId handles both shapes and scopes the
+  // lookup to this workspace.
+  const resolve = async (
+    argTaskId: string | undefined,
+  ): Promise<string | { error: string }> => {
+    const input = argTaskId ?? currentTaskId;
+    if (!input) {
+      return {
+        error:
+          "No taskId provided and no current task in context — pass taskId explicitly.",
+      };
+    }
+    const uuid = await resolveTaskId(input, workspaceId);
+    if (!uuid) return { error: `Task "${input}" not found in this workspace.` };
+    return uuid;
+  };
 
   return {
     get_task_coding_session: tool({
@@ -54,11 +59,11 @@ export function getSessionTools(
           .string()
           .optional()
           .describe(
-            "Task ID to look up. Defaults to the current task in context when omitted.",
+            "Task displayId to look up (e.g. tk-abcde). Defaults to the current task in context when omitted.",
           ),
       }),
       execute: async ({ taskId }) => {
-        const resolved = resolveTaskId(taskId, currentTaskId);
+        const resolved = await resolve(taskId);
         if (typeof resolved !== "string") return resolved;
 
         const session = await getLastCodingSession(resolved, workspaceId);
@@ -89,11 +94,11 @@ export function getSessionTools(
           .string()
           .optional()
           .describe(
-            "Task ID to look up. Defaults to the current task in context when omitted.",
+            "Task displayId to look up (e.g. tk-abcde). Defaults to the current task in context when omitted.",
           ),
       }),
       execute: async ({ taskId }) => {
-        const resolved = resolveTaskId(taskId, currentTaskId);
+        const resolved = await resolve(taskId);
         if (typeof resolved !== "string") return resolved;
 
         const sessions = await getCodingSessionsForTask(resolved, workspaceId);
@@ -122,11 +127,11 @@ export function getSessionTools(
           .string()
           .optional()
           .describe(
-            "Task ID to look up. Defaults to the current task in context when omitted.",
+            "Task displayId to look up (e.g. tk-abcde). Defaults to the current task in context when omitted.",
           ),
       }),
       execute: async ({ taskId }) => {
-        const resolved = resolveTaskId(taskId, currentTaskId);
+        const resolved = await resolve(taskId);
         if (typeof resolved !== "string") return resolved;
 
         const sessions = await getBrowserSessionsForTask(

--- a/apps/webapp/app/services/agent/tools/skill-tools.ts
+++ b/apps/webapp/app/services/agent/tools/skill-tools.ts
@@ -12,6 +12,10 @@ import { createSkill, updateSkill, getSkill } from "~/services/skills.server";
 import { createAgent, resolveModelString } from "~/lib/model.server";
 import { getConnectedIntegrationAccounts } from "~/services/integrationAccount.server";
 import { SKILL_GENERATOR_SYSTEM_PROMPT } from "~/utils/skill-generator-prompt";
+import {
+  getBuiltinSkill,
+  isBuiltinSkillId,
+} from "~/services/skills.builtin";
 
 /**
  * Get the get_skill tool for the agent
@@ -25,6 +29,15 @@ export function getSkillTool(workspaceId: string): Tool {
     }),
     execute: async ({ skill_id }) => {
       try {
+        // Built-in skills are resolved from a static registry, not Prisma.
+        // They use `builtin:*` IDs that never collide with DB UUIDs.
+        if (isBuiltinSkillId(skill_id)) {
+          const builtin = getBuiltinSkill(skill_id);
+          if (!builtin) return "Skill not found";
+          logger.info(`Core agent: loading builtin skill ${skill_id}`);
+          return `## Skill: ${builtin.title}\n\n${builtin.content}`;
+        }
+
         logger.info(`Core agent: loading skill ${skill_id}`);
         const skill = await prisma.document.findFirst({
           where: { id: skill_id, workspaceId, type: "skill", deleted: null },

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -9,7 +9,6 @@ import {
   getTasks,
   changeTaskStatus,
   deleteTask,
-  confirmTaskActive,
   rescheduleTaskAt,
   getScheduledTasksForWorkspace,
   recalculateTasksForTimezone,
@@ -886,26 +885,6 @@ The task's status does NOT change. If your plan involves splitting into subtasks
           return error instanceof Error
             ? error.message
             : "Failed to delete task";
-        }
-      },
-    }),
-
-    confirm_task: tool({
-      description:
-        "Confirm user wants to keep a scheduled task active. Stops future prompts about turning it off.",
-      inputSchema: z.object({
-        taskId: z
-          .string()
-          .describe("The displayId of the task to confirm (e.g. tk-abcde)"),
-      }),
-      execute: async ({ taskId }) => {
-        try {
-          const resolved = await resolve("Task", taskId);
-          if (typeof resolved !== "string") return resolved.error;
-          await confirmTaskActive(resolved, workspaceId);
-          return "Task confirmed active.";
-        } catch (error) {
-          return "Failed to confirm task.";
         }
       },
     }),

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -54,7 +54,6 @@ export function getTaskTools(
   channelRecords?: ChannelRecord[],
   currentTaskId?: string,
   source?: string,
-  currentTaskPhase: "prep" | "execute" = "execute",
 ): Record<string, Tool> {
   const minRecurrenceLabel =
     minRecurrenceMinutes >= 60
@@ -785,16 +784,21 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
     }),
 
     // enter_plan_mode / exit_plan_mode — phase toggle on the current task.
-    // Only one of the two is registered at a time, based on the current
-    // phase: enter_plan_mode only in execute mind, exit_plan_mode only in
-    // plan mind. Both require a task in scope.
-    ...(currentTaskId && currentTaskPhase === "execute" && {
+    // Both are always registered when a task is in scope; the tool body is
+    // idempotent (no-op when called in the matching phase). The agent flips
+    // mind WITHIN the same turn — there's no forced turn boundary. The
+    // current turn's prompt still reflects the pre-flip phase, but the
+    // tool's response message tells the agent to adopt the new mental
+    // model immediately. The next prompt build (next user message, next
+    // scheduled wake-up, or an explicit reschedule_self / update_task)
+    // will render the matching block.
+    ...(currentTaskId && {
       enter_plan_mode: tool({
         description: `Switch this task into PLAN mind. Call when you can't execute yet because the goal is ambiguous, the shape is undefined, you need to gather information, or the work is open-ended and needs to be sketched out first.
 
-When you call this, you STOP execution for this turn. On your next turn (next user message, next wake-up, or your own reschedule_self), the system prompt will render the PLAN mind block instead of EXECUTE. Use plan mind to gather info, load readiness skills, and write a plan into the task description. When the plan is ready, call exit_plan_mode and you'll be back in execute mind.
+Plan mind is for gathering info, loading readiness skills (Gather Information / Brainstorm / Plan / Decompose Task), and writing a plan into the task description via update_task with <plan>...</plan> HTML. When the plan is ready, call exit_plan_mode and act on it.
 
-The task's status does NOT change — only the phase metadata. The agent remains the owner of this task throughout.`,
+The task's status does NOT change — only the phase metadata. You can continue working in the same turn after this call.`,
         inputSchema: z.object({
           reason: z
             .string()
@@ -823,20 +827,18 @@ The task's status does NOT change — only the phase metadata. The agent remains
               `Task ${currentTaskId} entered PLAN mind: ${reason}`,
             );
 
-            return `Switched to PLAN mind. STOP this turn — your next turn will render the planning block. Reason recorded: "${reason}". To re-run yourself immediately (background only), call reschedule_self(minutesFromNow=1); otherwise the next user reply or scheduled wake-up resumes you.`;
+            return `Now in PLAN mind. Reason recorded: "${reason}". Continue in this turn: load the readiness skill that fits the gap, gather context, write your plan into the description with <plan>...</plan> HTML via update_task, then call exit_plan_mode and act on the plan.`;
           } catch (error) {
             logger.error("Failed to enter plan mode", { error });
             return `Failed to enter plan mode: ${error instanceof Error ? error.message : "Unknown error"}`;
           }
         },
       }),
-    }),
 
-    ...(currentTaskId && currentTaskPhase === "prep" && {
       exit_plan_mode: tool({
-        description: `Switch this task back to EXECUTE mind. Call after you've written the plan into the task description and you're ready to act on it. On your next turn you'll see the execute block again.
+        description: `Switch this task back to EXECUTE mind. Call after you've written the plan into the task description and you're ready to act on it. You can continue working in the same turn — the next prompt build will render the execute block.
 
-The task's status does NOT change. If your plan involves splitting into subtasks, do that AFTER exit_plan_mode, in execute mind. If you need user approval before executing the plan, call update_task(status: "Waiting") + send_message FIRST, then exit_plan_mode — on resume you'll be in execute mind with the user's reply.`,
+The task's status does NOT change. If your plan involves splitting into subtasks, do that AFTER exit_plan_mode. If you need user approval before executing the plan, call update_task(status: "Waiting") + send_message FIRST.`,
         inputSchema: z.object({}),
         execute: async () => {
           try {
@@ -857,7 +859,7 @@ The task's status does NOT change. If your plan involves splitting into subtasks
 
             logger.info(`Task ${currentTaskId} exited PLAN mind`);
 
-            return "Switched to EXECUTE mind. STOP this turn — your next turn will render the execute block with the plan you wrote in front of you. To re-run yourself immediately (background only), call reschedule_self(minutesFromNow=1); otherwise the next user reply or scheduled wake-up resumes you.";
+            return "Now in EXECUTE mind. Continue in this turn: act on the plan you wrote into the description.";
           } catch (error) {
             logger.error("Failed to exit plan mode", { error });
             return `Failed to exit plan mode: ${error instanceof Error ? error.message : "Unknown error"}`;

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -30,7 +30,7 @@ import { createEmptyConversation } from "~/services/conversation.server";
 import { logger } from "~/services/logger.service";
 import type { TaskStatus } from "@prisma/client";
 import { UserTypeEnum } from "@core/types";
-import { getTaskPhase } from "~/services/task.phase";
+import { getTaskPhase, setTaskPhaseInMetadata } from "~/services/task.phase";
 import { env } from "~/env.server";
 import {
   computeNextRun,
@@ -54,6 +54,7 @@ export function getTaskTools(
   channelRecords?: ChannelRecord[],
   currentTaskId?: string,
   source?: string,
+  currentTaskPhase: "prep" | "execute" = "execute",
 ): Record<string, Tool> {
   const minRecurrenceLabel =
     minRecurrenceMinutes >= 60
@@ -178,18 +179,8 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             .enum(["Todo", "Waiting", "Ready"])
             .optional()
             .describe(
-              "Initial status, classified by the rules in <capabilities> STARTING WORK. Todo = COMPLEX work (multi-step, decomposable, irreversible bulk). 2-min prep buffer applies. Ready = SIMPLE + CLEAR (single action, well-scoped). 2-min buffer still applies (gives the user a window to add context); execution starts after expiry. Waiting = SIMPLE + UNCLEAR (need one question answered) OR needs explicit user approval. Send_message the question/plan, then unblock_task when answered.",
+              "Initial status. Ready (default for agent-created) = runs after a 2-minute buffer; the user has that window to edit before execution starts. Todo = backlog — the task sits idle and only runs once the user (or unblock_task) moves it to Ready. Waiting = needs explicit user input or approval; send_message the question/plan, then unblock_task when answered.",
             ),
-          skillId: z
-            .string()
-            .optional()
-            .describe(
-              "ID of a skill to attach. When the task fires, the skill is loaded and executed.",
-            ),
-          skillName: z
-            .string()
-            .optional()
-            .describe("Name of the attached skill."),
         }),
         execute: async ({
           title,
@@ -202,8 +193,6 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
           channel: taskChannel,
           isFollowUp,
           parentTaskId,
-          skillId,
-          skillName,
         }) => {
           try {
             // BACKGROUND CONTEXT GUARD: when invoked from inside a running task,
@@ -278,13 +267,6 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 }
               }
 
-              // Build metadata
-              const metadata: Record<string, unknown> = {};
-              if (skillId) {
-                metadata.skillId = skillId;
-                metadata.skillName = skillName || null;
-              }
-
               const task = await createScheduledTask(workspaceId, userId, {
                 title,
                 description,
@@ -296,7 +278,6 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 endDate: endDate ? new Date(endDate) : null,
                 startDate: startDate ? new Date(startDate) : null,
                 parentTaskId: resolvedParentId ?? null,
-                metadata: Object.keys(metadata).length > 0 ? metadata : null,
               });
 
               let limitInfo = "";
@@ -316,22 +297,15 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               return `Created scheduled task: "${title}" (ID: ${task.displayId ?? task.id}).${nextRunInfo}${limitInfo}`;
             }
 
-            // Immediate task (no scheduling)
-            // Subtasks default to Waiting (they sit idle until parent is approved
-            // and the system transitions them to Todo sequentially).
-            // Top-level tasks default to Todo (with 2-min prep buffer).
-            const effectiveStatus =
-              resolvedParentId && !initialStatus ? "Waiting" : undefined;
-
-            // Pass the resolved status directly to createTask. createTask
-            // applies the 2-min buffer for Todo (anyone) and for Ready+agent
-            // (skip-prep path); Waiting (subtask default or agent-requested
-            // approval) lands without a buffer. The old post-create
-            // changeTaskStatus flip is no longer needed for non-subtask
-            // flows.
-            const resolvedStatus = (effectiveStatus ??
-              initialStatus ??
-              "Todo") as TaskStatus;
+            // Immediate task (no scheduling).
+            //
+            // Agent-created tasks default to Ready: the wake-up handler
+            // runs them after a 2-minute buffer (the user's editing
+            // window). Todo is the backlog state — only reached when the
+            // agent or user explicitly parks the task; it does not auto-
+            // schedule a buffer. Subtasks behave the same way — they run
+            // in parallel with siblings under their own Ready buffers.
+            const resolvedStatus = (initialStatus ?? "Ready") as TaskStatus;
 
             const task = await createTask(
               workspaceId,
@@ -356,10 +330,10 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             const targetStatus = resolvedStatus;
             const statusNote =
               targetStatus === "Waiting"
-                ? resolvedParentId
-                  ? "Waiting — will run when parent is approved. The task executes in its own thread; do not do its work in the current conversation."
-                  : "Waiting — send_message to user explaining what's needed. Once unblocked, the task executes in its own thread; do not do its work in the current conversation."
-                : `Added to ${targetStatus} (planning). The task will be picked up and executed in its own thread — do NOT do its work in the current conversation; just acknowledge creation and stop.`;
+                ? "Waiting — send_message to user explaining what's needed. Once unblocked, the task executes in its own thread; do not do its work in the current conversation."
+                : resolvedParentId
+                  ? `Added to ${targetStatus}. The subtask runs its own execute cycle through a 2-minute buffer, in parallel with siblings. Do NOT do its work in the current conversation; just acknowledge creation and continue with the parent or stop.`
+                  : `Added to ${targetStatus}. The task will be picked up and executed in its own thread — do NOT do its work in the current conversation; just acknowledge creation and stop.`;
             logger.info(
               `Task ${task.id} created (${targetStatus})${resolvedParentId ? ` subtask of ${resolvedParentId}` : ""}`,
             );
@@ -729,7 +703,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
     // unblock_task — available in all flows (web chat, channels, etc.)
     ...(source && {
       unblock_task: tool({
-        description: `Approve a Waiting task and move it to Ready (or Todo for prep-phase tasks) so execution can start. Requires a reason explaining why the wait is resolved. The reason is added to the task's conversation as a user reply, so the agent picks it up on its next turn. Only works on tasks currently in Waiting status.`,
+        description: `Approve a Waiting task and move it to Ready so execution can start. Requires a reason explaining why the wait is resolved. The reason is added to the task's conversation as a user reply, so the agent picks it up on its next turn. Only works on tasks currently in Waiting status. If the task was in PLAN mind when it went Waiting, the phase is preserved — the agent resumes in plan mind until it calls exit_plan_mode.`,
         inputSchema: z.object({
           taskId: z
             .string()
@@ -789,21 +763,14 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
               },
             });
 
-            // Phase-aware: prep → back to Todo (continue planning),
-            // execute → Ready (auto-enqueues, resumes execution).
-            // EXCEPTION: if task has Waiting subtasks (butler decomposed it),
-            // approval means "start the subtask chain" — go to Ready.
-            const phase = getTaskPhase(task);
-            const waitingSubtaskCount = await prisma.task.count({
-              where: { parentTaskId: resolved, status: "Waiting" },
-            });
-            const hasWaitingSubtasks = waitingSubtaskCount > 0;
-            const targetStatus =
-              phase === "prep" && !hasWaitingSubtasks ? "Todo" : "Ready";
-
+            // Execute-first lifecycle: unblock always targets Ready. The
+            // task's phase metadata (if any) is preserved automatically —
+            // changeTaskStatus no longer touches it. The Ready transition
+            // triggers an immediate enqueue (non-scheduled) or waits for
+            // the schedule (scheduled tasks).
             await changeTaskStatus(
               resolved,
-              targetStatus,
+              "Ready",
               workspaceId,
               userId,
               "user",
@@ -811,6 +778,88 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             return `Task "${task.title}" unblocked and resumed in its own conversation. Tell the user it's being worked on. Do NOT take any further action on this task — it handles itself from here.`;
           } catch (error) {
             return `Failed to unblock task: ${error instanceof Error ? error.message : "Unknown error"}`;
+          }
+        },
+      }),
+    }),
+
+    // enter_plan_mode / exit_plan_mode — phase toggle on the current task.
+    // Only one of the two is registered at a time, based on the current
+    // phase: enter_plan_mode only in execute mind, exit_plan_mode only in
+    // plan mind. Both require a task in scope.
+    ...(currentTaskId && currentTaskPhase === "execute" && {
+      enter_plan_mode: tool({
+        description: `Switch this task into PLAN mind. Call when you can't execute yet because the goal is ambiguous, the shape is undefined, you need to gather information, or the work is open-ended and needs to be sketched out first.
+
+When you call this, you STOP execution for this turn. On your next turn (next user message, next wake-up, or your own reschedule_self), the system prompt will render the PLAN mind block instead of EXECUTE. Use plan mind to gather info, load readiness skills, and write a plan into the task description. When the plan is ready, call exit_plan_mode and you'll be back in execute mind.
+
+The task's status does NOT change — only the phase metadata. The agent remains the owner of this task throughout.`,
+        inputSchema: z.object({
+          reason: z
+            .string()
+            .describe(
+              "Why you can't execute yet — what gap plan mind needs to close (e.g. 'goal is open-ended, need to brainstorm shape', 'need to gather code structure before I can fix this', 'description names entities I don't recognize').",
+            ),
+        }),
+        execute: async ({ reason }) => {
+          try {
+            const task = await getTaskById(currentTaskId);
+            if (!task) return `Task ${currentTaskId} not found.`;
+
+            const currentPhase = getTaskPhase(task);
+            if (currentPhase === "prep") {
+              return "Already in PLAN mind. Continue planning, or call exit_plan_mode when ready.";
+            }
+
+            await prisma.task.update({
+              where: { id: currentTaskId },
+              data: {
+                metadata: setTaskPhaseInMetadata(task.metadata, "prep"),
+              },
+            });
+
+            logger.info(
+              `Task ${currentTaskId} entered PLAN mind: ${reason}`,
+            );
+
+            return `Switched to PLAN mind. STOP this turn — your next turn will render the planning block. Reason recorded: "${reason}". To re-run yourself immediately (background only), call reschedule_self(minutesFromNow=1); otherwise the next user reply or scheduled wake-up resumes you.`;
+          } catch (error) {
+            logger.error("Failed to enter plan mode", { error });
+            return `Failed to enter plan mode: ${error instanceof Error ? error.message : "Unknown error"}`;
+          }
+        },
+      }),
+    }),
+
+    ...(currentTaskId && currentTaskPhase === "prep" && {
+      exit_plan_mode: tool({
+        description: `Switch this task back to EXECUTE mind. Call after you've written the plan into the task description and you're ready to act on it. On your next turn you'll see the execute block again.
+
+The task's status does NOT change. If your plan involves splitting into subtasks, do that AFTER exit_plan_mode, in execute mind. If you need user approval before executing the plan, call update_task(status: "Waiting") + send_message FIRST, then exit_plan_mode — on resume you'll be in execute mind with the user's reply.`,
+        inputSchema: z.object({}),
+        execute: async () => {
+          try {
+            const task = await getTaskById(currentTaskId);
+            if (!task) return `Task ${currentTaskId} not found.`;
+
+            const currentPhase = getTaskPhase(task);
+            if (currentPhase === "execute") {
+              return "Already in EXECUTE mind. Continue executing.";
+            }
+
+            await prisma.task.update({
+              where: { id: currentTaskId },
+              data: {
+                metadata: setTaskPhaseInMetadata(task.metadata, "execute"),
+              },
+            });
+
+            logger.info(`Task ${currentTaskId} exited PLAN mind`);
+
+            return "Switched to EXECUTE mind. STOP this turn — your next turn will render the execute block with the plan you wrote in front of you. To re-run yourself immediately (background only), call reschedule_self(minutesFromNow=1); otherwise the next user reply or scheduled wake-up resumes you.";
+          } catch (error) {
+            logger.error("Failed to exit plan mode", { error });
+            return `Failed to exit plan mode: ${error instanceof Error ? error.message : "Unknown error"}`;
           }
         },
       }),

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -7,7 +7,6 @@ import {
   updateScheduledTask,
   getTaskById,
   getTasks,
-  searchTasks,
   changeTaskStatus,
   deleteTask,
   confirmTaskActive,
@@ -423,7 +422,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
 
     list_tasks: tool({
       description:
-        "List tasks with their current status. Use type filter to see scheduled/recurring tasks separately.",
+        "List tasks with their current status. Use type filter to see scheduled/recurring tasks separately. Date filters narrow by createdAt (when the task was created) or dueAt (when a scheduled task next fires). All dates are ISO 8601 (YYYY-MM-DD or full ISO datetime). Use this to find tasks by topic — there is no keyword search; list all and pick the matching one yourself.",
       inputSchema: z.object({
         status: z
           .enum([
@@ -443,14 +442,56 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
           .describe(
             "Filter by type: 'immediate' (no schedule), 'scheduled' (one-time), 'recurring'. Default: all.",
           ),
+        createdAfter: z
+          .string()
+          .optional()
+          .describe(
+            "ISO 8601 date — only return tasks created on or after this date (e.g. '2026-05-01').",
+          ),
+        createdBefore: z
+          .string()
+          .optional()
+          .describe(
+            "ISO 8601 date — only return tasks created on or before this date.",
+          ),
+        dueAfter: z
+          .string()
+          .optional()
+          .describe(
+            "ISO 8601 date — only return tasks scheduled to fire on or after this date (applies to scheduled/recurring tasks via nextRunAt).",
+          ),
+        dueBefore: z
+          .string()
+          .optional()
+          .describe(
+            "ISO 8601 date — only return tasks scheduled to fire on or before this date.",
+          ),
       }),
-      execute: async ({ status, type }) => {
+      execute: async ({
+        status,
+        type,
+        createdAfter,
+        createdBefore,
+        dueAfter,
+        dueBefore,
+      }) => {
         try {
+          const parseDate = (input: string | undefined): Date | undefined => {
+            if (!input) return undefined;
+            const d = new Date(input);
+            return Number.isNaN(d.getTime()) ? undefined : d;
+          };
+          const dateOpts = {
+            createdAfter: parseDate(createdAfter),
+            createdBefore: parseDate(createdBefore),
+            dueAfter: parseDate(dueAfter),
+            dueBefore: parseDate(dueBefore),
+          };
+
           let tasks;
 
           if (type === "scheduled" || type === "recurring") {
-            // Get active scheduled tasks
-            tasks = await getScheduledTasksForWorkspace(workspaceId);
+            tasks = await getScheduledTasksForWorkspace(workspaceId, dateOpts);
             if (type === "recurring") {
               tasks = tasks.filter(
                 (t) =>
@@ -460,16 +501,16 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               tasks = tasks.filter((t) => t.maxOccurrences === 1);
             }
           } else if (type === "immediate") {
-            tasks = await getTasks(
-              workspaceId,
-              status as TaskStatus | undefined,
-            );
+            tasks = await getTasks(workspaceId, {
+              status: status as TaskStatus | undefined,
+              ...dateOpts,
+            });
             tasks = tasks.filter((t) => !t.schedule && !t.nextRunAt);
           } else {
-            tasks = await getTasks(
-              workspaceId,
-              status as TaskStatus | undefined,
-            );
+            tasks = await getTasks(workspaceId, {
+              status: status as TaskStatus | undefined,
+              ...dateOpts,
+            });
           }
 
           if (tasks.length === 0) return "No tasks found.";
@@ -495,37 +536,6 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
           return lines.join("\n");
         } catch (error) {
           return "Failed to list tasks.";
-        }
-      },
-    }),
-
-    search_tasks: tool({
-      description: `Find an existing task by keyword. Use when the user is referring to a task that already exists and you need to locate it. Searches across task titles and descriptions.`,
-      inputSchema: z.object({
-        query: z
-          .string()
-          .describe(
-            "Search keyword to match against task title and description",
-          ),
-      }),
-      execute: async ({ query }) => {
-        try {
-          const tasks = await searchTasks(workspaceId, query);
-          if (tasks.length === 0) return "No matching tasks found.";
-          const lines = await Promise.all(
-            tasks.map(async (t, i) => {
-              let info = `${i + 1}. [${t.status}] ${t.title}`;
-              if (t.pageId) {
-                const html = await getPageContentAsHtml(t.pageId);
-                if (html) info += ` — ${html.substring(0, 100)}`;
-              }
-              info += ` (ID: ${t.displayId ?? t.id})`;
-              return info;
-            }),
-          );
-          return lines.join("\n");
-        } catch (error) {
-          return "Failed to search tasks.";
         }
       },
     }),

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -27,7 +27,7 @@ import {
 import { upsertPageSection } from "~/services/coding-task.server";
 import { createEmptyConversation } from "~/services/conversation.server";
 import { logger } from "~/services/logger.service";
-import type { TaskStatus } from "@prisma/client";
+import { Prisma, type TaskStatus } from "@prisma/client";
 import { UserTypeEnum } from "@core/types";
 import { getTaskPhase, setTaskPhaseInMetadata } from "~/services/task.phase";
 import { env } from "~/env.server";
@@ -650,12 +650,12 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
 
           if (status) {
             if (isRecurring) {
-              // Recurring tasks: silently map Done to Review, allow other statuses
-              const effectiveStatus = status === "Done" ? "Review" : status;
+              // Recurring tasks: schema only allows Waiting | Review, so no
+              // Done-to-Review mapping is needed here.
               try {
                 await changeTaskStatus(
                   resolvedTaskId,
-                  effectiveStatus as TaskStatus,
+                  status as TaskStatus,
                   workspaceId,
                   userId,
                   "agent",
@@ -727,7 +727,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             // create a new one if none exists. Then insert the reason as a
             // userType: User row so the agent's next turn picks it up like
             // a normal user reply and resumes the conversation.
-            let conversationId =
+            let conversationId: string | null =
               task.conversationIds[task.conversationIds.length - 1] ?? null;
 
             if (conversationId) {
@@ -818,7 +818,10 @@ The task's status does NOT change — only the phase metadata. You can continue 
             await prisma.task.update({
               where: { id: currentTaskId },
               data: {
-                metadata: setTaskPhaseInMetadata(task.metadata, "prep"),
+                metadata: setTaskPhaseInMetadata(
+                  task.metadata,
+                  "prep",
+                ) as Prisma.InputJsonValue,
               },
             });
 
@@ -852,7 +855,10 @@ The task's status does NOT change. If your plan involves splitting into subtasks
             await prisma.task.update({
               where: { id: currentTaskId },
               data: {
-                metadata: setTaskPhaseInMetadata(task.metadata, "execute"),
+                metadata: setTaskPhaseInMetadata(
+                  task.metadata,
+                  "execute",
+                ) as Prisma.InputJsonValue,
               },
             });
 

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -16,6 +16,7 @@ import {
   recalculateTasksForTimezone,
   getTaskTree,
   reparentTask,
+  resolveTaskId,
 } from "~/services/task.server";
 import {
   findOrCreateTaskPage,
@@ -72,6 +73,18 @@ export function getTaskTools(
   const channelNames = channelRecords?.length
     ? channelRecords.map((ch) => ch.name)
     : null;
+
+  // Agent tools speak displayIds (tk-xxxxx). Resolve to UUID at the boundary;
+  // everything downstream still uses UUIDs. Returns the UUID string or an
+  // error string the tool can return verbatim to the model.
+  const resolve = async (
+    label: string,
+    input: string,
+  ): Promise<string | { error: string }> => {
+    const uuid = await resolveTaskId(input, workspaceId);
+    if (!uuid) return { error: `${label} "${input}" not found in this workspace.` };
+    return uuid;
+  };
 
   const channelSchema =
     channelNames && channelNames.length > 0
@@ -159,7 +172,9 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
           parentTaskId: z
             .string()
             .optional()
-            .describe("ID of the parent task. Required if isFollowUp is true."),
+            .describe(
+              "displayId of the parent task (e.g. tk-abcde). Required if isFollowUp is true.",
+            ),
           status: z
             .enum(["Todo", "Waiting", "Ready"])
             .optional()
@@ -200,9 +215,18 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               return "create_task in background context requires parentTaskId — only subtask creation is permitted from inside a running task. If you need a top-level task, the user must create it from the foreground chat.";
             }
 
+            // Resolve the agent-supplied parent displayId to its UUID once;
+            // downstream code paths all expect UUIDs.
+            let resolvedParentId: string | undefined;
+            if (parentTaskId) {
+              const resolved = await resolve("Parent task", parentTaskId);
+              if (typeof resolved !== "string") return resolved.error;
+              resolvedParentId = resolved;
+            }
+
             // Follow-up: reschedule the parent task
-            if (isFollowUp && parentTaskId) {
-              const parentTask = await getTaskById(parentTaskId);
+            if (isFollowUp && resolvedParentId) {
+              const parentTask = await getTaskById(resolvedParentId);
               if (!parentTask) return "Parent task not found.";
 
               if (!schedule) return "Schedule is required for follow-up.";
@@ -212,7 +236,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               if (!followUpNextRun) return "Could not compute follow-up time.";
 
               await rescheduleTaskAt(
-                parentTaskId,
+                resolvedParentId,
                 workspaceId,
                 followUpNextRun,
               );
@@ -272,7 +296,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                   maxOccurrences && maxOccurrences > 0 ? maxOccurrences : null,
                 endDate: endDate ? new Date(endDate) : null,
                 startDate: startDate ? new Date(startDate) : null,
-                parentTaskId: parentTaskId ?? null,
+                parentTaskId: resolvedParentId ?? null,
                 metadata: Object.keys(metadata).length > 0 ? metadata : null,
               });
 
@@ -290,7 +314,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 ? ` Next: ${task.nextRunAt.toLocaleString()}`
                 : "";
 
-              return `Created scheduled task: "${title}" (ID: ${task.id}).${nextRunInfo}${limitInfo}`;
+              return `Created scheduled task: "${title}" (ID: ${task.displayId ?? task.id}).${nextRunInfo}${limitInfo}`;
             }
 
             // Immediate task (no scheduling)
@@ -298,7 +322,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             // and the system transitions them to Todo sequentially).
             // Top-level tasks default to Todo (with 2-min prep buffer).
             const effectiveStatus =
-              parentTaskId && !initialStatus ? "Waiting" : undefined;
+              resolvedParentId && !initialStatus ? "Waiting" : undefined;
 
             // Pass the resolved status directly to createTask. createTask
             // applies the 2-min buffer for Todo (anyone) and for Ready+agent
@@ -318,7 +342,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               {
                 actor: "agent",
                 status: resolvedStatus,
-                ...(parentTaskId && { parentTaskId }),
+                ...(resolvedParentId && { parentTaskId: resolvedParentId }),
               },
             );
             if (description) {
@@ -329,18 +353,18 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               );
               await setPageContentFromHtml(page.id, description);
             }
-            const label = parentTaskId ? "subtask" : "task";
+            const label = resolvedParentId ? "subtask" : "task";
             const targetStatus = resolvedStatus;
             const statusNote =
               targetStatus === "Waiting"
-                ? parentTaskId
+                ? resolvedParentId
                   ? "Waiting — will run when parent is approved. The task executes in its own thread; do not do its work in the current conversation."
                   : "Waiting — send_message to user explaining what's needed. Once unblocked, the task executes in its own thread; do not do its work in the current conversation."
                 : `Added to ${targetStatus} (planning). The task will be picked up and executed in its own thread — do NOT do its work in the current conversation; just acknowledge creation and stop.`;
             logger.info(
-              `Task ${task.id} created (${targetStatus})${parentTaskId ? ` subtask of ${parentTaskId}` : ""}`,
+              `Task ${task.id} created (${targetStatus})${resolvedParentId ? ` subtask of ${resolvedParentId}` : ""}`,
             );
-            return `${label} created: "${title}" (ID: ${task.id}). ${statusNote} Link: ${env.APP_ORIGIN}/home/tasks?taskId=${task.id}`;
+            return `${label} created: "${title}" (ID: ${task.displayId ?? task.id}). ${statusNote} Link: ${env.APP_ORIGIN}/home/tasks?taskId=${task.id}`;
           } catch (error) {
             logger.error("Failed to create task", { error });
             return `Failed to create task: ${error instanceof Error ? error.message : "Unknown error"}`;
@@ -351,11 +375,16 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
     get_task: tool({
       description: `Get full details of a task including its complete description. Use before updating a task so you can see what's already there and merge new context into it.`,
       inputSchema: z.object({
-        taskId: z.string().describe("The task ID"),
+        taskId: z
+          .string()
+          .describe("The task displayId (e.g. tk-abcde or tk-abcde.1)"),
       }),
       execute: async ({ taskId }) => {
         try {
-          const task = await getTaskById(taskId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+
+          const task = await getTaskById(resolved);
           if (!task) return `Task ${taskId} not found.`;
 
           // Read description from linked page (HTML)
@@ -369,7 +398,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             `Title: ${task.title}`,
             `Status: ${task.status}`,
             `Description: ${description}`,
-            `ID: ${task.id}`,
+            `ID: ${task.displayId ?? task.id}`,
             `Created: ${task.createdAt}`,
           ];
 
@@ -459,7 +488,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 info +=
                   remaining === 1 ? " [one-time]" : ` [${remaining} left]`;
               }
-              info += ` (ID: ${t.id})`;
+              info += ` (ID: ${t.displayId ?? t.id})`;
               return info;
             }),
           );
@@ -490,7 +519,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
                 const html = await getPageContentAsHtml(t.pageId);
                 if (html) info += ` — ${html.substring(0, 100)}`;
               }
-              info += ` (ID: ${t.id})`;
+              info += ` (ID: ${t.displayId ?? t.id})`;
               return info;
             }),
           );
@@ -517,7 +546,9 @@ Anything outside these tags is silently dropped — the user's prose elsewhere o
 
 REPARENTING: Pass newParentId to move a task under a different parent (or null to make it a root task). This deletes the task and recreates it under the new parent — the task gets a new displayId. Subtasks are also deleted.`,
       inputSchema: z.object({
-        taskId: z.string().describe("The task ID"),
+        taskId: z
+          .string()
+          .describe("The task displayId (e.g. tk-abcde or tk-abcde.1)"),
         status: z
           .enum(["Waiting", "Review"])
           .optional()
@@ -552,7 +583,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
           .string()
           .optional()
           .describe(
-            "Move task under a new parent (UUID). Deletes and recreates the task with a new displayId. Omit if not reparenting.",
+            "Move task under a new parent (displayId, e.g. tk-abcde). Deletes and recreates the task with a new displayId. Omit if not reparenting.",
           ),
       }),
       execute: async ({
@@ -569,19 +600,25 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
         newParentId,
       }) => {
         try {
+          const resolvedTaskId = await resolve("Task", taskId);
+          if (typeof resolvedTaskId !== "string") return resolvedTaskId.error;
+
           // Reparent: delete + recreate under new parent (requires a non-null string)
           if (typeof newParentId === "string") {
+            const resolvedNewParent = await resolve("New parent", newParentId);
+            if (typeof resolvedNewParent !== "string")
+              return resolvedNewParent.error;
             const newTask = await reparentTask(
-              taskId,
-              newParentId,
+              resolvedTaskId,
+              resolvedNewParent,
               workspaceId,
               userId,
             );
-            return `Task reparented. New ID: ${newTask.id}, displayId: ${(newTask as { displayId?: string | null }).displayId ?? "pending"}.`;
+            return `Task reparented. New displayId: ${(newTask as { displayId?: string | null }).displayId ?? "pending"}.`;
           }
 
           // Fetch task once for recurring check and reuse
-          const currentTask = await getTaskById(taskId);
+          const currentTask = await getTaskById(resolvedTaskId);
           const isRecurring = !!currentTask?.schedule;
 
           // Handle scheduling updates
@@ -592,7 +629,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             endDate !== undefined ||
             updateChannel !== undefined
           ) {
-            await updateScheduledTask(taskId, workspaceId, {
+            await updateScheduledTask(resolvedTaskId, workspaceId, {
               title,
               // Never update description for recurring tasks — it pollutes the
               // next run's context. Results go via send_message.
@@ -621,11 +658,11 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
               }
             }
             if (title) {
-              await updateTask(taskId, { title }, false);
+              await updateTask(resolvedTaskId, { title }, false);
             }
           } else if (isRecurring && title) {
             // Recurring tasks: allow title updates only (no description)
-            await updateTask(taskId, { title }, false);
+            await updateTask(resolvedTaskId, { title }, false);
           }
 
           if (status) {
@@ -634,7 +671,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
               const effectiveStatus = status === "Done" ? "Review" : status;
               try {
                 await changeTaskStatus(
-                  taskId,
+                  resolvedTaskId,
                   effectiveStatus as TaskStatus,
                   workspaceId,
                   userId,
@@ -647,7 +684,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             } else {
               try {
                 await changeTaskStatus(
-                  taskId,
+                  resolvedTaskId,
                   status as TaskStatus,
                   workspaceId,
                   userId,
@@ -684,7 +721,9 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
       unblock_task: tool({
         description: `Approve a Waiting task and move it to Ready (or Todo for prep-phase tasks) so execution can start. Requires a reason explaining why the wait is resolved. The reason is added to the task's conversation as a user reply, so the agent picks it up on its next turn. Only works on tasks currently in Waiting status.`,
         inputSchema: z.object({
-          taskId: z.string().describe("The ID of the waiting task"),
+          taskId: z
+            .string()
+            .describe("The displayId of the waiting task (e.g. tk-abcde)"),
           reason: z
             .string()
             .describe(
@@ -693,7 +732,10 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
         }),
         execute: async ({ taskId, reason }) => {
           try {
-            const task = await getTaskById(taskId);
+            const resolved = await resolve("Task", taskId);
+            if (typeof resolved !== "string") return resolved.error;
+
+            const task = await getTaskById(resolved);
             if (!task) return `Task ${taskId} not found.`;
             if (task.status !== "Waiting")
               return `Task is not Waiting (current status: ${task.status}). Only Waiting tasks can be approved.`;
@@ -743,14 +785,14 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             // approval means "start the subtask chain" — go to Ready.
             const phase = getTaskPhase(task);
             const waitingSubtaskCount = await prisma.task.count({
-              where: { parentTaskId: taskId, status: "Waiting" },
+              where: { parentTaskId: resolved, status: "Waiting" },
             });
             const hasWaitingSubtasks = waitingSubtaskCount > 0;
             const targetStatus =
               phase === "prep" && !hasWaitingSubtasks ? "Todo" : "Ready";
 
             await changeTaskStatus(
-              taskId,
+              resolved,
               targetStatus,
               workspaceId,
               userId,
@@ -768,11 +810,15 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
       description:
         "Delete a task permanently. Use when user wants to cancel a task or scheduled item.",
       inputSchema: z.object({
-        taskId: z.string().describe("The ID of the task to delete"),
+        taskId: z
+          .string()
+          .describe("The displayId of the task to delete (e.g. tk-abcde)"),
       }),
       execute: async ({ taskId }) => {
         try {
-          await deleteTask(taskId, workspaceId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+          await deleteTask(resolved, workspaceId);
           return "Task deleted.";
         } catch (error) {
           return error instanceof Error
@@ -786,11 +832,15 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
       description:
         "Confirm user wants to keep a scheduled task active. Stops future prompts about turning it off.",
       inputSchema: z.object({
-        taskId: z.string().describe("The ID of the task to confirm"),
+        taskId: z
+          .string()
+          .describe("The displayId of the task to confirm (e.g. tk-abcde)"),
       }),
       execute: async ({ taskId }) => {
         try {
-          await confirmTaskActive(taskId, workspaceId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+          await confirmTaskActive(resolved, workspaceId);
           return "Task confirmed active.";
         } catch (error) {
           return "Failed to confirm task.";
@@ -801,11 +851,17 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
     get_task_tree: tool({
       description: `Get the full ancestor chain for a task, from root down to the task itself. Use this to understand the hierarchy context — e.g. which epic/parent a task belongs to. Returns each ancestor's displayId and title in order.`,
       inputSchema: z.object({
-        taskId: z.string().describe("The task ID to get the tree for"),
+        taskId: z
+          .string()
+          .describe(
+            "The displayId of the task to get the tree for (e.g. tk-abcde)",
+          ),
       }),
       execute: async ({ taskId }) => {
         try {
-          const tree = await getTaskTree(taskId);
+          const resolved = await resolve("Task", taskId);
+          if (typeof resolved !== "string") return resolved.error;
+          const tree = await getTaskTree(resolved);
           if (tree.length === 0) return `Task ${taskId} not found.`;
           return tree
             .map((t, i) => {

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -106,13 +106,14 @@ export function getTaskTools(
       description: `Create a new CORE internal task. Tasks can be immediate (work items) or scheduled (reminders, recurring checks).
 NOTE: This is for CORE's own task system. If the user asks to create a task in an external tool (Todoist, Asana, Linear, Jira, etc.), do NOT use this — delegate to the orchestrator via take_action instead.
 
-BACKGROUND CONTEXT RULE: when called from inside a running task (prep or execute, i.e. <task_prep> or <task_execution> is in your system prompt), parentTaskId is MANDATORY — pass the current task's ID. You can only create SUBTASKS in background, never top-level tasks. Top-level task creation is reserved for the foreground chat agent. This prevents background runs from spawning unrelated work.
+BACKGROUND CONTEXT RULE: when called from inside a running task (i.e. <task_planning> or <task_execution> is in your system prompt), parentTaskId is MANDATORY — pass the current task's ID. You can only create SUBTASKS in background, never top-level tasks. Top-level task creation is reserved for the foreground chat agent. This prevents background runs from spawning unrelated work.
 
-BEFORE CREATING: Always call search_tasks first. If a matching task already exists in Todo/Working, reuse it instead of creating a duplicate.
+BEFORE CREATING: call list_tasks (filter by status Todo or Working) and scan the titles — if a matching task already exists, reuse it instead of creating a duplicate. There is no keyword search; list-and-pick.
 
 IMMEDIATE TASK (no scheduling):
-- Default status is Todo — use for active work items, planning, and tracked tasks.
-- Pass status="Waiting" for approval-gated work — send_message explaining the plan, wait for user to approve.
+- Default status is Ready — the task buffers briefly, then executes. Use this for any work the user delegated to you that should run.
+- Pass status="Todo" only when you want to PARK the task without running it (e.g. a backlog item the user said "later" to). Todo does NOT auto-buffer; promote to Ready (via UI or unblock_task) to start.
+- Pass status="Waiting" for approval-gated work — send_message explaining the plan, wait for user to approve. The user's reply triggers unblock_task → Ready → buffer + execute.
 
 SCHEDULED TASK (one-time, fires at a specific time):
 - Pass title + schedule (RRule) + maxOccurrences=1
@@ -179,7 +180,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             .enum(["Todo", "Waiting", "Ready"])
             .optional()
             .describe(
-              "Initial status. Ready (default for agent-created) = runs after a 2-minute buffer; the user has that window to edit before execution starts. Todo = backlog — the task sits idle and only runs once the user (or unblock_task) moves it to Ready. Waiting = needs explicit user input or approval; send_message the question/plan, then unblock_task when answered.",
+              "Initial status. Ready (default for agent-created) = runs after a brief editing buffer; the user has that window to edit before execution starts. Todo = backlog — the task sits idle and only runs once the user (or unblock_task) moves it to Ready. Waiting = needs explicit user input or approval; send_message the question/plan, then unblock_task when answered.",
             ),
         }),
         execute: async ({
@@ -300,7 +301,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
             // Immediate task (no scheduling).
             //
             // Agent-created tasks default to Ready: the wake-up handler
-            // runs them after a 2-minute buffer (the user's editing
+            // runs them after a brief editing buffer (the user's editing
             // window). Todo is the backlog state — only reached when the
             // agent or user explicitly parks the task; it does not auto-
             // schedule a buffer. Subtasks behave the same way — they run
@@ -332,7 +333,7 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
               targetStatus === "Waiting"
                 ? "Waiting — send_message to user explaining what's needed. Once unblocked, the task executes in its own thread; do not do its work in the current conversation."
                 : resolvedParentId
-                  ? `Added to ${targetStatus}. The subtask runs its own execute cycle through a 2-minute buffer, in parallel with siblings. Do NOT do its work in the current conversation; just acknowledge creation and continue with the parent or stop.`
+                  ? `Added to ${targetStatus}. The subtask runs its own execute cycle through its own editing buffer, in parallel with siblings. Do NOT do its work in the current conversation; just acknowledge creation and continue with the parent or stop.`
                   : `Added to ${targetStatus}. The task will be picked up and executed in its own thread — do NOT do its work in the current conversation; just acknowledge creation and stop.`;
             logger.info(
               `Task ${task.id} created (${targetStatus})${resolvedParentId ? ` subtask of ${resolvedParentId}` : ""}`,

--- a/apps/webapp/app/services/agent/types.ts
+++ b/apps/webapp/app/services/agent/types.ts
@@ -1,7 +1,9 @@
 export interface SkillRef {
   id: string;
   title: string;
-  metadata: Record<string, unknown> | null;
+  // Prisma surfaces `metadata` as a JsonValue (scalars, arrays, objects, null).
+  // SkillRef accepts that whole shape and call-sites narrow as needed.
+  metadata: unknown;
 }
 
 export type MessageChannel = "whatsapp" | "email" | "slack" | "telegram";

--- a/apps/webapp/app/services/agent/types/decision-agent.ts
+++ b/apps/webapp/app/services/agent/types/decision-agent.ts
@@ -87,8 +87,6 @@ export interface ScheduledTaskTriggerData {
   previousResponses: ResponseSummary[];
   unrespondedCount: number;
   confirmedActive: boolean;
-  skillId?: string;
-  skillName?: string;
   isRecurring?: boolean;
 }
 

--- a/apps/webapp/app/services/channels/slack/inbound.ts
+++ b/apps/webapp/app/services/channels/slack/inbound.ts
@@ -181,7 +181,12 @@ export async function parseSlackDMEvent(
   // Fallback: match by bot_user_id from authorizations (covers manual channels
   // where user_id is not set, single-user workspaces)
   if (!channel) {
-    channel = await findChannelByAuthorization(eventBody);
+    // The signature takes a slack user id; pass the bot_user_id from
+    // authorizations if available, otherwise fall back to the sender.
+    const botUserId =
+      (eventBody as { authorizations?: Array<{ user_id?: string }> })
+        .authorizations?.[0]?.user_id ?? slackUserId;
+    channel = await findChannelByAuthorization(botUserId);
   }
 
   if (!channel) {

--- a/apps/webapp/app/services/folder.server.ts
+++ b/apps/webapp/app/services/folder.server.ts
@@ -31,7 +31,7 @@ export class FolderService {
       return { folders: [] };
     }
 
-    return user.folders as FolderStructure;
+    return user.folders as unknown as FolderStructure;
   }
 
   /**

--- a/apps/webapp/app/services/hocuspocus/page-outlinks.server.ts
+++ b/apps/webapp/app/services/hocuspocus/page-outlinks.server.ts
@@ -43,7 +43,7 @@ export async function storeOutlinks(
       select: { outlinks: true },
     });
 
-    const currentIds = ((page?.outlinks ?? []) as Outlink[])
+    const currentIds = ((page?.outlinks ?? []) as unknown as Outlink[])
       .map((o) => o.id)
       .sort();
     const newIds = taskIds.slice().sort();

--- a/apps/webapp/app/services/integrations/integration-runner.ts
+++ b/apps/webapp/app/services/integrations/integration-runner.ts
@@ -244,7 +244,9 @@ export class IntegrationRunner {
       {
         event: IntegrationEventType.SETUP,
         eventBody,
-        integrationDefinition,
+        integrationDefinition: integrationDefinition as unknown as NonNullable<
+          IntegrationEventPayload["integrationDefinition"]
+        >,
       },
       slug,
     );
@@ -260,7 +262,9 @@ export class IntegrationRunner {
       {
         event: IntegrationEventType.IDENTIFY,
         eventBody: webhookData,
-        integrationDefinition,
+        integrationDefinition: integrationDefinition as unknown as NonNullable<
+          IntegrationEventPayload["integrationDefinition"]
+        >,
       },
       slug,
     );
@@ -276,8 +280,10 @@ export class IntegrationRunner {
       {
         event: IntegrationEventType.GET_TOOLS,
         eventBody: {},
-        config: config || {},
-        integrationDefinition,
+        config: (config || {}) as IntegrationEventPayload["config"],
+        integrationDefinition: integrationDefinition as unknown as NonNullable<
+          IntegrationEventPayload["integrationDefinition"]
+        >,
       },
       slug,
     );
@@ -294,8 +300,13 @@ export class IntegrationRunner {
       {
         event: IntegrationEventType.CALL_TOOL,
         eventBody: { name: toolName, arguments: toolArguments },
-        config: { ...config, timezone: timezone || "UTC" },
-        integrationDefinition,
+        config: {
+          ...config,
+          timezone: timezone || "UTC",
+        } as unknown as IntegrationEventPayload["config"],
+        integrationDefinition: integrationDefinition as unknown as NonNullable<
+          IntegrationEventPayload["integrationDefinition"]
+        >,
       },
       slug,
     );
@@ -311,9 +322,11 @@ export class IntegrationRunner {
       {
         event: IntegrationEventType.PROCESS,
         eventBody: eventData,
-        config: config || {},
-        integrationDefinition,
-        state,
+        config: (config || {}) as IntegrationEventPayload["config"],
+        integrationDefinition: integrationDefinition as unknown as NonNullable<
+          IntegrationEventPayload["integrationDefinition"]
+        >,
+        state: state as Record<string, string> | undefined,
       },
       slug,
     );

--- a/apps/webapp/app/services/oauth/oauth.server.ts
+++ b/apps/webapp/app/services/oauth/oauth.server.ts
@@ -311,7 +311,7 @@ export async function getRedirectURL(
     const uniqueId = Date.now().toString(36);
 
     // Generate PKCE code_verifier if PKCE is not disabled
-    const usePkce = !template.disable_pkce;
+    const usePkce = !(template as { disable_pkce?: boolean }).disable_pkce;
     const codeVerifier = usePkce ? generateCodeVerifier() : undefined;
 
     session[uniqueId] = {

--- a/apps/webapp/app/services/reminder.server.ts
+++ b/apps/webapp/app/services/reminder.server.ts
@@ -212,7 +212,9 @@ export async function addReminder(
         maxOccurrences: data.maxOccurrences ?? null,
         occurrenceCount: 0,
         endDate: data.endDate ?? null,
-        metadata: data.metadata ?? undefined,
+        metadata: (data.metadata ?? undefined) as
+          | Prisma.InputJsonValue
+          | undefined,
       },
     });
 

--- a/apps/webapp/app/services/routeBuilders/apiBuilder.server.ts
+++ b/apps/webapp/app/services/routeBuilders/apiBuilder.server.ts
@@ -20,9 +20,9 @@ import { getUserSession } from "../session.server";
 
 import { safeJsonParse } from "~/utils/json";
 
-type AnyZodSchema =
-  | z.ZodFirstPartySchemaTypes
-  | z.ZodDiscriminatedUnion<any, any>;
+// Zod v4: ZodFirstPartySchemaTypes lost runtime methods like safeParse.
+// Use ZodTypeAny (alias of ZodType) which retains the legacy API.
+type AnyZodSchema = z.ZodTypeAny;
 
 type ApiKeyRouteBuilderOptions<
   TParamsSchema extends AnyZodSchema | undefined = undefined,
@@ -37,14 +37,14 @@ type ApiKeyRouteBuilderOptions<
   corsStrategy?: "all" | "none";
   findResource: (
     params: TParamsSchema extends
-      | z.ZodFirstPartySchemaTypes
-      | z.ZodDiscriminatedUnion<any, any>
+      | z.ZodTypeAny
+      | never
       ? z.infer<TParamsSchema>
       : undefined,
     authentication: ApiAuthenticationResultSuccess,
     searchParams: TSearchParamsSchema extends
-      | z.ZodFirstPartySchemaTypes
-      | z.ZodDiscriminatedUnion<any, any>
+      | z.ZodTypeAny
+      | never
       ? z.infer<TSearchParamsSchema>
       : undefined,
   ) => Promise<TResource | undefined>;
@@ -54,18 +54,18 @@ type ApiKeyRouteBuilderOptions<
     resource: (
       resource: NonNullable<TResource>,
       params: TParamsSchema extends
-        | z.ZodFirstPartySchemaTypes
-        | z.ZodDiscriminatedUnion<any, any>
+        | z.ZodTypeAny
+      | never
         ? z.infer<TParamsSchema>
         : undefined,
       searchParams: TSearchParamsSchema extends
-        | z.ZodFirstPartySchemaTypes
-        | z.ZodDiscriminatedUnion<any, any>
+        | z.ZodTypeAny
+      | never
         ? z.infer<TSearchParamsSchema>
         : undefined,
       headers: THeadersSchema extends
-        | z.ZodFirstPartySchemaTypes
-        | z.ZodDiscriminatedUnion<any, any>
+        | z.ZodTypeAny
+      | never
         ? z.infer<THeadersSchema>
         : undefined,
     ) => AuthorizationResources;
@@ -80,18 +80,18 @@ type ApiKeyHandlerFunction<
   TResource = never,
 > = (args: {
   params: TParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TParamsSchema>
     : undefined;
   searchParams: TSearchParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TSearchParamsSchema>
     : undefined;
   headers: THeadersSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<THeadersSchema>
     : undefined;
   authentication: ApiAuthenticationResultSuccess;
@@ -345,23 +345,23 @@ type ApiKeyActionHandlerFunction<
   TBodySchema extends AnyZodSchema | undefined = undefined,
 > = (args: {
   params: TParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TParamsSchema>
     : undefined;
   searchParams: TSearchParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TSearchParamsSchema>
     : undefined;
   headers: THeadersSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<THeadersSchema>
     : undefined;
   body: TBodySchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TBodySchema>
     : undefined;
   authentication: ApiAuthenticationResultSuccess;
@@ -694,23 +694,23 @@ type HybridActionHandlerFunction<
   TBodySchema extends AnyZodSchema | undefined = undefined,
 > = (args: {
   params: TParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TParamsSchema>
     : undefined;
   searchParams: TSearchParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TSearchParamsSchema>
     : undefined;
   headers: THeadersSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<THeadersSchema>
     : undefined;
   body: TBodySchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TBodySchema>
     : undefined;
   authentication: HybridAuthenticationResult;
@@ -974,14 +974,14 @@ type HybridLoaderRouteBuilderOptions<
   corsStrategy?: "all" | "none";
   findResource: (
     params: TParamsSchema extends
-      | z.ZodFirstPartySchemaTypes
-      | z.ZodDiscriminatedUnion<any, any>
+      | z.ZodTypeAny
+      | never
       ? z.infer<TParamsSchema>
       : undefined,
     authentication: HybridAuthenticationResult,
     searchParams: TSearchParamsSchema extends
-      | z.ZodFirstPartySchemaTypes
-      | z.ZodDiscriminatedUnion<any, any>
+      | z.ZodTypeAny
+      | never
       ? z.infer<TSearchParamsSchema>
       : undefined,
   ) => Promise<TResource | undefined>;
@@ -991,18 +991,18 @@ type HybridLoaderRouteBuilderOptions<
     resource: (
       resource: NonNullable<TResource>,
       params: TParamsSchema extends
-        | z.ZodFirstPartySchemaTypes
-        | z.ZodDiscriminatedUnion<any, any>
+        | z.ZodTypeAny
+      | never
         ? z.infer<TParamsSchema>
         : undefined,
       searchParams: TSearchParamsSchema extends
-        | z.ZodFirstPartySchemaTypes
-        | z.ZodDiscriminatedUnion<any, any>
+        | z.ZodTypeAny
+      | never
         ? z.infer<TSearchParamsSchema>
         : undefined,
       headers: THeadersSchema extends
-        | z.ZodFirstPartySchemaTypes
-        | z.ZodDiscriminatedUnion<any, any>
+        | z.ZodTypeAny
+      | never
         ? z.infer<THeadersSchema>
         : undefined,
     ) => AuthorizationResources;
@@ -1017,18 +1017,18 @@ type HybridLoaderHandlerFunction<
   TResource = never,
 > = (args: {
   params: TParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TParamsSchema>
     : undefined;
   searchParams: TSearchParamsSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<TSearchParamsSchema>
     : undefined;
   headers: THeadersSchema extends
-    | z.ZodFirstPartySchemaTypes
-    | z.ZodDiscriminatedUnion<any, any>
+    | z.ZodTypeAny
+      | never
     ? z.infer<THeadersSchema>
     : undefined;
   authentication: HybridAuthenticationResult;

--- a/apps/webapp/app/services/search-v2/handlers.ts
+++ b/apps/webapp/app/services/search-v2/handlers.ts
@@ -100,25 +100,29 @@ function getTemporalDateRange(ctx: HandlerContext): {
 
   switch (temporal.type) {
     case "recent":
-      const days = temporal.days;
+      const days = temporal.days ?? 7;
       const startTime = new Date();
       startTime.setDate(startTime.getDate() - days);
       return { startTime };
 
     case "range":
       return {
-        startTime: new Date(temporal.startDate),
-        endTime: new Date(temporal.endDate),
+        startTime: temporal.startDate
+          ? new Date(temporal.startDate)
+          : undefined,
+        endTime: temporal.endDate ? new Date(temporal.endDate) : undefined,
       };
 
     case "before":
       return {
-        endTime: new Date(temporal.endDate),
+        endTime: temporal.endDate ? new Date(temporal.endDate) : undefined,
       };
 
     case "after":
       return {
-        startTime: new Date(temporal.startDate),
+        startTime: temporal.startDate
+          ? new Date(temporal.startDate)
+          : undefined,
       };
 
     case "all":

--- a/apps/webapp/app/services/search-v2/types.ts
+++ b/apps/webapp/app/services/search-v2/types.ts
@@ -375,6 +375,7 @@ export const ASPECT_DEFINITIONS: Record<StatementAspect, string> = {
     "Specific occurrences with timestamps - meetings, milestones, incidents",
   Problem: "Blockers, issues, challenges, obstacles, difficulties",
   Relationship: "Connections between people - who knows whom, team dynamics",
+  Task: "Trackable units of work - todos, action items, deliverables",
 };
 
 /**

--- a/apps/webapp/app/services/session.server.ts
+++ b/apps/webapp/app/services/session.server.ts
@@ -5,7 +5,6 @@ import { getImpersonationId } from "./impersonation.server";
 import { type Request as ERequest } from "express";
 import { prisma } from "~/db.server";
 import { getWorkspaceById } from "~/models/workspace.server";
-import { u } from "@/build/server/assets/server-build-DGNmHiPh";
 
 export async function getUserId(
   request: Request | ERequest,

--- a/apps/webapp/app/services/skills.builtin.ts
+++ b/apps/webapp/app/services/skills.builtin.ts
@@ -1,0 +1,87 @@
+/**
+ * Built-in skills.
+ *
+ * Skills that ship with the agent itself — never seeded to the database,
+ * never shown in the user's skills UI, but always available in every
+ * workspace's <skills> block so the agent can discover and load them via
+ * get_skill the same way as user-installed skills.
+ *
+ * IDs are synthetic and namespaced with the `builtin:` prefix so that:
+ *   - get_skill can route lookups to this module instead of the DB
+ *   - the IDs never collide with DB-backed skill UUIDs
+ *
+ * Add a new entry here when there's a behavior we want the agent to
+ * consistently know about across all workspaces without users having to
+ * install or manage it.
+ */
+
+export interface BuiltinSkillDef {
+  /** Stable synthetic ID, must start with "builtin:". */
+  id: string;
+  title: string;
+  shortDescription: string;
+  content: string;
+}
+
+const BUILTIN_ID_PREFIX = "builtin:";
+
+export const BUILTIN_SKILLS: BuiltinSkillDef[] = [
+  {
+    id: "builtin:decompose-task",
+    title: "Decompose Task",
+    shortDescription:
+      "Use when a task looks big — decide whether to split into subtasks and how.",
+    content: `# Decompose Task
+
+You're inside an execute mind on a task that looks big. This skill helps you decide whether to split it into subtasks and, if so, how.
+
+## Default answer: don't split
+
+Most tasks are one unit of work even if they involve several steps. Linear steps inside one task are fine — write them in the description, execute them in order, mark Review. Don't reach for decomposition unless one of the SPLIT triggers below clearly fires.
+
+## SPLIT when (at least one is true)
+
+- **Multiple independent deliverables** that don't share runtime state — each could be handed to a different person without coordination. Examples: "set up OAuth provider + build login UI + add session middleware", "draft the investor email + the customer email + the team announcement".
+- **Irreversibly bulk action** that benefits from per-chunk review boundaries: mass deletions, mass sends, schema migrations, refactors touching >5 files.
+- **User explicitly said** "plan this", "decompose this", "split this up", "think through this".
+
+## DON'T SPLIT when
+
+- The work is a single artifact (one summary, one email, one investigation, one PR).
+- The "steps" are sequential and tightly coupled (set up DB → seed it → smoke test). That's one task — write the steps in the description.
+- You're tempted to split into "Planning" / "Execution" phases. Phases are NOT decomposition. Skip.
+- One chunk would just be "wait for user reply". Use Waiting status on the current task instead — Waiting is for blockers, subtasks are for divide-and-conquer.
+
+## HOW to split (when splitting)
+
+1. **Each subtask is a meaningful work chunk** — a deliverable, not a phase. Bad: "Plan", "Execute", "Verify". Good: "Set up OAuth provider", "Build login form", "Add session middleware".
+2. **Subtasks must be independent.** They run in parallel — no shared mid-execution state, no ordering assumptions. If A depends on B's output, fold them into one task instead.
+3. **Call create_task with parentTaskId set and no status override.** Subtasks default to Ready and start their own execution cycle on the 2-minute buffer. Each runs through its own SKILL CHECK and execute mind.
+4. **Write the breakdown into the parent description** via update_task with a <plan> section listing the subtask titles so the user can see the split.
+5. **Send a heads-up message.** "Splitting this into A, B, C — each starts in 2 min. Stop me if wrong." Don't move the parent to Waiting — the buffer already gives the user a veto window. Parent stays Working until all subtasks complete; the system auto-marks it Done.
+
+## Max depth
+
+Two levels: epic → task → subtask. A subtask cannot decompose further. If a subtask feels like it needs splitting, the parent was scoped wrong — go back, redo the parent split.
+
+## After deciding NOT to split
+
+Just execute the task. Don't write an "I considered splitting but decided not to" message — silence is the default.`,
+  },
+];
+
+/**
+ * Look up a built-in skill by its synthetic ID. Returns undefined if no
+ * built-in skill has that ID (caller should fall through to the DB lookup).
+ */
+export function getBuiltinSkill(id: string): BuiltinSkillDef | undefined {
+  return BUILTIN_SKILLS.find((s) => s.id === id);
+}
+
+/**
+ * Cheap discriminator: any ID with the `builtin:` prefix is a built-in skill
+ * and must be resolved via this module, not Prisma.
+ */
+export function isBuiltinSkillId(id: string): boolean {
+  return id.startsWith(BUILTIN_ID_PREFIX);
+}

--- a/apps/webapp/app/services/skills.server.ts
+++ b/apps/webapp/app/services/skills.server.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "~/db.server";
 
 export interface UpdateSkillParams {
@@ -192,7 +193,7 @@ export const updateSkill = async (
         metadata: {
           ...existingMeta,
           ...metadataUpdate,
-        },
+        } as Prisma.InputJsonValue,
       }),
       editedBy: userId,
     },

--- a/apps/webapp/app/services/task.phase.ts
+++ b/apps/webapp/app/services/task.phase.ts
@@ -3,14 +3,20 @@ import type { TaskStatus } from "@prisma/client";
 export type { TaskStatus };
 
 /**
- * A task's phase. Stored in `task.metadata.phase`.
+ * A task's phase — which mind the agent is in when it picks up the task.
  *
- * - "prep"    = Phase 1: butler is preparing the task (Todo ⇄ Waiting → Ready).
- * - "execute" = Phase 2: butler is executing (Ready → Working ⇄ Waiting → Review → Done).
+ * - "execute" = the default. The agent reads the task and does the work.
+ * - "prep"    = the agent self-promoted via the enter_plan_mode tool to
+ *               gather information / shape an open-ended goal. It writes
+ *               a plan into the task description, then calls
+ *               exit_plan_mode to drop back into execute.
  *
- * Phase disambiguates the `Waiting` status, which can legitimately appear in
- * either phase. When the user answers a Waiting question, phase tells the
- * agent whether the answer feeds planning or execution.
+ * Phase is agent-driven, not status-driven. Status transitions do NOT
+ * change phase — that prevents an in-flight plan from being silently
+ * undone by an update_task(status: "Waiting") side-effect.
+ *
+ * Only "prep" is stored in metadata. Absence of `metadata.phase` is
+ * execute.
  */
 export type TaskPhase = "prep" | "execute";
 
@@ -22,14 +28,12 @@ export type TaskPhase = "prep" | "execute";
  */
 export type TransitionActor = "agent" | "user" | "system";
 
-const PHASE_1_STATUSES: TaskStatus[] = ["Todo", "Waiting"];
-
 // ─── Phase storage helpers ──────────────────────────────────────────
 
 /**
- * Read the phase for a task. Phase lives in `task.metadata.phase`. When
- * absent (older tasks created before this feature), we infer from status:
- * Todo/Waiting → prep, everything else → execute.
+ * Read the phase for a task. "prep" is recorded in metadata when the agent
+ * calls enter_plan_mode; everything else (including absence of metadata,
+ * legacy values, and explicit "execute") is execute.
  */
 export function getTaskPhase(task: {
   status: TaskStatus;
@@ -39,23 +43,17 @@ export function getTaskPhase(task: {
     task.metadata && typeof task.metadata === "object"
       ? (task.metadata as Record<string, unknown>)
       : null;
-  const raw = meta?.phase;
-  if (raw === "prep" || raw === "execute") return raw;
-  return inferPhaseFromStatus(task.status);
-}
-
-/**
- * Default phase for a given status when no metadata is present. Matches the
- * backfill rule: Phase 1 statuses are prep, everything else is execute.
- */
-export function inferPhaseFromStatus(status: TaskStatus): TaskPhase {
-  if (status === "Todo" || status === "Waiting") return "prep";
-  return "execute";
+  return meta?.phase === "prep" ? "prep" : "execute";
 }
 
 /**
  * Immutably produce a new metadata object with `phase` set. Caller is
  * responsible for persisting the result (typically via prisma.task.update).
+ *
+ * When `phase === "execute"` the phase key is REMOVED from metadata rather
+ * than set — execute is the implicit default and storing it would just
+ * add noise (and would force every transition to write metadata even when
+ * the phase didn't change).
  */
 export function setTaskPhaseInMetadata(
   existing: unknown,
@@ -65,6 +63,10 @@ export function setTaskPhaseInMetadata(
     existing && typeof existing === "object"
       ? (existing as Record<string, unknown>)
       : {};
+  if (phase === "execute") {
+    const { phase: _phase, ...rest } = base;
+    return rest;
+  }
   return { ...base, phase };
 }
 
@@ -72,63 +74,29 @@ export function setTaskPhaseInMetadata(
 
 /**
  * Decide whether a (from → to) status transition is allowed for the given
- * actor and current phase. Encodes the spec's transition table.
+ * actor. Phase is NOT consulted — status and phase are independent in the
+ * execute-first lifecycle (phase is agent-driven via enter/exit_plan_mode
+ * only).
+ *
+ * Agent-allowed targets: Waiting, Review. Everything else is reserved for
+ * system (runtime promotions, scheduled fires) or user (UI / approval).
  */
 export function canTransition(
   from: TaskStatus,
   to: TaskStatus,
-  phase: TaskPhase,
   actor: TransitionActor,
 ): boolean {
   if (from === to) return true;
 
-  // Deny-list: only block transitions that are genuinely dangerous.
-  // Everything else is allowed — the system and prompts guide correct usage.
-
-  // Working, Done, Todo — never agent-driven. The system manages these
-  // (runtime → Working when execution starts, user → Done, parking → Todo).
+  // Agents may only put a task into Waiting (block, need user input) or
+  // Review (work complete, awaiting user verification). Working / Done /
+  // Todo / Ready are all system- or user-driven in execute-first.
   if (
-    (to === "Working" || to === "Done" || to === "Todo") &&
-    actor === "agent"
+    actor === "agent" &&
+    (to === "Working" || to === "Done" || to === "Todo" || to === "Ready")
   ) {
     return false;
   }
 
-  // Ready — agent may set Ready ONLY during prep. This covers two cases:
-  // (1) butler skips the prep gate for simple+clear tasks (Todo -> Ready),
-  // (2) butler unblocks itself after a Waiting answer (Waiting -> Ready).
-  // Once we've crossed into execute, only system or user can flip back to
-  // Ready (e.g., user approves from Review). This guard is what prevents
-  // an auto-loop: once the agent moves a task to execute, it cannot
-  // promote it back to Ready from execute context.
-  if (to === "Ready" && actor === "agent" && phase !== "prep") {
-    return false;
-  }
-
   return true;
-}
-
-/**
- * Given a validated transition, compute the new `phase` value.
- * Called after canTransition returns true.
- */
-export function inferNewPhase(
-  from: TaskStatus,
-  to: TaskStatus,
-  currentPhase: TaskPhase,
-): TaskPhase {
-  // Any transition TO Ready/Working/Review/Done flips to execute.
-  if (to === "Ready" || to === "Working" || to === "Review" || to === "Done") {
-    return "execute";
-  }
-  // Waiting keeps the current phase (the disambiguation problem — Waiting can
-  // exist in either phase, so we preserve whichever we were in).
-  if (to === "Waiting") {
-    return currentPhase;
-  }
-  // Todo is always prep (only entered fresh; we don't go back to Todo).
-  if (to === "Todo") {
-    return "prep";
-  }
-  return currentPhase;
 }

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -394,13 +394,16 @@ export async function changeTaskStatus(
   // Subtask Done — auto-complete parent if no siblings are still active.
   // In the parallel model there is no "next sibling" to kick off; subtasks
   // run independently and the parent flips to Done once every child has
-  // left the active set (Todo / Working / Waiting / Ready).
+  // reached its terminal state. Review counts as non-terminal because the
+  // user still has to move Review → Done — if we treated Review as finished
+  // here, the parent could auto-Done while a sibling is still awaiting
+  // user verification.
   if (status === "Done" && current.parentTaskId) {
     const activeSiblings = await prisma.task.count({
       where: {
         parentTaskId: current.parentTaskId,
         id: { not: taskId },
-        status: { in: ["Todo", "Working", "Waiting", "Ready"] },
+        status: { in: ["Todo", "Working", "Waiting", "Ready", "Review"] },
       },
     });
     if (activeSiblings === 0) {

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -243,9 +243,23 @@ export async function getTaskFull(
 
 export async function getTasks(
   workspaceId: string,
-  options?: { status?: TaskStatus; isScheduled?: boolean },
+  options?: {
+    status?: TaskStatus;
+    isScheduled?: boolean;
+    createdAfter?: Date;
+    createdBefore?: Date;
+    dueAfter?: Date;
+    dueBefore?: Date;
+  },
 ): Promise<TaskWithRelations[]> {
-  const { status, isScheduled } = options ?? {};
+  const {
+    status,
+    isScheduled,
+    createdAfter,
+    createdBefore,
+    dueAfter,
+    dueBefore,
+  } = options ?? {};
 
   const scheduledFilter =
     isScheduled === true
@@ -262,11 +276,33 @@ export async function getTasks(
           }
         : {};
 
+  const createdAtFilter =
+    createdAfter || createdBefore
+      ? {
+          createdAt: {
+            ...(createdAfter && { gte: createdAfter }),
+            ...(createdBefore && { lte: createdBefore }),
+          },
+        }
+      : {};
+
+  const dueAtFilter =
+    dueAfter || dueBefore
+      ? {
+          nextRunAt: {
+            ...(dueAfter && { gte: dueAfter }),
+            ...(dueBefore && { lte: dueBefore }),
+          },
+        }
+      : {};
+
   return prisma.task.findMany({
     where: {
       workspaceId,
       ...(status && { status }),
       ...scheduledFilter,
+      ...createdAtFilter,
+      ...dueAtFilter,
     },
     orderBy: { createdAt: "desc" },
     include: {
@@ -1053,12 +1089,37 @@ export async function rescheduleTaskAt(
  */
 export async function getScheduledTasksForWorkspace(
   workspaceId: string,
+  options?: {
+    createdAfter?: Date;
+    createdBefore?: Date;
+    dueAfter?: Date;
+    dueBefore?: Date;
+  },
 ): Promise<Task[]> {
+  const { createdAfter, createdBefore, dueAfter, dueBefore } = options ?? {};
+
+  // nextRunAt must be non-null AND fall inside the requested range when one
+  // is provided. Combine both conditions into a single Prisma filter.
+  const nextRunAtFilter: Record<string, unknown> = { not: null };
+  if (dueAfter) nextRunAtFilter.gte = dueAfter;
+  if (dueBefore) nextRunAtFilter.lte = dueBefore;
+
+  const createdAtFilter =
+    createdAfter || createdBefore
+      ? {
+          createdAt: {
+            ...(createdAfter && { gte: createdAfter }),
+            ...(createdBefore && { lte: createdBefore }),
+          },
+        }
+      : {};
+
   return prisma.task.findMany({
     where: {
       workspaceId,
       isActive: true,
-      nextRunAt: { not: null },
+      nextRunAt: nextRunAtFilter,
+      ...createdAtFilter,
     },
     orderBy: { createdAt: "desc" },
   });

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -186,6 +186,38 @@ export async function getTaskById(id: string): Promise<Task | null> {
   return prisma.task.findUnique({ where: { id } });
 }
 
+/**
+ * Resolve a user-facing task identifier to its internal UUID.
+ *
+ * Accepts either a UUID (passed through after a workspace-scoped existence
+ * check) or a `tk-…` displayId (looked up via the `(workspaceId, displayId)`
+ * unique index). Returns null if no task in this workspace matches.
+ *
+ * Agent tools take displayIds from the model and call this at the boundary;
+ * everything downstream keeps working with UUIDs.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function resolveTaskId(
+  input: string,
+  workspaceId: string,
+): Promise<string | null> {
+  if (!input) return null;
+  if (UUID_RE.test(input)) {
+    const task = await prisma.task.findFirst({
+      where: { id: input, workspaceId },
+      select: { id: true },
+    });
+    return task?.id ?? null;
+  }
+  const task = await prisma.task.findUnique({
+    where: { workspaceId_displayId: { workspaceId, displayId: input } },
+    select: { id: true },
+  });
+  return task?.id ?? null;
+}
+
 export type TaskWithRelations = Task & {
   subtasks: Pick<Task, "id" | "status" | "source">[];
   parentTask: Pick<Task, "id" | "title"> | null;

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -21,9 +21,6 @@ import {
 import { updateTaskTitleInPages } from "~/services/hocuspocus/page-outlinks.server";
 import {
   canTransition,
-  getTaskPhase,
-  inferNewPhase,
-  setTaskPhaseInMetadata,
   type TransitionActor,
 } from "~/services/task.phase";
 
@@ -91,31 +88,17 @@ export async function createTask(
   }
 
   const effectiveStatus = options?.status ?? "Todo";
-  // Agent-created Ready tasks (no schedule) are special: the agent already
-  // classified them as simple+clear and skipped prep, but we still want a
-  // 2-min buffer so the user can edit before execution. During the buffer
-  // the task sits in Ready with phase=prep; the wake-up handler flips
-  // phase to execute when it fires.
-  const isAgentCreatedReady =
-    effectiveStatus === "Ready" && options?.actor === "agent";
-  // Initial phase: Todo or Waiting → prep (task needs planning),
-  // agent-created Ready → prep (buffer hasn't fired yet),
-  // everything else → execute (e.g., recurring tasks created in Ready
-  // via createScheduledTask skip prep entirely).
-  const initialPhase =
-    effectiveStatus === "Todo" ||
-    effectiveStatus === "Waiting" ||
-    isAgentCreatedReady
-      ? "prep"
-      : "execute";
 
+  // Execute-first lifecycle: every new task starts in execute mind. We do
+  // NOT write metadata.phase at creation — the absence of phase IS execute
+  // (see getTaskPhase). Only enter_plan_mode writes metadata.phase = "prep"
+  // when the agent self-promotes; exit_plan_mode flips it back to execute.
   const task = await prisma.task.create({
     data: {
       title,
       status: effectiveStatus,
       workspaceId,
       userId,
-      metadata: setTaskPhaseInMetadata(null, initialPhase),
       ...(options?.source && { source: options.source }),
       ...(resolvedParentTaskId && { parentTaskId: resolvedParentTaskId }),
     },
@@ -126,39 +109,20 @@ export async function createTask(
     await setPageContentFromHtml(page.id, description);
   }
 
-  // Buffer wake-up: freshly-created tasks sit for 2 minutes so the user
-  // can edit freely. At expiry, the scheduled-task wake-up handler starts
-  // prep (Todo path) or directly enqueues execution (agent-created Ready
-  // path, see scheduled-task.logic.ts isReadyBufferExpiry branch).
-  // Two cases get the buffer:
-  //   1. Anyone creates a Todo task (existing behavior — prep starts at expiry)
-  //   2. Agent creates a Ready task with no schedule (new — execution starts
-  //      at expiry; the agent already classified it as simple+clear and we
-  //      record that decision via metadata.prepDecided=true so the prep
-  //      invoker never re-enters prep for this task)
+  // Buffer wake-up: a freshly-created Ready task sits for 2 minutes so the
+  // user can edit before execution starts. At expiry, the scheduled-task
+  // wake-up handler enqueues the task for the runner.
+  //
+  // Other statuses skip the buffer:
+  //   - Todo = backlog. The task sits idle until promoted to Ready (which
+  //     applies the buffer through the changeTaskStatus path).
+  //   - Waiting = gated on user input via send_message; should not auto-run.
   // Scheduled/recurring tasks use createScheduledTask and skip this buffer.
-  const needsBuffer = effectiveStatus === "Todo" || isAgentCreatedReady;
-
-  if (needsBuffer) {
+  if (effectiveStatus === "Ready") {
     const nextRunAt = new Date(Date.now() + 2 * 60 * 1000);
     await prisma.task.update({
       where: { id: task.id },
-      data: {
-        nextRunAt,
-        // For agent-created Ready, mark prep decided. Phase stays "prep" —
-        // the wake-up handler in scheduled-task.logic.ts will flip it to
-        // "execute" when the buffer expires. The prepDecided flag is what
-        // the prep invoker reads to short-circuit (Task 6).
-        ...(isAgentCreatedReady && {
-          metadata: setTaskPhaseInMetadata(
-            {
-              ...((task.metadata as Record<string, unknown>) ?? {}),
-              prepDecided: true,
-            },
-            "prep",
-          ),
-        }),
-      },
+      data: { nextRunAt },
     });
     try {
       await enqueueScheduledTask(
@@ -361,24 +325,11 @@ export async function updateTaskStatus(
 }
 
 /**
- * Get the next Todo subtask for a parent, ordered by displayId.
- * Returns null if no Todo subtasks remain.
- */
-export async function getNextBacklogSubtask(
-  parentTaskId: string,
-): Promise<Task | null> {
-  return prisma.task.findFirst({
-    where: { parentTaskId, status: "Waiting" },
-    orderBy: { displayId: "asc" },
-  });
-}
-
-/**
  * Central lifecycle handler for task status changes.
  * - Cancels any queued/executing job when moving away from InProgress
  * - Cancels scheduled jobs when deactivating
- * - Sequential subtask execution: parent Todo enqueues first subtask,
- *   subtask completion enqueues next sibling
+ * - Parallel subtask execution: subtasks default Ready and run independently;
+ *   parent auto-Dones when all subtasks are no longer active
  */
 export async function changeTaskStatus(
   taskId: string,
@@ -390,22 +341,21 @@ export async function changeTaskStatus(
   const current = await prisma.task.findUnique({ where: { id: taskId } });
   if (!current) throw new Error(`Task ${taskId} not found`);
 
-  const currentPhase = getTaskPhase(current);
-  if (!canTransition(current.status, status, currentPhase, actor)) {
+  if (!canTransition(current.status, status, actor)) {
     throw new Error(
-      `Invalid transition: ${current.status} -> ${status} in phase ${currentPhase} by ${actor}`,
+      `Invalid transition: ${current.status} -> ${status} by ${actor}`,
     );
   }
 
-  const newPhase = inferNewPhase(current.status, status, currentPhase);
-  const newMetadata = setTaskPhaseInMetadata(current.metadata, newPhase);
-
+  // Canonical wake-up rule for non-scheduled tasks:
+  //   - Moving to Todo / Waiting / Review parks the task. Clear nextRunAt
+  //     and cancel any pending wake-up so an old buffer doesn't fire late.
+  //   - Moving to Ready gives the task a 2-minute editing buffer; at expiry
+  //     the buffer wake-up enqueues the task for execution.
+  // Scheduled/recurring tasks own their own nextRunAt via
+  // scheduleNextTaskOccurrence — we never touch it from here.
   if (status === "Todo" || status === "Waiting" || status === "Review") {
     await cancelTaskJob(taskId);
-    // Also cancel any pending scheduled wake-up (e.g., the Todo 2-min buffer
-    // wake-up, or a stale one-time scheduled fire). None of these states
-    // should have a pending wake-up. Skip for recurring tasks — their
-    // nextRunAt is owned by scheduleNextTaskOccurrence.
     if (!current.schedule && current.nextRunAt) {
       await removeScheduledTask(taskId);
       await prisma.task.update({
@@ -415,108 +365,53 @@ export async function changeTaskStatus(
     }
   }
 
-  // Unblock resume: when a task moves from Waiting → Todo (prep-phase unblock),
-  // the original 2-min buffer wake-up was already cancelled above. Immediately
-  // enqueue so prep resumes without waiting for a wake-up that will never come.
-  if (
-    status === "Todo" &&
-    current.status === "Waiting" &&
-    !current.schedule
-  ) {
-    await enqueueTask({ taskId, workspaceId, userId });
-  }
-
-  // Auto-start execution when task moves to Ready
-  if (status === "Ready") {
-    // If this transition is skipping ahead of a pending scheduled wake-up
-    // (typical for the Todo+buffer case, or butler/user promoting early), we
-    // must cancel the stale scheduled wake-up and clear nextRunAt — otherwise
-    // the wake-up fires after execution starts and runs the pipeline a second
-    // time. Only do this for non-recurring tasks; recurring tasks own their
-    // nextRunAt via scheduleNextTaskOccurrence.
-    if (!current.schedule && current.nextRunAt) {
+  if (status === "Ready" && !current.schedule) {
+    // Clear any stale wake-up before scheduling the new buffer. Without
+    // this, a leftover wake-up from an earlier Ready stint could still
+    // fire alongside the new one.
+    if (current.nextRunAt) {
       await removeScheduledTask(taskId);
-      await prisma.task.update({
-        where: { id: taskId },
-        data: { nextRunAt: null },
-      });
     }
 
-    // Scheduled/recurring tasks must NOT be enqueued immediately — their
-    // nextRunAt is still valid and the scheduled wake-up will fire at the
-    // right time. Only enqueue non-scheduled tasks right away.
-    if (!current.schedule) {
-      // Check if this task has Waiting subtasks — if so, start the first one
-      // by transitioning it to Todo (which triggers enqueue via the
-      // Waiting→Todo handler above), and move parent to Working.
-      const nextSubtask = await getNextBacklogSubtask(taskId);
-      if (nextSubtask) {
-        await changeTaskStatus(
-          nextSubtask.id,
-          "Todo",
-          workspaceId,
-          userId,
-          "system",
-        );
-        // Parent flips directly to Working/execute (subtask sequencing is its own
-        // engine; parent doesn't need its own prep pass).
-        await prisma.task.update({
-          where: { id: taskId },
-          data: {
-            status: "Working",
-            metadata: setTaskPhaseInMetadata(current.metadata, "execute"),
-          },
-        });
-        return prisma.task.findUniqueOrThrow({ where: { id: taskId } });
-      }
-      // No subtasks — enqueue the task itself (existing behavior)
-      await enqueueTask({ taskId, workspaceId, userId });
+    const nextRunAt = new Date(Date.now() + 2 * 60 * 1000);
+    await prisma.task.update({
+      where: { id: taskId },
+      data: { nextRunAt },
+    });
+    try {
+      await enqueueScheduledTask(
+        { taskId, workspaceId, userId, channel: current.channel ?? "email" },
+        nextRunAt,
+      );
+    } catch (err) {
+      logger.warn("Failed to enqueue 2-min Ready buffer wake-up", {
+        err,
+        taskId,
+      });
     }
   }
 
-  // Subtask completed — trigger next Waiting sibling (sequential flow only),
-  // or auto-complete parent if all done.
-  if (status === "Done") {
-    if (current.parentTaskId) {
-      // Load parent to check if this is sequential flow or cherry-pick
-      const parentTask = await prisma.task.findUnique({
-        where: { id: current.parentTaskId },
-        select: { status: true },
-      });
-
-      // Only trigger next sibling if parent is Working (sequential flow).
-      // If parent is Waiting (not yet approved), this was a cherry-pick — don't cascade.
-      if (parentTask?.status === "Working") {
-        const nextSibling = await getNextBacklogSubtask(current.parentTaskId);
-        if (nextSibling) {
-          // Transition Waiting → Todo triggers enqueue
-          await changeTaskStatus(
-            nextSibling.id,
-            "Todo",
-            workspaceId,
-            userId,
-            "system",
-          );
-        } else {
-          // No more Waiting siblings — check if all subtasks are done
-          const activeSubtasks = await prisma.task.count({
-            where: {
-              parentTaskId: current.parentTaskId,
-              status: { in: ["Todo", "Working", "Waiting"] },
-            },
-          });
-          if (activeSubtasks === 0) {
-            // Parent auto-completion is a system-on-behalf-of-user transition.
-            await changeTaskStatus(
-              current.parentTaskId,
-              "Done",
-              workspaceId,
-              userId,
-              "user",
-            );
-          }
-        }
-      }
+  // Subtask Done — auto-complete parent if no siblings are still active.
+  // In the parallel model there is no "next sibling" to kick off; subtasks
+  // run independently and the parent flips to Done once every child has
+  // left the active set (Todo / Working / Waiting / Ready).
+  if (status === "Done" && current.parentTaskId) {
+    const activeSiblings = await prisma.task.count({
+      where: {
+        parentTaskId: current.parentTaskId,
+        id: { not: taskId },
+        status: { in: ["Todo", "Working", "Waiting", "Ready"] },
+      },
+    });
+    if (activeSiblings === 0) {
+      // Parent auto-completion is a system-on-behalf-of-user transition.
+      await changeTaskStatus(
+        current.parentTaskId,
+        "Done",
+        workspaceId,
+        userId,
+        "user",
+      );
     }
   }
 
@@ -535,19 +430,8 @@ export async function changeTaskStatus(
 
   const task = await prisma.task.update({
     where: { id: taskId },
-    data: { status, metadata: newMetadata },
+    data: { status },
   });
-
-  // Auto-transition: when a SUBTASK moves to Review in prep phase,
-  // skip the user approval gate and move directly to Ready.
-  // The user already approved the parent plan — subtasks execute autonomously.
-  if (
-    status === "Review" &&
-    current.parentTaskId &&
-    currentPhase === "prep"
-  ) {
-    return changeTaskStatus(taskId, "Ready", workspaceId, userId, "system");
-  }
 
   return task;
 }
@@ -563,15 +447,10 @@ export async function markTaskInProcess(
   id: string,
   jobId?: string,
 ): Promise<Task> {
-  const existing = await prisma.task.findUnique({ where: { id } });
-  // Preserve the current phase — prep tasks should stay in prep even while
-  // Working, so the agent context still knows it's planning, not executing.
-  const currentPhase = existing ? getTaskPhase(existing) : "execute";
   return prisma.task.update({
     where: { id },
     data: {
       status: "Working",
-      metadata: setTaskPhaseInMetadata(existing?.metadata ?? null, currentPhase),
       ...(jobId && { jobId }),
     },
   });
@@ -581,12 +460,10 @@ export async function markTaskCompleted(
   id: string,
   result: string,
 ): Promise<Task> {
-  const existing = await prisma.task.findUnique({ where: { id } });
   return prisma.task.update({
     where: { id },
     data: {
       status: "Review",
-      metadata: setTaskPhaseInMetadata(existing?.metadata ?? null, "execute"),
       result,
     },
   });
@@ -737,9 +614,9 @@ export async function createScheduledTask(
     nextRunAt = computeNextRun(data.schedule, timezone, afterTime);
   }
 
-  // Scheduled/recurring tasks skip the prep phase — the user already told us
-  // when to run and (implicitly) what to do. The first execution handles any
-  // clarification in the execution conversation, not a separate prep pass.
+  // Scheduled/recurring tasks land directly in Ready — execute mind is the
+  // implicit default (absence of metadata.phase). The first execution
+  // handles any clarification in the execution conversation.
   const status: TaskStatus = "Ready";
 
   const task = await prisma.task.create({
@@ -759,7 +636,7 @@ export async function createScheduledTask(
       parentTaskId: data.parentTaskId ?? null,
       isActive: true,
       source: data.source ?? "manual",
-      metadata: setTaskPhaseInMetadata(data.metadata ?? null, "execute"),
+      ...(data.metadata && { metadata: data.metadata as never }),
     },
   });
 

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -502,7 +502,12 @@ export async function getTaskTree(taskId: string): Promise<TaskAncestor[]> {
   let currentId: string | null = taskId;
 
   while (currentId) {
-    const task = await prisma.task.findUnique({
+    const task: {
+      id: string;
+      displayId: string | null;
+      title: string;
+      parentTaskId: string | null;
+    } | null = await prisma.task.findUnique({
       where: { id: currentId },
       select: { id: true, displayId: true, title: true, parentTaskId: true },
     });

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -914,20 +914,6 @@ export async function deactivateScheduledTask(taskId: string): Promise<void> {
 }
 
 /**
- * Confirm a scheduled task as active — user wants to keep it.
- */
-export async function confirmTaskActive(
-  taskId: string,
-  workspaceId: string,
-): Promise<void> {
-  await prisma.task.update({
-    where: { id: taskId, workspaceId },
-    data: { confirmedActive: true, unrespondedCount: 0 },
-  });
-  logger.info(`Confirmed task ${taskId} as active`);
-}
-
-/**
  * Reschedule a task to fire at a specific time (for follow-ups).
  */
 export async function rescheduleTaskAt(

--- a/apps/webapp/app/trigger/utils/stdio.ts
+++ b/apps/webapp/app/trigger/utils/stdio.ts
@@ -2,7 +2,7 @@ import { type ChildProcess, type IOType } from "node:child_process";
 import process from "node:process";
 import { type Stream } from "node:stream";
 
-import { type Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import { type Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   type JSONRPCMessage,
   JSONRPCMessageSchema,

--- a/apps/webapp/app/trigger/utils/types.ts
+++ b/apps/webapp/app/trigger/utils/types.ts
@@ -1,5 +1,5 @@
 import { type ActionStatusEnum } from "@core/types";
-import { type CoreMessage } from "ai";
+import { type ModelMessage as CoreMessage } from "ai";
 import { z } from "zod";
 
 // Define types for the MCP tool schema

--- a/apps/webapp/app/utils/json.ts
+++ b/apps/webapp/app/utils/json.ts
@@ -15,7 +15,7 @@ export function safeJsonParse(json?: string): unknown {
 export function safeJsonZodParse<T>(
   schema: z.Schema<T>,
   json: string,
-): z.SafeParseReturnType<unknown, T> | undefined {
+): ReturnType<z.ZodType<T>["safeParse"]> | undefined {
   const parsed = safeJsonParse(json);
 
   if (parsed === null) {
@@ -51,7 +51,7 @@ export async function safeBodyFromResponse<T>(
 export async function safeParseBodyFromResponse<T>(
   response: Response,
   schema: z.Schema<T>,
-): Promise<z.SafeParseReturnType<unknown, T> | undefined> {
+): Promise<ReturnType<z.ZodType<T>["safeParse"]> | undefined> {
   try {
     const unknownJson = await response.json();
 

--- a/apps/webapp/app/utils/loader-data.ts
+++ b/apps/webapp/app/utils/loader-data.ts
@@ -1,0 +1,21 @@
+import type { TypedJsonResponse } from "remix-typedjson";
+
+/**
+ * Loaders that mix `return typedjson(data)` with `return redirect(...)` end up
+ * with a return type of `TypedJsonResponse<X> | TypedResponse<never>`.
+ * `useTypedLoaderData` can't narrow that union (its conditional doesn't
+ * distribute) and returns the whole thing, breaking destructuring at every
+ * call site.
+ *
+ * `LoaderData<typeof loader>` picks out only the `TypedJsonResponse` branch.
+ * Distributes over unions, so it filters out the redirect branch automatically.
+ */
+type ExtractData<R> = R extends Response
+  ? R extends TypedJsonResponse<infer U>
+    ? U
+    : never
+  : R;
+
+export type LoaderData<L> = L extends (...args: any[]) => Promise<infer R>
+  ? ExtractData<R>
+  : never;

--- a/apps/webapp/app/utils/mcp/integration-loader.ts
+++ b/apps/webapp/app/utils/mcp/integration-loader.ts
@@ -9,6 +9,8 @@ import {
   type CustomMcpTransportStrategy,
 } from "./custom-mcp-config";
 
+export type { CustomMcpIntegration };
+
 export interface CustomMcpAccount {
   id: string;
   accountId: string;

--- a/apps/webapp/global.d.ts
+++ b/apps/webapp/global.d.ts
@@ -1,0 +1,29 @@
+/// <reference types="@remix-run/dev" />
+
+// ── @redplanethq/types: external package not vendored locally ──────────────
+declare module "@redplanethq/types" {
+  export interface WidgetConfigField {
+    key: string;
+    label: string;
+    type: "text" | "select" | string;
+    required?: boolean;
+    default?: string;
+    placeholder?: string;
+    options?: Array<{ value: string; label: string }>;
+  }
+
+  export interface WidgetMeta {
+    slug: string;
+    name: string;
+    description: string;
+    support: string[];
+    configSchema?: WidgetConfigField[];
+    [key: string]: unknown;
+  }
+}
+
+// ── Build-time virtual module emitted by Remix/Vite ───────────────────────
+declare module "./build/server/index.js" {
+  const build: unknown;
+  export = build;
+}

--- a/apps/webapp/server.ts
+++ b/apps/webapp/server.ts
@@ -29,7 +29,7 @@ async function init() {
 
   const build: any = viteDevServer
     ? () => viteDevServer.ssrLoadModule("virtual:remix/server-build")
-    : await import("./build/server/index.js");
+    : await import(/* @vite-ignore */ "./build/server/index.js" as string);
 
   const module = viteDevServer
     ? (await build()).entry.module

--- a/apps/webapp/tiptap-augment.d.ts
+++ b/apps/webapp/tiptap-augment.d.ts
@@ -1,0 +1,10 @@
+import "@tiptap/core";
+
+declare module "@tiptap/core" {
+  interface Storage {
+    markdown?: {
+      getMarkdown(): string;
+      [key: string]: unknown;
+    };
+  }
+}

--- a/apps/webapp/trigger.config.ts
+++ b/apps/webapp/trigger.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       })),
       prismaExtension({
         schema: "prisma/schema.prisma",
+        mode: "legacy",
       }),
     ],
   },

--- a/apps/webapp/tsconfig.json
+++ b/apps/webapp/tsconfig.json
@@ -31,8 +31,7 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"],
-      "@/*": ["./*"],
-      "tinykeys": ["./node_modules/tinykeys/dist/tinykeys.d.ts"]
+      "@/*": ["./*"]
     },
     "noEmit": true
   }

--- a/apps/webapp/tsconfig.json
+++ b/apps/webapp/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "exclude": [],
+  "exclude": ["prisma/migrations/**/*.ts"],
   "include": [
     "remix.env.d.ts",
     "global.d.ts",
+    "tiptap-augment.d.ts",
     "**/*.ts",
     "**/*.tsx",
     "tailwind.config.js",
@@ -30,7 +31,8 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"],
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "tinykeys": ["./node_modules/tinykeys/dist/tinykeys.d.ts"]
     },
     "noEmit": true
   }

--- a/apps/webapp/websocket.ts
+++ b/apps/webapp/websocket.ts
@@ -33,18 +33,22 @@ export function setupWebSocket(server: Server): void {
   server.on("upgrade", (req, socket, head) => {
     const url = new URL(req.url!, `http://${req.headers.host}`);
 
+    // Node's upgrade event surfaces `socket` as a Duplex, but the WebSocket
+    // server expects a net.Socket. Cast — the underlying object is correct.
+    const netSocket = socket as unknown as import("net").Socket;
+
     if (url.pathname.startsWith("/collab")) {
-      collabWss.handleUpgrade(req, socket, head, (ws) => {
+      collabWss.handleUpgrade(req, netSocket, head, (ws) => {
         hocuspocus.handleConnection(ws, req);
       });
       return;
     }
 
-    if (tryHandleBrowserCdpUpgrade(req, socket, head, browserCdpWss)) {
+    if (tryHandleBrowserCdpUpgrade(req, netSocket, head, browserCdpWss)) {
       return;
     }
 
-    if (tryHandleXtermUpgrade(req, socket, head, xtermWss)) {
+    if (tryHandleXtermUpgrade(req, netSocket, head, xtermWss)) {
       return;
     }
 

--- a/integrations/github/src/index.ts
+++ b/integrations/github/src/index.ts
@@ -107,6 +107,8 @@ class GitHubCLI extends IntegrationCLI {
       schedule: {
         frequency: '*/5 * * * *',
       },
+      toolUISupported: true,
+      enableAutoRead: true,
       auth: {
         OAuth2: {
           token_url: 'https://github.com/login/oauth/access_token',

--- a/integrations/granola/package.json
+++ b/integrations/granola/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core/granola",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Granola integration for Core",
   "main": "./bin/index.cjs",
   "type": "module",
@@ -40,7 +40,7 @@
   "dependencies": {
     "axios": "^1.7.9",
     "commander": "^12.0.0",
-    "@redplanethq/sdk": "0.1.13",
+    "@redplanethq/sdk": "0.1.21",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^3.25.4",
     "zod-to-json-schema": "^3.25.1"

--- a/integrations/granola/pnpm-lock.yaml
+++ b/integrations/granola/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.26.0
         version: 1.27.1(zod@3.25.76)
       '@redplanethq/sdk':
-        specifier: 0.1.13
-        version: 0.1.13
+        specifier: 0.1.21
+        version: 0.1.21
       axios:
         specifier: ^1.7.9
         version: 1.13.6
@@ -459,8 +459,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@redplanethq/sdk@0.1.13':
-    resolution: {integrity: sha512-Tb2/MZPdj8HpN2i7HVUQ9ploDWWnm7Cm2Dbk+Sw9Woqy/qs0815h7lNOaHc5W7K7KLEGINGdo1dnATEp9aIVow==}
+  '@redplanethq/sdk@0.1.21':
+    resolution: {integrity: sha512-9mXCt/46NcCCxa9b6dZ2Q0Gf7dW9DzRTUA++w/2szybvHFFLBQZr9PzjFlan73zFzhqeSPiWbI8zBGVLmIFrBA==}
     engines: {node: '>=18.0.0'}
 
   '@rtsao/scc@1.1.0':
@@ -2167,7 +2167,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@redplanethq/sdk@0.1.13':
+  '@redplanethq/sdk@0.1.21':
     dependencies:
       commander: 14.0.0
       zod: 3.25.76

--- a/integrations/granola/src/index.ts
+++ b/integrations/granola/src/index.ts
@@ -73,6 +73,7 @@ class GranolaCLI extends IntegrationCLI {
           server_url: "https://mcp.granola.ai/mcp",
         } as McpAuthParams,
       },
+      enableAutoRead: true,
     };
   }
 }

--- a/integrations/granola/src/schedule.ts
+++ b/integrations/granola/src/schedule.ts
@@ -1,15 +1,15 @@
-import { callGranolaToolRPC } from './utils';
+import { callGranolaToolRPC } from "./utils";
 
 function getDefaultSyncTime(): string {
   return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 }
 
 function parseMeetingContent(content: any[]): string {
-  if (!content || content.length === 0) return '';
+  if (!content || content.length === 0) return "";
   return content
-    .filter((c: any) => c.type === 'text')
+    .filter((c: any) => c.type === "text")
     .map((c: any) => c.text)
-    .join('\n');
+    .join("\n");
 }
 
 interface Meeting {
@@ -33,7 +33,7 @@ function parseMeetingsFromContent(raw: string): Meeting[] {
 
 function createActivityMessage(params: { text: string; sourceURL: string }) {
   return {
-    type: 'activity',
+    type: "activity",
     data: {
       text: params.text,
       sourceURL: params.sourceURL,
@@ -42,7 +42,7 @@ function createActivityMessage(params: { text: string; sourceURL: string }) {
 }
 
 function formatMeetingActivity(meeting: Meeting): string {
-  const title = meeting.title || 'Untitled Meeting';
+  const title = meeting.title || "Untitled Meeting";
   let text = `New meeting added: ${title}`;
   if (meeting.id) text += ` (id: ${meeting.id})`;
   return text;
@@ -50,14 +50,14 @@ function formatMeetingActivity(meeting: Meeting): string {
 
 export async function handleSchedule(
   config: Record<string, any>,
-  state: Record<string, any>,
+  state: Record<string, any>
 ): Promise<any[]> {
   const lastSyncTime = state?.lastSyncTime ?? getDefaultSyncTime();
   const activities: any[] = [];
   let latestMeetingTime = 0;
 
   try {
-    const listResult = await callGranolaToolRPC(config, 'list_meetings', {
+    const listResult = await callGranolaToolRPC(config, "list_meetings", {
       after: lastSyncTime,
     });
 
@@ -73,18 +73,18 @@ export async function handleSchedule(
       activities.push(
         createActivityMessage({
           text: formatMeetingActivity(meeting),
-          sourceURL: meeting.url ?? '',
-        }),
+          sourceURL: meeting.url ?? "",
+        })
       );
     }
   } catch (error: any) {
-    console.error('Granola schedule sync error:', error.message);
+    console.error("Granola schedule sync error:", error.message);
   }
 
   // Only advance lastSyncTime and emit state when meetings were found (mirrors Gmail behavior)
   if (latestMeetingTime > 0) {
     activities.push({
-      type: 'state',
+      type: "state",
       data: { lastSyncTime: new Date(latestMeetingTime + 1000).toISOString() },
     });
   }

--- a/integrations/ynab/package.json
+++ b/integrations/ynab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core/ynab",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "YNAB integration for CORE",
   "main": "./bin/index.js",
   "module": "./bin/index.mjs",
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@redplanethq/sdk": "0.1.9",
+    "@redplanethq/sdk": "0.1.21",
     "axios": "^1.7.9",
     "commander": "^12.0.0",
     "zod": "^3.22.4",

--- a/integrations/ynab/pnpm-lock.yaml
+++ b/integrations/ynab/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@redplanethq/sdk':
-        specifier: 0.1.9
-        version: 0.1.9
+        specifier: 0.1.21
+        version: 0.1.21
       axios:
         specifier: ^1.7.9
         version: 1.13.6
@@ -69,6 +69,9 @@ importers:
       typescript:
         specifier: ^4.7.2
         version: 4.9.5
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@18.19.130)
 
 packages:
 
@@ -201,16 +204,34 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -219,16 +240,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -237,10 +276,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -249,10 +300,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -261,10 +324,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -273,10 +348,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -285,16 +372,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -309,6 +414,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -319,6 +430,12 @@ packages:
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -333,11 +450,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -345,10 +474,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -411,6 +552,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -443,12 +588,153 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@redplanethq/sdk@0.1.9':
-    resolution: {integrity: sha512-fi+mtKTTdKPp1E6gCl9W8Ri7ZuULs0J/s5Hy5am1mg/lQ1foX+mLoBE08kr4p1LTNXJYJFsY7J4PHMe16AcN/g==}
+  '@redplanethq/sdk@0.1.21':
+    resolution: {integrity: sha512-9mXCt/46NcCCxa9b6dZ2Q0Gf7dW9DzRTUA++w/2szybvHFFLBQZr9PzjFlan73zFzhqeSPiWbI8zBGVLmIFrBA==}
     engines: {node: '>=18.0.0'}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -495,10 +781,29 @@ packages:
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -511,6 +816,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -542,6 +851,9 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -577,6 +889,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -596,9 +912,16 @@ packages:
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -621,6 +944,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -658,6 +984,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -672,6 +1002,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -715,6 +1049,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -848,9 +1187,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -933,6 +1279,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -940,6 +1289,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -1002,6 +1355,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1102,6 +1459,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -1134,6 +1495,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -1169,6 +1533,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1176,12 +1544,21 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1199,20 +1576,36 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1241,6 +1634,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1252,6 +1649,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -1273,12 +1674,25 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -1321,9 +1735,16 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -1354,6 +1775,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -1363,6 +1788,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1391,6 +1819,11 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -1453,13 +1886,30 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1481,9 +1931,16 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1496,6 +1953,17 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1525,6 +1993,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -1546,6 +2018,9 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -1561,6 +2036,67 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -1583,6 +2119,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -1600,6 +2141,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -1797,52 +2342,103 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -1851,10 +2447,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1863,13 +2465,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -1932,6 +2546,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1965,11 +2583,89 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@redplanethq/sdk@0.1.9':
+  '@redplanethq/sdk@0.1.21':
     dependencies:
       commander: 14.0.0
+      zod: 3.25.76
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@sinclair/typebox@0.27.10': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2030,7 +2726,40 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
 
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -2046,6 +2775,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   argparse@2.0.1: {}
 
@@ -2101,6 +2832,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@1.1.0: {}
+
   async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
@@ -2138,6 +2871,8 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2159,10 +2894,24 @@ snapshots:
 
   caniuse-lite@1.0.30001777: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   color-convert@2.0.1:
     dependencies:
@@ -2179,6 +2928,8 @@ snapshots:
   commander@14.0.0: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2214,6 +2965,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2229,6 +2984,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -2327,6 +3084,32 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2501,7 +3284,23 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -2579,6 +3378,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2596,6 +3397,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -2663,6 +3466,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  human-signals@5.0.0: {}
 
   ignore@5.3.2: {}
 
@@ -2768,6 +3573,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@3.0.0: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -2800,6 +3607,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -2827,17 +3636,32 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 1.3.1
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
+
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -2852,17 +3676,32 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@4.0.0: {}
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
   minimist@1.2.8: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
   node-releases@2.0.36: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   object-inspect@1.13.4: {}
 
@@ -2901,6 +3740,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2920,6 +3763,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -2934,9 +3781,17 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-type@4.0.0: {}
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -2977,7 +3832,19 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
 
@@ -2997,11 +3864,19 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  react-is@18.3.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3038,6 +3913,37 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -3122,9 +4028,19 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
   slash@3.0.0: {}
 
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -3156,7 +4072,13 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   supports-color@7.2.0:
     dependencies:
@@ -3167,6 +4089,12 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tinybench@2.9.0: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3198,6 +4126,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.1.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -3234,6 +4164,8 @@ snapshots:
 
   typescript@4.9.5: {}
 
+  ufo@1.6.4: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -3252,6 +4184,67 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vite-node@1.6.1(@types/node@18.19.130):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@18.19.130)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@18.19.130):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.60.4
+    optionalDependencies:
+      '@types/node': 18.19.130
+      fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@18.19.130):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@18.19.130)
+      vite-node: 1.6.1(@types/node@18.19.130)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.130
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -3298,6 +4291,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
@@ -3307,6 +4305,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:

--- a/packages/emails/src/transports/aws-ses.ts
+++ b/packages/emails/src/transports/aws-ses.ts
@@ -28,7 +28,7 @@ export class AwsSesMailTransport implements MailTransport {
         to,
         replyTo: replyTo,
         subject,
-        html: render(react),
+        html: await render(react),
       });
     }
     catch (error) {

--- a/packages/emails/src/transports/smtp.ts
+++ b/packages/emails/src/transports/smtp.ts
@@ -29,7 +29,7 @@ export class SmtpMailTransport implements MailTransport {
         to,
         replyTo: replyTo,
         subject,
-        html: render(react),
+        html: await render(react),
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "compilerOptions": {},
-  "extends": "expo/tsconfig.base"
-}


### PR DESCRIPTION
## Summary

Flips the agent's task lifecycle from prep-first to **execute-first**. Tasks land in execute mind by default. The agent opts in to plan mind via `enter_plan_mode` only when it can't see the shape of the work; it writes the plan into the task description and calls `exit_plan_mode` to return.

## What changed

### Lifecycle
- **Phase is agent-driven, not status-driven.** Only `"prep"` is stored in `metadata.phase`; absence = execute. `setTaskPhaseInMetadata("execute")` deletes the field. Status transitions do NOT change phase — that prevents an `update_task(Waiting)` from plan mind silently flipping back to execute.
- **Subtasks default Ready and run in parallel.** No more sequential queueing. Subtasks are for divide-and-conquer only; blockers go on the task itself via Waiting. Parent stays Working until all subtasks Done, then auto-Done.
- **Canonical wake-up rule**, owned by `changeTaskStatus` + `createTask`:
  - `→ Todo / Waiting / Review`: clear `nextRunAt` + cancel wake-up. Todo is the backlog state, no auto-buffer.
  - `→ Ready (no schedule)`: set `nextRunAt = now+2min`, enqueue scheduled wake-up. Same 2-min editing buffer wherever Ready is set.
  - `→ Ready (with schedule)`: leave `nextRunAt` alone — `scheduleNextTaskOccurrence` owns it.

### New tools / skills
- `enter_plan_mode(reason)` and `exit_plan_mode()` in `task-tools.ts`. **Phase-conditional registration**: enter only when phase=execute, exit only when phase=prep.
- New built-in `Decompose Task` skill (`skills.builtin.ts`). Ships with the agent, never seeded to DB, never shown in the user's skills UI. Loaded via `get_skill` using `builtin:*` IDs.

### Prompts
- Re-split into \`<task_planning>\` (the old PREP RULES content, framing changed to \"you self-promoted here\") and \`<task_execution>\` (new execute-first rules: SHAPE OF THE INPUT, ROUTING, parallel decomposition, CODING SESSIONS).
- **SKILL CHECK FIRST** is the global rule at the top of the \`<skills>\` block — scan against intent and load via \`get_skill\` on every turn, before delegating / composing / calling any tool. Per-task-block reinforcements removed.
- \`capabilities.ts\` SUBTASKS section rewritten for the parallel model.

### Cleanups
- \`metadata.skillId\` plumbing removed everywhere (\`create_task\`, \`add_reminder\`, \`backfill-morning-brief\`, \`workspace.server\`, agent context). The agent picks skills purely by intent matching.
- \`canTransition\` simplified: phase parameter dropped. Agent cannot set Working / Done / Todo / Ready — only Waiting and Review.
- Buffer-expiry dispatch in \`scheduled-task.logic.ts\` simplified to status-only. \`startPrepFromBuffer\` and \`startExecutionFromReadyBuffer\` merged into a single \`startExecutionFromBuffer\`.
- \`inferNewPhase\`, \`inferPhaseFromStatus\`, \`getNextBacklogSubtask\` deleted (no callers).

## Test plan
- [x] \`task-lifecycle.test.ts\` — 34/34 passing (5 tests rewritten or inverted for the new model)
- [x] \`task-phase.test.ts\` — 18/18 passing
- [x] \`session-tools.test.ts\` — 7/7 passing
- [ ] Manual: create a Todo task — verify it sits idle (no buffer). Move to Ready — verify 2-min buffer fires execute.
- [ ] Manual: agent picks up an ambiguous task — verify it calls \`enter_plan_mode\`, sees the planning block on next turn, writes a plan, calls \`exit_plan_mode\`, executes.
- [ ] Manual: agent decomposes a complex task — verify subtasks run in parallel, parent auto-Done when all complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)