### PR TITLE
fix(voice-inbox): surface write failures, enrich list, auto-clear on task resolution

### DIFF
--- a/apps/webapp/app/routes/api.v1.inbox.tsx
+++ b/apps/webapp/app/routes/api.v1.inbox.tsx
@@ -54,6 +54,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         taskId: true,
         channelType: true,
         createdAt: true,
+        task: { select: { displayId: true, title: true } },
       },
     }),
   ]);

--- a/apps/webapp/app/services/agent/tools/message-tools.ts
+++ b/apps/webapp/app/services/agent/tools/message-tools.ts
@@ -191,7 +191,7 @@ export function getMessageTools(
           // these rows.
           // ---------------------------------------------------------------
           try {
-            await prisma.voiceInboxMessage.create({
+            const row = await prisma.voiceInboxMessage.create({
               data: {
                 userId,
                 workspaceId,
@@ -199,10 +199,25 @@ export function getMessageTools(
                 message,
                 channelType,
               },
+              select: { id: true },
+            });
+            logger.info("[send_message] Wrote inbox row", {
+              id: row.id,
+              userId,
+              workspaceId,
+              taskId: currentTaskId ?? null,
+              channelType,
             });
           } catch (inboxError) {
-            logger.warn("[send_message] Failed to write inbox row", {
-              error: inboxError,
+            logger.error("[send_message] Failed to write inbox row", {
+              error:
+                inboxError instanceof Error
+                  ? { message: inboxError.message, stack: inboxError.stack }
+                  : inboxError,
+              userId,
+              workspaceId,
+              taskId: currentTaskId ?? null,
+              channelType,
             });
           }
 

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -436,6 +436,36 @@ export async function changeTaskStatus(
     data: { status },
   });
 
+  // Clear any unread voice inbox rows that belong to this task once it's
+  // resolved. Two trigger conditions:
+  //   - status moved to Done (task is finished, no need to nag)
+  //   - status moved out of Waiting (the blocker was acknowledged)
+  // The pill should stop showing stale "task is waiting on you" updates after
+  // the user acts.
+  const shouldClearInbox =
+    status === "Done" ||
+    (current.status === "Waiting" && status !== "Waiting");
+  if (shouldClearInbox) {
+    try {
+      const cleared = await prisma.voiceInboxMessage.updateMany({
+        where: { taskId, checked: null },
+        data: { checked: new Date() },
+      });
+      if (cleared.count > 0) {
+        logger.info(
+          `Auto-checked ${cleared.count} voice inbox row(s) for task ${taskId} (${current.status} -> ${status})`,
+        );
+      }
+    } catch (err) {
+      logger.warn("Failed to auto-check voice inbox rows on status change", {
+        err,
+        taskId,
+        from: current.status,
+        to: status,
+      });
+    }
+  }
+
   return task;
 }
 


### PR DESCRIPTION
## Summary

Three small but related fixes to the voice-inbox pill flow, prompted by `send_message` calls landing in Slack but no rows showing up in `VoiceInboxMessage`.

- **`message-tools.ts`** — the inbox write was wrapped in `try/catch` with a `logger.warn` that silently swallowed prisma errors, so any FK or migration failure was invisible. Upgraded to `logger.error` with the prisma message + stack, plus a success `logger.info` carrying the row id. After one more send-from-task, the logs will say definitively whether the insert ran.
- **`api.v1.inbox.tsx`** — added `task: { displayId, title }` to the list response so the pill UI can label rows by task instead of a bare uuid (parallels what `api.v1.inbox.summarise.tsx` already includes).
- **`task.server.changeTaskStatus`** — after the status update, stamp `checked = NOW()` on unchecked `VoiceInboxMessage` rows for that taskId when either:
  - new status is `Done`, or
  - prior status was `Waiting` and new status isn't `Waiting` (unblock).

  Stops the pill nagging about resolved/acknowledged tasks. Wrapped in `try/catch` with `logger.warn` so a transient DB hiccup can't break the status transition.

### Caveat — direct status setters

Only `changeTaskStatus` is hooked. Direct setters (`markTaskInProcess` → Working, `markTaskCompleted` → Review, `markTaskFailed`, `updateTaskStatus`) bypass it. If "completed" should also clear inbox when a task hits Review (via `markTaskCompleted`), say the word and I'll duplicate the hook.

## Test plan

- [ ] Trigger a slack `send_message` from a background task; confirm logs show `[send_message] Wrote inbox row { id, … }` (or a clear `Failed to write inbox row` error if the migration / FK is broken).
- [ ] Hit `GET /api/v1/inbox` and confirm items now include `task.displayId` and `task.title`.
- [ ] Move a task with unchecked inbox rows to `Done` and confirm those rows get `checked` stamped.
- [ ] Move a task with unchecked inbox rows from `Waiting` to `Ready` (unblock) and confirm those rows get `checked` stamped.
- [ ] Move a task to `Working` from `Ready` and confirm inbox rows are NOT cleared (the hook only fires for Done / out-of-Waiting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)