### PR TITLE
feat(mcp): expose skills as MCP tools (list_skills, get_skill)

### DIFF
--- a/apps/webapp/app/services/mcp.server.ts
+++ b/apps/webapp/app/services/mcp.server.ts
@@ -15,6 +15,7 @@ import { MCPSessionManager } from "~/utils/mcp/session-manager";
 import { TransportManager } from "~/utils/mcp/transport-manager";
 import { callMemoryTool, memoryTools } from "~/utils/mcp/memory";
 import { reminderTools, callReminderTool } from "~/utils/mcp/reminder";
+import { skillTools, callSkillTool } from "~/utils/mcp/skill";
 import { logger } from "~/services/logger.service";
 import { type Response, type Request } from "express";
 import { ensureBillingInitialized } from "./billing.server";
@@ -88,6 +89,9 @@ async function createMcpServer(
 
     // Add reminder tools
     tools = tools.concat(reminderTools as any);
+
+    // Add skill tools
+    tools = tools.concat(skillTools as any);
 
     return {
       tools,
@@ -164,6 +168,12 @@ async function createMcpServer(
     if (reminderToolNames.includes(name)) {
       const timezone = await getUserTimezone(userId);
       return await callReminderTool(name, args, workspaceId, timezone);
+    }
+
+    // Handle skill tools
+    const skillToolNames = ["list_skills", "get_skill"];
+    if (skillToolNames.includes(name)) {
+      return await callSkillTool(name, args, workspaceId);
     }
 
     throw new Error(`Unknown tool: ${name}`);

--- a/apps/webapp/app/utils/mcp/skill.ts
+++ b/apps/webapp/app/utils/mcp/skill.ts
@@ -1,0 +1,198 @@
+/**
+ * MCP Skill Tools
+ *
+ * Provides list_skills and get_skill tools for MCP clients.
+ *
+ * Exposes a workspace's stored CORE skills so coding agents (Claude Code,
+ * Codex, Cursor, ...) can discover and load skill instructions on demand
+ * instead of users manually pasting skill content into their sessions.
+ *
+ */
+
+import {
+  listSkills,
+  getSkill,
+  findSkillBySlug,
+} from "~/services/skills.server";
+import { logger } from "~/services/logger.service";
+
+function titleToSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+export const skillTools = [
+  {
+    name: "list_skills",
+    description:
+      "List the user's available CORE skills. Returns each skill's title, short description (if any), and ID. Use the returned IDs with get_skill to load full instructions. Paginated via optional cursor; default limit 50.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "number",
+          description:
+            "Maximum number of skills to return. Defaults to 30 if omitted.",
+        },
+        cursor: {
+          type: "string",
+          description:
+            "Pagination cursor returned by a previous list_skills call. Omit on the first call.",
+        },
+      },
+    },
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "get_skill",
+    description:
+      "Load a CORE skill's full instructions. Look up by skillId (preferred) OR by name (the skill's title; matched case-insensitively against a slugified form). Returns the skill title followed by its markdown content. Use this when the user asks to run / apply / follow a saved skill, or when you need a stored procedure or set of rules to complete a task.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        skillId: {
+          type: "string",
+          description: "The skill's ID (preferred). Get IDs via list_skills.",
+        },
+        name: {
+          type: "string",
+          description:
+            "The skill's title. Used only when skillId is not provided. Matched case-insensitively against existing skill titles.",
+        },
+      },
+    },
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      destructiveHint: false,
+    },
+  },
+];
+
+export async function callSkillTool(
+  toolName: string,
+  args: any,
+  workspaceId: string,
+) {
+  try {
+    switch (toolName) {
+      case "list_skills": {
+        const { limit, cursor } = args ?? {};
+        logger.info(`Listing skills for workspace ${workspaceId}`);
+
+        const result = await listSkills(workspaceId, { limit, cursor });
+
+        if (result.skills.length === 0) {
+          return {
+            content: [{ type: "text", text: "No skills found." }],
+          };
+        }
+
+        const skillsList = result.skills
+          .map((s, i) => {
+            const meta = (s.metadata as Record<string, unknown>) ?? {};
+            const shortDescription =
+              typeof meta.shortDescription === "string"
+                ? ` — ${meta.shortDescription}`
+                : "";
+            return `${i + 1}. ${s.title}${shortDescription} [id:${s.id}]`;
+          })
+          .join("\n");
+
+        const footer =
+          result.hasMore && result.nextCursor
+            ? `\n\nMore results available. Pass cursor=${result.nextCursor} to list_skills to fetch the next page.`
+            : "";
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Skills (${result.skills.length} of ${result.totalCount}):\n${skillsList}${footer}`,
+            },
+          ],
+        };
+      }
+
+      case "get_skill": {
+        const { skillId, name } = args ?? {};
+
+        if (!skillId && !name) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Provide either skillId or name to look up a skill.",
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        logger.info(
+          `Getting skill for workspace ${workspaceId} (skillId=${skillId ?? "-"}, name=${name ?? "-"})`,
+        );
+
+        let skill: { id: string; title: string; content: string } | null = null;
+
+        if (skillId) {
+          const found = await getSkill(skillId, workspaceId);
+          if (found) {
+            skill = {
+              id: found.id,
+              title: found.title,
+              content: found.content,
+            };
+          }
+        }
+
+        if (!skill && name) {
+          skill = await findSkillBySlug(workspaceId, titleToSlug(name));
+        }
+
+        if (!skill) {
+          return {
+            content: [{ type: "text", text: "Skill not found." }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `## Skill: ${skill.title}\n\n${skill.content}`,
+            },
+          ],
+        };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown skill tool: ${toolName}` }],
+          isError: true,
+        };
+    }
+  } catch (error) {
+    logger.error("Skill tool error", {
+      error,
+      toolName,
+      workspaceId,
+    });
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to ${toolName}: ${error instanceof Error ? error.message : "Unknown error"}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Exposes user-defined CORE skills as MCP tools so coding agents (Claude Code, Codex, Cursor, etc.) can discover and load skill instructions on demand instead of requiring users to manually paste skill content into their sessions.

## What's Included

### New MCP Tools (Read-Only)

#### `list_skills`

Returns a paginated list of skills available in the current workspace.

**Response includes:**

* `id`
* `title`
* `shortDescription` (when available)
* `cursor` for fetching the next page when additional results exist

#### `get_skill`

Retrieves the full markdown content of a skill.

**Lookup options:**

* `skillId` (preferred)
* `name`

Name-based lookups are slugified and resolved using the existing `findSkillBySlug` helper.

---

### New Module

#### `app/utils/mcp/skill.ts`

Introduces a new MCP module following the same structure as existing `reminder.ts` and `memory.ts` implementations.

**Contains:**

* `skillTools` array of MCP tool definitions

  * `name`
  * `description`
  * `inputSchema`
  * `annotations`
* `callSkillTool(toolName, args, workspaceId)` dispatcher
* MCP-compliant responses in the form:

  ```ts
  { content, isError? }
  ```

---

### MCP Server Registration

#### `services/mcp.server.ts`

Updated to register and route the new skill tools.

**Changes:**

* Import `skillTools` and `callSkillTool`
* Append `skillTools` to the `ListToolsRequestSchema` response after `reminderTools`
* Route `list_skills` and `get_skill` requests through `callSkillTool` within the `CallToolRequestSchema` handler

---

### Reuse of Existing Infrastructure

No business logic was duplicated.

All database access is delegated to existing helpers in `skills.server.ts`:

* `listSkills`
* `getSkill`
* `findSkillBySlug`

Additional implementation details:

* Workspace scoping is inherited from the MCP session (`workspaceId`)
* Both tools are marked as:

  * `readOnlyHint: true`
  * `idempotentHint: true`
  * `destructiveHint: false`

---

## File Structure

```text
apps/webapp/app/
├── utils/
│   └── mcp/
│       └── skill.ts          # New: MCP tool definitions + dispatcher
└── services/
    └── mcp.server.ts         # Updated: registration and routing
```

---

## Scope

This PR implements the two read-only operations explicitly called out in the issue:

* List available skills
* Retrieve a skill by ID or name

CRUD operations (`create_skill`, `update_skill`, `delete_skill`) were intentionally excluded to keep the scope focused and can be introduced in a follow-up PR.

---


https://github.com/user-attachments/assets/8b9bec91-cce7-4075-bd13-555c368ae573

Closes #872
