### PR TITLE
fix(cli): align gateway banners with new "Sidebar → Gateways" UI path

### DIFF
--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -372,7 +372,7 @@ fn maybe_notify_gateway_setup<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     }
 
     let title = "Set up your CORE gateway";
-    let body = "CORE needs a local gateway to run coding sessions and tools on this Mac. Open CORE → Settings → Gateway to register one.";
+    let body = "CORE needs a local gateway to run coding sessions and tools on this Mac. Open CORE → Sidebar → Gateways → New gateway to register one.";
 
     let result = n.builder().title(title).body(body).show();
 

--- a/packages/cli/src/commands/gateway/register.tsx
+++ b/packages/cli/src/commands/gateway/register.tsx
@@ -122,7 +122,7 @@ export async function runRegister(opts: RegisterOptions): Promise<RegisterResult
 			`${chalk.bold('baseUrl:')}     ${baseUrl}`,
 			`${chalk.bold('securityKey:')} ${chalk.yellow(securityKey)}`,
 			'',
-			chalk.dim('Paste baseUrl + securityKey into CORE → Settings → Gateways.'),
+			chalk.dim('Paste baseUrl + securityKey into CORE → Sidebar → Gateways → New gateway.'),
 			chalk.dim('This is the ONLY time the raw key is shown — it is not stored locally.'),
 		].join('\n'),
 		'Gateway registered',

--- a/packages/cli/src/utils/env-bootstrap.ts
+++ b/packages/cli/src/utils/env-bootstrap.ts
@@ -208,7 +208,7 @@ export function bootstrapFromEnv(): string[] {
 			`  ${printRawKey}`,
 			'',
 			'Paste this (with your gateway URL) into the webapp:',
-			'  Settings → Gateways → New gateway',
+			'  Sidebar → Gateways → New gateway',
 			'',
 			'Set COREBRAIN_GATEWAY_SECURITY_KEY env var to provide your own.',
 			'='.repeat(64),

--- a/packages/cli/src/utils/setup/docker.ts
+++ b/packages/cli/src/utils/setup/docker.ts
@@ -246,7 +246,7 @@ export async function setupDockerGateway(): Promise<DockerSetupResult | {cancell
 		p.note(
 			[
 				`Container running at ${localUrl} (public: ${publicBaseUrl}).`,
-				'Register later via Settings → Gateways in the webapp,',
+				'Register later via Sidebar → Gateways → Register in the webapp,',
 				`or with the security key in ${composeDir}/.env:`,
 				`  ${chalk.yellow(securityKey)}`,
 			].join('\n'),

--- a/packages/cli/src/utils/setup/railway.ts
+++ b/packages/cli/src/utils/setup/railway.ts
@@ -251,7 +251,7 @@ export async function setupRailwayGateway(): Promise<RailwaySetupResult | {cance
 				`Railway service running at ${baseUrl}.`,
 				`Security key: ${chalk.yellow(securityKey)}`,
 				'',
-				'Register later via Settings → Gateways → Register.',
+				'Register later via Sidebar → Gateways → Register.',
 			].join('\n'),
 			'Not registered',
 		);


### PR DESCRIPTION
## Summary

* Update CLI banners in `gateway register`, `env-bootstrap`, and the Railway / Docker setup flows to point at 
**Sidebar → Gateways → New Gateway**.


## Files Changed

* `packages/cli/src/commands/gateway/register.tsx`
* `packages/cli/src/utils/env-bootstrap.ts`
* `packages/cli/src/utils/setup/railway.ts`
* `packages/cli/src/utils/setup/docker.ts`
* `apps/tauri/src-tauri/src/lib.rs`

Closes #835
