### PR TITLE
fix(llm): make local Ollama work end-to-end for self-hosted deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,9 @@ MODEL=gpt-5.2-2025-12-11
 # Provider routing (optional)
 CHAT_PROVIDER=openai
 # EMBEDDINGS_PROVIDER=openai
+# Local Ollama: set CHAT_PROVIDER=ollama, OLLAMA_URL=http://localhost:11434 (bare host —
+# no /api or /v1 suffix, the app appends them), MODEL=<pulled model>, EMBEDDINGS_PROVIDER=ollama,
+# EMBEDDING_MODEL_SIZE = the model's real dim (nomic-embed-text=768)
 # Override tolerant JSON parsing behavior (optional). Controls error tolerance when parsing LLM responses
 # Set to 'true' to allow lenient parsing, or leave empty for strict mode: true/1/yes or false/0/no
 LLM_TOLERANT_OUTPUT=

--- a/apps/webapp/app/lib/model.server.ts
+++ b/apps/webapp/app/lib/model.server.ts
@@ -65,6 +65,10 @@ function toOllamaApiBase(url: string): string {
  * Falls back to default chat provider from DB cache.
  */
 function inferProvider(modelId: string): string {
+  // Model IDs like `mistral-7b` or `deepseek-r1` are ambiguous — pullable via Ollama
+  // or callable against the hosted provider. When CHAT_PROVIDER=ollama is explicitly
+  // set, env wins over prefix so bare IDs go local. Use `<provider>/<model>` router
+  // strings to force hosted routing in an Ollama-default deploy
   if (getDefaultChatProviderType() === "ollama") return "ollama";
   if (modelId.startsWith("gpt-") || modelId.startsWith("o3") || modelId.startsWith("o4"))
     return "openai";

--- a/apps/webapp/app/lib/model.server.ts
+++ b/apps/webapp/app/lib/model.server.ts
@@ -1,5 +1,5 @@
 import { embed, type ModelMessage } from "ai";
-import { type z } from "zod";
+import { z } from "zod";
 import {
   createOpenAI,
   type OpenAIResponsesProviderOptions,
@@ -50,10 +50,22 @@ export interface AvailableModel {
 // ---------------------------------------------------------------------------
 
 /**
+ * ollama-ai-provider-v2 posts to `${baseURL}/chat` and expects the base to end
+ * in `/api` (its own default is http://localhost:11434/api). OLLAMA_URL is the
+ * bare host (the embedding path appends `/v1`), so add `/api` here for the
+ * chat/completions provider. Idempotent.
+ */
+function toOllamaApiBase(url: string): string {
+  const base = url.replace(/\/+$/, "");
+  return base.endsWith("/api") ? base : `${base}/api`;
+}
+
+/**
  * Infer provider from a bare model ID (no "/" prefix).
  * Falls back to default chat provider from DB cache.
  */
 function inferProvider(modelId: string): string {
+  if (getDefaultChatProviderType() === "ollama") return "ollama";
   if (modelId.startsWith("gpt-") || modelId.startsWith("o3") || modelId.startsWith("o4"))
     return "openai";
   if (modelId.startsWith("claude-")) return "anthropic";
@@ -126,7 +138,7 @@ export const getModel = (takeModel?: string) => {
     if (!modelId) {
       throw new Error("No chat model configured for Ollama.");
     }
-    const ollama = createOllama({ baseURL: ollamaUrl });
+    const ollama = createOllama({ baseURL: toOllamaApiBase(ollamaUrl) });
     return ollama(modelId);
   }
 
@@ -260,7 +272,7 @@ export function createAgent(
   // BYOK Ollama: apiKey field carries the base URL (Ollama has no API key).
   if (options?.apiKey && provider === "ollama") {
     const modelId = getModelId(modelString);
-    const ollama = createOllama({ baseURL: options.apiKey });
+    const ollama = createOllama({ baseURL: toOllamaApiBase(options.apiKey) });
     return new Agent({
       id: `model-call-${modelString}`,
       name: `Model Call (${modelString})`,
@@ -454,6 +466,26 @@ export async function makeStructuredModelCall<T extends z.ZodType>(
   }
 }
 
+/**
+ * Render a Zod schema as a JSON Schema string for the prompt. Self-hosted/proxy
+ * models don't get strict structured output, so they otherwise guess key names
+ * from the prompt's prose examples (e.g. emitting `subject`/`object`/`fact_text`
+ * instead of the schema's `source`/`target`/`fact`). Showing the exact JSON
+ * Schema makes them use the right keys. Falls back to "" if conversion fails.
+ */
+function schemaInstruction(schema: z.ZodType): string {
+  try {
+    const jsonSchema = z.toJSONSchema(schema, { io: "output" });
+    return (
+      "\n\nThe object MUST conform EXACTLY to this JSON Schema — use these property " +
+      "names verbatim and do not rename, add, or omit keys:\n" +
+      JSON.stringify(jsonSchema)
+    );
+  } catch {
+    return "";
+  }
+}
+
 async function structuredCallWithTolerantParsing<T extends z.ZodType>(
   schema: T,
   messages: ModelMessage[],
@@ -461,10 +493,12 @@ async function structuredCallWithTolerantParsing<T extends z.ZodType>(
   temperature?: number,
   apiKey?: string,
 ): Promise<{ object: z.infer<T>; usage: any }> {
+  const schemaHint = schemaInstruction(schema);
   const jsonPreamble =
     "Return ONLY a single valid JSON object that matches the requested schema. " +
     "Do not wrap it in Markdown fences. Do not include extra text. " +
-    "Include every required key; use null for nullable fields; use [] for empty arrays.";
+    "Include every required key; use null for nullable fields; use [] for empty arrays." +
+    schemaHint;
 
   const agentOpts = apiKey ? { apiKey } : undefined;
   const agent = createAgent(modelString, jsonPreamble, undefined, agentOpts);
@@ -483,7 +517,8 @@ async function structuredCallWithTolerantParsing<T extends z.ZodType>(
   const repairAgent = createAgent(
     modelString,
     "You are a JSON repair assistant. Convert the user's content into a single valid JSON object. " +
-    "Return ONLY the JSON object, with no Markdown fences and no extra text.",
+      "Return ONLY the JSON object, with no Markdown fences and no extra text." +
+      schemaHint,
     undefined,
     agentOpts,
   );

--- a/apps/webapp/app/services/llm-provider.server.ts
+++ b/apps/webapp/app/services/llm-provider.server.ts
@@ -446,6 +446,7 @@ export async function resolveApiKeyForWorkspace(
  * Duplicated from model.server.ts to avoid circular imports.
  */
 function inferProviderFromModelId(modelId: string): string {
+  if (env.CHAT_PROVIDER === "ollama") return "ollama";
   if (
     modelId.startsWith("gpt-") ||
     modelId.startsWith("o3") ||
@@ -523,13 +524,24 @@ export async function resolveModelConfig(
   modelString: string,
   workspaceId: string | null | undefined,
 ): Promise<ResolvedModelConfig> {
-  const { toRouterString, getProvider } = await import("~/lib/model.server");
+  const { toRouterString, getProvider, getModel } = await import("~/lib/model.server");
 
   const providerType = getProvider(modelString);
   const { apiKey, isBYOK } = await resolveApiKeyForWorkspace(
     workspaceId,
     providerType,
   );
+
+  // Mastra's router has no local-Ollama provider (only ollama-cloud), so a local
+  // Ollama needs a concrete AI SDK model instance built with its base URL — the
+  // same path createAgent/getModel uses — instead of a router string that fails.
+  if (providerType === "ollama") {
+    return {
+      modelConfig: getModel(modelString) as unknown as ModelConfig,
+      isBYOK,
+    };
+  }
+
   const routerString = toRouterString(modelString) as `${string}/${string}`;
 
   if (isBYOK && apiKey) {


### PR DESCRIPTION
### Summary
Deployments configured for local Ollama (`CHAT_PROVIDER=ollama`) can't actually use it: chat 404s, the main conversation agent falls back to OpenAI, and memory ingestion fails to parse structured output. This fixes the four defects that block the local-Ollama path, with no change to the OpenAI / Anthropic / Google hosted paths.

### Current Issue
- **Chat 404** — `getModel` passes bare `OLLAMA_URL` to `createOllama` → requests hit `…/chat` instead of `…/api/chat` (`ollama-ai-provider-v2` expects the base to end in `/api`).
- **`gpt-` models route to OpenAI** — provider inference matches the `gpt-` prefix before honoring `CHAT_PROVIDER=ollama`, so `gpt-oss:120b` goes to `api.openai.com`.
- **Main agent can't reach local Ollama** — `resolveModelConfig` hands Mastra a router string, but Mastra's registry only has `ollama-cloud`, no local `ollama`.
- **Structured output fails** — the tolerant path never shows the model the schema, so it emits wrong keys (`subject`/`object`/`fact_text` vs `source`/`target`/`fact`) → `No object generated…`.

### Expected Behavior
- `CHAT_PROVIDER=ollama` routes chat, sub-agents, background jobs, and ingestion through the local Ollama endpoint.
- Bare ids (incl. `gpt-`-prefixed Ollama models) are treated as Ollama when Ollama is the configured provider.
- The conversation agent talks to local Ollama directly.
- Structured-extraction calls validate first pass.

### Proposed Fix
- `model.server.ts`: `toOllamaApiBase` helper at both `createOllama` sites; `inferProvider` short-circuits to `ollama` under `CHAT_PROVIDER=ollama`; `schemaInstruction` injects the JSON Schema into the tolerant-parsing prompt only.
- `llm-provider.server.ts`: mirror the inference short-circuit in `inferProviderFromModelId`; `resolveModelConfig` returns a built model instance for `ollama` (mirrors existing `createAgent`/`getModel` behavior).
- `.env.example`: commented local-Ollama hint (bare `OLLAMA_URL`; `EMBEDDING_MODEL_SIZE` must match the model dim).
- Note: for `CHAT_PROVIDER=ollama` we build the model directly because Mastra's router has no local-Ollama provider; the `ollama-cloud` gateway.