### PR TITLE
feat(tasks): add <log> append zone and background-mode description gate

### DIFF
--- a/apps/webapp/app/components/editor/extensions/log-extension.tsx
+++ b/apps/webapp/app/components/editor/extensions/log-extension.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { Node, mergeAttributes } from "@tiptap/core";
+import {
+  ReactNodeViewRenderer,
+  NodeViewWrapper,
+  NodeViewContent,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+function LogNodeView({ node }: NodeViewProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const isEmpty =
+    node.content.size === 0 ||
+    (node.childCount === 1 &&
+      node.firstChild?.type.name === "paragraph" &&
+      node.firstChild?.content.size === 0);
+  if (isEmpty) return null;
+
+  return (
+    <NodeViewWrapper
+      className="my-2 rounded-lg border border-border"
+      data-type="log"
+    >
+      <button
+        type="button"
+        contentEditable={false}
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex w-full items-center gap-1.5 border-b border-border bg-grayAlpha-50 px-3 py-2 text-xs font-medium text-muted-foreground select-none hover:bg-grayAlpha-100"
+      >
+        {collapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
+        Log
+      </button>
+      {!collapsed && (
+        <NodeViewContent className="px-3 py-2 prose prose-sm max-w-full" />
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+export const LogNode = Node.create({
+  name: "log",
+  group: "block",
+  content: "block+",
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: "log" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["log", mergeAttributes(HTMLAttributes), 0];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(LogNodeView);
+  },
+});

--- a/apps/webapp/app/components/editor/page-editor.client.tsx
+++ b/apps/webapp/app/components/editor/page-editor.client.tsx
@@ -34,6 +34,7 @@ import {
 } from "~/components/editor/extensions/widget-node-extension";
 import { PlanNode } from "~/components/editor/extensions/plan-extension";
 import { OutcomeNode } from "~/components/editor/extensions/outcome-extension";
+import { LogNode } from "~/components/editor/extensions/log-extension";
 import type { WidgetOption } from "~/components/overview/types";
 
 const lowlight = createLowlight(all);
@@ -125,6 +126,7 @@ function buildExtensions(
     WidgetNode,
     PlanNode,
     OutcomeNode,
+    LogNode,
     Collaboration.configure({ document: ydoc }),
   ];
 }

--- a/apps/webapp/app/services/__tests__/description-zones.test.ts
+++ b/apps/webapp/app/services/__tests__/description-zones.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+import { mergeStructuredSections } from "~/services/coding-task.server";
+
+// Helper: build a doc node from a list of structured zones + optional prose.
+type Doc = { type: string; content: Node[] };
+type Node = { type: string; content?: Node[]; text?: string };
+
+const para = (text: string): Node => ({
+  type: "paragraph",
+  content: [{ type: "text", text }],
+});
+
+const zone = (type: "plan" | "outcome" | "log", paragraphs: string[]): Node => ({
+  type,
+  content: paragraphs.map(para),
+});
+
+const doc = (...children: Node[]): Doc => ({ type: "doc", content: children });
+
+// Pull the text out of a zone's paragraphs so assertions stay readable.
+function textsIn(node: Node): string[] {
+  return (node.content ?? []).map(
+    (p) => (p.content?.[0] as Node | undefined)?.text ?? "",
+  );
+}
+
+function findZone(d: Doc, type: string): Node | undefined {
+  return d.content.find((n) => n.type === type);
+}
+
+function findAllZones(d: Doc, type: string): Node[] {
+  return d.content.filter((n) => n.type === type);
+}
+
+describe("mergeStructuredSections — <plan>/<outcome> REPLACE semantics", () => {
+  it("replaces existing <plan> content in place when input has <plan>", () => {
+    const existing = doc(
+      para("user prose above"),
+      zone("plan", ["old step 1", "old step 2"]),
+      para("user prose below"),
+    );
+    const input = doc(zone("plan", ["new step"]));
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(merged.content).toHaveLength(3);
+    expect(merged.content[0].type).toBe("paragraph");
+    expect(merged.content[1].type).toBe("plan");
+    expect(merged.content[2].type).toBe("paragraph");
+    expect(textsIn(merged.content[1])).toEqual(["new step"]);
+  });
+
+  it("appends <plan> at end if none exists", () => {
+    const existing = doc(para("user prose"));
+    const input = doc(zone("plan", ["a plan"]));
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(merged.content).toHaveLength(2);
+    expect(merged.content[1].type).toBe("plan");
+    expect(textsIn(merged.content[1])).toEqual(["a plan"]);
+  });
+
+  it("replaces <outcome> in place, leaves <plan> untouched", () => {
+    const existing = doc(
+      zone("plan", ["the plan stays"]),
+      zone("outcome", ["old outcome"]),
+    );
+    const input = doc(zone("outcome", ["new outcome"]));
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(textsIn(findZone(merged, "plan")!)).toEqual(["the plan stays"]);
+    expect(textsIn(findZone(merged, "outcome")!)).toEqual(["new outcome"]);
+  });
+
+  it("updates plan AND outcome in a single call when both present in input", () => {
+    const existing = doc(
+      zone("plan", ["old plan"]),
+      zone("outcome", ["old outcome"]),
+    );
+    const input = doc(
+      zone("plan", ["new plan"]),
+      zone("outcome", ["new outcome"]),
+    );
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(textsIn(findZone(merged, "plan")!)).toEqual(["new plan"]);
+    expect(textsIn(findZone(merged, "outcome")!)).toEqual(["new outcome"]);
+  });
+});
+
+describe("mergeStructuredSections — <log> APPEND semantics", () => {
+  it("appends children to existing <log> instead of replacing", () => {
+    const existing = doc(zone("log", ["day 1: 3 emails"]));
+    const input = doc(zone("log", ["day 2: 5 emails"]));
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    const log = findZone(merged, "log")!;
+    expect(textsIn(log)).toEqual(["day 1: 3 emails", "day 2: 5 emails"]);
+  });
+
+  it("accumulates across many sequential appends (the recurring task case)", () => {
+    let acc = doc(para("user-authored brief"));
+    for (let i = 1; i <= 7; i++) {
+      acc = mergeStructuredSections(acc, doc(zone("log", [`day ${i}`]))) as Doc;
+    }
+
+    const log = findZone(acc, "log")!;
+    expect(textsIn(log)).toEqual([
+      "day 1",
+      "day 2",
+      "day 3",
+      "day 4",
+      "day 5",
+      "day 6",
+      "day 7",
+    ]);
+    // User prose untouched
+    expect(acc.content[0].type).toBe("paragraph");
+    expect((acc.content[0].content?.[0] as Node | undefined)?.text).toBe(
+      "user-authored brief",
+    );
+  });
+
+  it("inserts new <log> at end when none exists", () => {
+    const existing = doc(
+      para("user prose"),
+      zone("plan", ["the plan"]),
+    );
+    const input = doc(zone("log", ["first entry"]));
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(merged.content).toHaveLength(3);
+    expect(merged.content[2].type).toBe("log");
+    expect(textsIn(merged.content[2])).toEqual(["first entry"]);
+    // Plan untouched
+    expect(textsIn(findZone(merged, "plan")!)).toEqual(["the plan"]);
+  });
+
+  it("does not affect <plan> or <outcome> when only <log> is in input", () => {
+    const existing = doc(
+      zone("plan", ["the plan"]),
+      zone("outcome", ["the outcome"]),
+      zone("log", ["entry 1"]),
+    );
+    const input = doc(zone("log", ["entry 2"]));
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(textsIn(findZone(merged, "plan")!)).toEqual(["the plan"]);
+    expect(textsIn(findZone(merged, "outcome")!)).toEqual(["the outcome"]);
+    expect(textsIn(findZone(merged, "log")!)).toEqual(["entry 1", "entry 2"]);
+  });
+
+  it("can append to <log> AND replace <outcome> in one call", () => {
+    const existing = doc(
+      zone("log", ["mon", "tue", "wed"]),
+      zone("outcome", ["old summary"]),
+    );
+    const input = doc(
+      zone("log", ["thu"]),
+      zone("outcome", ["new summary"]),
+    );
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(textsIn(findZone(merged, "log")!)).toEqual([
+      "mon",
+      "tue",
+      "wed",
+      "thu",
+    ]);
+    expect(textsIn(findZone(merged, "outcome")!)).toEqual(["new summary"]);
+  });
+});
+
+describe("mergeStructuredSections — input validation", () => {
+  it("throws when input has two <plan> nodes", () => {
+    const existing = doc();
+    const input = doc(zone("plan", ["a"]), zone("plan", ["b"]));
+
+    expect(() => mergeStructuredSections(existing, input)).toThrow(
+      /at most one <plan>/,
+    );
+  });
+
+  it("throws when input has two <log> nodes", () => {
+    const existing = doc();
+    const input = doc(zone("log", ["a"]), zone("log", ["b"]));
+
+    expect(() => mergeStructuredSections(existing, input)).toThrow(
+      /at most one <log>/,
+    );
+  });
+
+  it("throws when input has two <outcome> nodes", () => {
+    const existing = doc();
+    const input = doc(zone("outcome", ["a"]), zone("outcome", ["b"]));
+
+    expect(() => mergeStructuredSections(existing, input)).toThrow(
+      /at most one <outcome>/,
+    );
+  });
+});
+
+describe("mergeStructuredSections — user content preservation", () => {
+  it("drops non-structured input nodes (e.g. paragraphs)", () => {
+    const existing = doc(para("user prose"));
+    const input = doc(
+      para("agent's casual text — should be ignored"),
+      zone("plan", ["the plan"]),
+    );
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    // Only the original user prose + the new <plan> survive.
+    expect(merged.content).toHaveLength(2);
+    expect(merged.content[0].type).toBe("paragraph");
+    expect((merged.content[0].content?.[0] as Node).text).toBe("user prose");
+    expect(merged.content[1].type).toBe("plan");
+  });
+
+  it("preserves user prose position when replacing a zone", () => {
+    const existing = doc(
+      para("intro from user"),
+      zone("plan", ["v1"]),
+      para("user note between zones"),
+      zone("outcome", ["v1 outcome"]),
+      para("user footer"),
+    );
+    const input = doc(
+      zone("plan", ["v2"]),
+      zone("outcome", ["v2 outcome"]),
+    );
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    expect(merged.content.map((n) => n.type)).toEqual([
+      "paragraph",
+      "plan",
+      "paragraph",
+      "outcome",
+      "paragraph",
+    ]);
+    expect((merged.content[0].content?.[0] as Node).text).toBe(
+      "intro from user",
+    );
+    expect((merged.content[2].content?.[0] as Node).text).toBe(
+      "user note between zones",
+    );
+    expect((merged.content[4].content?.[0] as Node).text).toBe("user footer");
+  });
+
+  it("does NOT dedupe pre-existing duplicate zones (only first match is touched)", () => {
+    // Edge case: the merger replaces/appends into the FIRST matching node.
+    // If a doc already has two <plan>s (weird but possible), the second is
+    // left as-is. Documenting this so future changes don't quietly alter it.
+    const existing = doc(
+      zone("plan", ["first plan"]),
+      zone("plan", ["second plan"]),
+    );
+    const input = doc(zone("plan", ["new"]));
+
+    const merged = mergeStructuredSections(existing, input) as Doc;
+
+    const plans = findAllZones(merged, "plan");
+    expect(plans).toHaveLength(2);
+    expect(textsIn(plans[0])).toEqual(["new"]);
+    expect(textsIn(plans[1])).toEqual(["second plan"]);
+  });
+});

--- a/apps/webapp/app/services/__tests__/update-task-background-gate.test.ts
+++ b/apps/webapp/app/services/__tests__/update-task-background-gate.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests the background/scheduled-run gate inside update_task.
+ *
+ * On a background execution turn (scheduled task fire, or any background
+ * agent run), the agent must not be able to rewrite <plan> or <outcome>
+ * on the task description — the plan is frozen until the user is back in
+ * the loop. Only <log> writes (append) and clearLog are permitted.
+ *
+ * Live-chat turns (isBackgroundExecution falsy) are unrestricted.
+ *
+ * We mock every collaborator that would otherwise touch the DB or page
+ * store. The gate is meant to short-circuit before any write call lands,
+ * so mocks for those writes double as a regression check: if the gate
+ * leaks, the mocks would be called.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const taskServerMocks = vi.hoisted(() => ({
+  resolveTaskId: vi.fn(),
+  getTaskById: vi.fn(),
+  updateTask: vi.fn(),
+  updateScheduledTask: vi.fn(),
+  changeTaskStatus: vi.fn(),
+  createTask: vi.fn(),
+  createScheduledTask: vi.fn(),
+  deleteTask: vi.fn(),
+  rescheduleTaskAt: vi.fn(),
+  getScheduledTasksForWorkspace: vi.fn(),
+  recalculateTasksForTimezone: vi.fn(),
+  getTaskTree: vi.fn(),
+  reparentTask: vi.fn(),
+  getTasks: vi.fn(),
+}));
+vi.mock("~/services/task.server", () => taskServerMocks);
+
+const codingTaskMocks = vi.hoisted(() => ({
+  upsertPageSection: vi.fn(async () => {}),
+  clearPageSection: vi.fn(async () => {}),
+}));
+vi.mock("~/services/coding-task.server", () => codingTaskMocks);
+
+const contentMocks = vi.hoisted(() => ({
+  setPageContentFromHtml: vi.fn(async () => {}),
+  getPageContentAsHtml: vi.fn(async () => ""),
+}));
+vi.mock("~/services/hocuspocus/content.server", () => contentMocks);
+
+vi.mock("~/services/page.server", () => ({
+  findOrCreateTaskPage: vi.fn(async () => ({ id: "page-1" })),
+  findOrCreateDailyPage: vi.fn(async () => ({ id: "daily-1" })),
+}));
+
+vi.mock("~/services/logger.service", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("~/services/conversation.server", () => ({
+  createEmptyConversation: vi.fn(),
+}));
+
+vi.mock("~/lib/queue-adapter.server", () => ({
+  enqueueTask: vi.fn(),
+}));
+
+vi.mock("~/db.server", () => ({
+  prisma: {},
+}));
+
+vi.mock("~/env.server", () => ({
+  env: {},
+}));
+
+vi.mock("~/services/task.phase", () => ({
+  getTaskPhase: vi.fn(() => "execute"),
+  setTaskPhaseInMetadata: vi.fn(),
+}));
+
+vi.mock("~/utils/schedule-utils", () => ({
+  computeNextRun: vi.fn(),
+  getRecurrenceIntervalMinutes: vi.fn(() => 60),
+  formatScheduleForUser: vi.fn(),
+}));
+
+import { getTaskTools } from "~/services/agent/tools/task-tools";
+
+function tools(isBackgroundExecution: boolean) {
+  return getTaskTools(
+    "ws-1",
+    "user-1",
+    isBackgroundExecution,
+    "UTC",
+    "email",
+    ["email"],
+    60,
+    [],
+    "tk-current",
+    "channel",
+  );
+}
+
+async function runUpdate(
+  isBackgroundExecution: boolean,
+  args: Record<string, unknown>,
+) {
+  const t = tools(isBackgroundExecution);
+  const tool = t.update_task as { execute: (a: unknown) => Promise<string> };
+  return await tool.execute({ taskId: "tk-test", ...args });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  taskServerMocks.resolveTaskId.mockResolvedValue("task-uuid-1");
+  taskServerMocks.getTaskById.mockResolvedValue({
+    id: "task-uuid-1",
+    pageId: "page-1",
+    schedule: "FREQ=DAILY",
+    workspaceId: "ws-1",
+    userId: "user-1",
+  });
+});
+
+describe("update_task — background gate REJECTS <plan> and <outcome>", () => {
+  it("rejects <plan> write on background run", async () => {
+    const result = await runUpdate(true, {
+      description: "<plan>new plan</plan>",
+    });
+
+    expect(result).toMatch(/<plan> and <outcome> writes are not allowed/);
+    expect(codingTaskMocks.upsertPageSection).not.toHaveBeenCalled();
+    expect(contentMocks.setPageContentFromHtml).not.toHaveBeenCalled();
+  });
+
+  it("rejects <outcome> write on background run", async () => {
+    const result = await runUpdate(true, {
+      description: "<outcome>some result</outcome>",
+    });
+
+    expect(result).toMatch(/<plan> and <outcome> writes are not allowed/);
+    expect(codingTaskMocks.upsertPageSection).not.toHaveBeenCalled();
+  });
+
+  it("rejects legacy <output> tag on background run (same alias as <outcome>)", async () => {
+    const result = await runUpdate(true, {
+      description: "<output>weekly summary</output>",
+    });
+
+    expect(result).toMatch(/<plan> and <outcome> writes are not allowed/);
+    expect(codingTaskMocks.upsertPageSection).not.toHaveBeenCalled();
+  });
+
+  it("rejects mixed <log>+<plan> on background run (plan poisons the whole call)", async () => {
+    const result = await runUpdate(true, {
+      description: "<log>today</log><plan>rewrite</plan>",
+    });
+
+    expect(result).toMatch(/<plan> and <outcome> writes are not allowed/);
+    expect(codingTaskMocks.upsertPageSection).not.toHaveBeenCalled();
+  });
+
+  it("rejects replaceDescription: true on background run", async () => {
+    const result = await runUpdate(true, {
+      description: "<log>safe content</log>",
+      replaceDescription: true,
+    });
+
+    expect(result).toMatch(/replaceDescription is not allowed/);
+    expect(contentMocks.setPageContentFromHtml).not.toHaveBeenCalled();
+  });
+});
+
+describe("update_task — background gate ALLOWS <log> and clearLog", () => {
+  it("allows pure <log> write on background run", async () => {
+    const result = await runUpdate(true, {
+      description: "<log>day 3: 2 new emails</log>",
+    });
+
+    expect(result).toMatch(/description updated/);
+    expect(codingTaskMocks.upsertPageSection).toHaveBeenCalledTimes(1);
+    expect(codingTaskMocks.upsertPageSection).toHaveBeenCalledWith(
+      "page-1",
+      "<log>day 3: 2 new emails</log>",
+    );
+  });
+
+  it("allows clearLog: true on background run", async () => {
+    const result = await runUpdate(true, {
+      clearLog: true,
+    });
+
+    expect(result).toMatch(/log cleared/);
+    expect(codingTaskMocks.clearPageSection).toHaveBeenCalledTimes(1);
+    expect(codingTaskMocks.clearPageSection).toHaveBeenCalledWith(
+      "page-1",
+      "log",
+    );
+  });
+
+  it("allows <log> append AND clearLog in the same call (the weekly send pattern)", async () => {
+    const result = await runUpdate(true, {
+      description: "<log>final day</log>",
+      clearLog: true,
+    });
+
+    // Both ops happen, in order — append then wipe is unusual but explicitly
+    // permitted. The typical "send and clear" call would be clearLog alone
+    // (after using send_message to deliver the body of the existing log).
+    expect(result).toMatch(/description updated/);
+    expect(result).toMatch(/log cleared/);
+    expect(codingTaskMocks.upsertPageSection).toHaveBeenCalledTimes(1);
+    expect(codingTaskMocks.clearPageSection).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("update_task — live-chat (isBackgroundExecution=false) is UNRESTRICTED", () => {
+  it("allows <plan> write in live chat", async () => {
+    const result = await runUpdate(false, {
+      description: "<plan>v2 plan from user request</plan>",
+    });
+
+    expect(result).toMatch(/description updated/);
+    expect(codingTaskMocks.upsertPageSection).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows <outcome> write in live chat", async () => {
+    const result = await runUpdate(false, {
+      description: "<outcome>shipped</outcome>",
+    });
+
+    expect(result).toMatch(/description updated/);
+    expect(codingTaskMocks.upsertPageSection).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows <log> write in live chat too", async () => {
+    const result = await runUpdate(false, {
+      description: "<log>manual entry</log>",
+    });
+
+    expect(result).toMatch(/description updated/);
+    expect(codingTaskMocks.upsertPageSection).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("update_task — scheduling fields bundled with description (the bug path)", () => {
+  it("routes description through upsertPageSection, not setPageContentFromHtml (the fix)", async () => {
+    // Before the fix, passing any scheduling field alongside description
+    // routed into updateScheduledTask, which wholesale-replaced the page
+    // via setPageContentFromHtml — obliterating <plan>. The fix splits the
+    // two: scheduling fields go to updateScheduledTask, description goes
+    // through upsertPageSection (zone-aware merge).
+    const result = await runUpdate(false, {
+      description: "<log>entry from scheduling-tied update</log>",
+      isActive: true,
+    });
+
+    expect(result).toMatch(/description updated/);
+    expect(taskServerMocks.updateScheduledTask).toHaveBeenCalledTimes(1);
+    // Critical: the description must NOT have been passed down into
+    // updateScheduledTask (which would wholesale-replace) — it's handled
+    // separately by upsertPageSection.
+    const callArgs = taskServerMocks.updateScheduledTask.mock.calls[0][2];
+    expect(callArgs.description).toBeUndefined();
+    expect(codingTaskMocks.upsertPageSection).toHaveBeenCalledTimes(1);
+    expect(contentMocks.setPageContentFromHtml).not.toHaveBeenCalled();
+  });
+
+  it("background + scheduling field + <plan> in description → still rejected", async () => {
+    const result = await runUpdate(true, {
+      description: "<plan>sneaking a plan rewrite</plan>",
+      isActive: true,
+    });
+
+    expect(result).toMatch(/<plan> and <outcome> writes are not allowed/);
+    // No writes of any kind should fire.
+    expect(taskServerMocks.updateScheduledTask).not.toHaveBeenCalled();
+    expect(codingTaskMocks.upsertPageSection).not.toHaveBeenCalled();
+    expect(contentMocks.setPageContentFromHtml).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -616,8 +616,9 @@ RULES:
   2. send_message that names the task title so the user can identify it. Example: "Task '${linkedTask.title}' is waiting: <reason>. <what's needed to continue>"
 - DO NOT create independent top-level tasks. ${isSubtask ? "You are a subtask — just do your work." : "Subtasks under this task only."}
 - DO NOT mark Done — that's the user's call.
-- DESCRIPTION UPDATES. Only at meaningful boundaries: Waiting (record what's blocked), decomposition (record the plan), Review (record the outcome), or when the user provides new context. Never write error logs, debug output, or transient state into the description.
-- PRESERVE USER CONTENT. You may edit the <plan> and <outcome> zones freely, and anything the user has SPECIFICALLY asked you to change. Everything else the user authored stays as-is — do not silently rewrite, reorder, or delete it just because you're touching the description for another reason.
+- DESCRIPTION UPDATES. Only at meaningful boundaries: Waiting (record what's blocked), decomposition (record the plan), Review (record the outcome), or when the user provides new context. For recurring tasks that accumulate per-run data, use <log>...</log> (append) and clearLog at cycle boundaries. Never write error logs, debug output, or transient state into the description.
+- PRESERVE USER CONTENT. You may edit the <plan>, <outcome>, and <log> zones, and anything the user has SPECIFICALLY asked you to change. Everything else the user authored stays as-is — do not silently rewrite, reorder, or delete it just because you're touching the description for another reason.
+- BACKGROUND MODE. You are in background execution. update_task will reject <plan> and <outcome> writes — only <log> and clearLog are allowed. The plan is frozen until the user is back in the loop. If the plan genuinely needs to change, mark Waiting and ask.
 
 CODING SESSIONS:
 The gateway sub-agent owns all sleep/polling for coding sessions. You do NOT sleep or poll directly.
@@ -676,7 +677,7 @@ This IS the task — don't create or search for other tasks about this topic. If
       : `**The trigger description IS your runbook — the user pre-authorized it.** The user wrote this task knowing it would fire on a schedule, so any actions it specifies (auto-send, archive, delete, reply, draft, label, etc.) are already approved. Execute the steps as written. Do NOT ask "should I do X?" and do NOT end the turn with "say 'do it' if you want me to" for actions the description already covers — that breaks the recurring flow because the user can't keep re-approving every occurrence. Only stop and ask if a step has a genuine blocking gap that changes the outcome (a referenced field is missing, a destination is truly ambiguous). Cosmetic mismatches and obvious defaults are NOT blockers.`;
 
     systemPrompt += `\n\n<trigger_context>
-A trigger has fired: "${triggerContext.reminderText}"${isTriggerFollowUp ? `\nThis is a FOLLOW-UP trigger. One follow-up level is the maximum — if the issue is still unresolved, mark the task Waiting and notify the user via send_message.` : ""}${isRecurring ? `\nThis is a RECURRING task. Send results via send_message only and leave the task description untouched. The system handles the recurring lifecycle, so use Review for status changes; the next occurrence is scheduled automatically.` : ""}
+A trigger has fired: "${triggerContext.reminderText}"${isTriggerFollowUp ? `\nThis is a FOLLOW-UP trigger. One follow-up level is the maximum — if the issue is still unresolved, mark the task Waiting and notify the user via send_message.` : ""}${isRecurring ? `\nThis is a RECURRING task running in background mode. The <plan> is frozen — update_task will reject <plan>/<outcome> writes. Deliver results via send_message. If the runbook says to accumulate per-run data across occurrences, append to <log>...</log>; if it says to clear at a cycle boundary (e.g. weekly summary then reset), set clearLog: true after delivery. The system handles the recurring lifecycle; use Review for status, and the next occurrence is scheduled automatically.` : ""}
 
 ${surfacingOrRunbookRule}
 
@@ -697,7 +698,7 @@ The \`think\` tool is your decision filter. It tells you whether to speak, what 
 
 6. Apply \`createFollowUps\`${isTriggerFollowUp ? ` (ignore these — this trigger is itself a follow-up; the chain stops here)` : ` by calling \`create_task\` with \`isFollowUp=true\` and \`parentTaskId\` set to the triggering task's ID (these are reschedules of the existing task, not new ones)`}.
 
-7. Apply \`updateTasks\` via \`update_task\`${isRecurring ? ` — except skip description updates and skip \`status: "Done"\` (the system loops recurring tasks automatically)` : ""}.
+7. Apply \`updateTasks\` via \`update_task\`${isRecurring ? ` — restricted on recurring runs: description writes are limited to <log> (append) and clearLog; <plan>/<outcome> are rejected. Skip \`status: "Done"\` (the system loops recurring tasks automatically)` : ""}.
 
 8. Apply \`silentActions\` (log entries, state updates).
 

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -243,11 +243,15 @@ When they mention a task by topic, list first, then update.
 TASK DESCRIPTION UPDATES:
 Do NOT update the task description on every interaction. Only update it at meaningful phase boundaries:
 - **Blocked/Waiting**: record what was attempted and what's needed from the user
-- **Plan produced**: save the plan to the description as HTML with \`<plan>...</plan>\` tags (update_task upserts that section)
-- **Review/Done**: record the output as HTML with \`<outcome>...</outcome>\` tags
+- **Plan produced**: save the plan to the description as HTML with \`<plan>...</plan>\` tags (update_task replaces that zone)
+- **Review/Done**: record the output as HTML with \`<outcome>...</outcome>\` tags (update_task replaces that zone)
+- **Rolling run data**: when a task accumulates per-run data across many fires (e.g. a daily recurring task logging today's findings, summarized weekly), use \`<log>...</log>\` tags. APPEND semantics — each write concatenates onto the existing log. To wipe the log at a cycle boundary (e.g. after the weekly send_message), call update_task with \`clearLog: true\` — that wipes <log> only, leaves <plan>/<outcome>/user prose untouched.
 - **User provides new context**: when the user adds requirements or constraints, append their input. EXCEPTION: do NOT append the user's reply when you're about to call unblock_task — unblock_task already records the resolution as "Approved: …" in the description, so a separate append duplicates the same content.
-Do NOT update the description just because you interacted with the task. The description is a living brief, not a log.
-What you may edit in the description: the \`<plan>\` and \`<outcome>\` zones (always), and anything the user has SPECIFICALLY asked you to change. Everything else the user authored stays as-is — do not silently rewrite, reorder, or delete it just because you're touching the description for another reason.
+Do NOT update the description just because you interacted with the task. The description is a living brief plus (optionally) a rolling log — not a play-by-play.
+What you may edit in the description: the \`<plan>\`, \`<outcome>\`, and \`<log>\` zones, and anything the user has SPECIFICALLY asked you to change. Everything else the user authored stays as-is — do not silently rewrite, reorder, or delete it just because you're touching the description for another reason.
+
+BACKGROUND / SCHEDULED RUNS — DESCRIPTION RULES:
+When the turn is a scheduled-fire (\`scheduled_task_fired\`) or any background execution, the plan is FROZEN. update_task will REJECT <plan> and <outcome> writes — only <log> (append) and \`clearLog\` are allowed. Rationale: the user isn't in the loop to object, and a recurring task's plan is user-authored configuration. If the recurring runbook calls for accumulating data, append to <log>; if it calls for "send and clear" at a boundary, set \`clearLog: true\` after delivery. If you genuinely need to change the plan, mark the task Waiting and ask the user — don't rewrite their plan unattended.
 
 SCHEDULING & REMINDERS:
 Scheduled tasks are how you stay on top of things. Your own wake-up calls — to check on delegations, follow up on pending items, nudge them about something important.

--- a/apps/webapp/app/services/agent/tools/task-tools.ts
+++ b/apps/webapp/app/services/agent/tools/task-tools.ts
@@ -24,7 +24,10 @@ import {
   setPageContentFromHtml,
   getPageContentAsHtml,
 } from "~/services/hocuspocus/content.server";
-import { upsertPageSection } from "~/services/coding-task.server";
+import {
+  upsertPageSection,
+  clearPageSection,
+} from "~/services/coding-task.server";
 import { createEmptyConversation } from "~/services/conversation.server";
 import { logger } from "~/services/logger.service";
 import { Prisma, type TaskStatus } from "@prisma/client";
@@ -518,14 +521,17 @@ FOLLOW-UP: Set isFollowUp=true and parentTaskId to reschedule an existing task.`
 
 DESCRIPTION CONTENT (the task body the user reads):
 
-The description has two structured zones the agent owns. Pass HTML in the \`description\` parameter containing one or both of these tags:
+The description has three structured zones the agent owns. Pass HTML in the \`description\` parameter containing one or more of these tags:
 
-- <plan>...</plan> — the current plan or step-by-step approach you are following. Rewrite this in full whenever the plan changes.
-- <outcome>...</outcome> — the result the user reads when the work is done. Replace each run.
+- <plan>...</plan> — the current plan or step-by-step approach. REPLACE semantics: each write overwrites the zone.
+- <outcome>...</outcome> — the result the user reads when the work is done. REPLACE semantics: each write overwrites the zone.
+- <log>...</log> — rolling per-run data (e.g. a daily recurring task accumulating entries through the week). APPEND semantics: each write's children are concatenated onto the existing log.
 
-Strict input contract: at most ONE <plan> tag and at most ONE <outcome> tag per call. Multiple of either returns an error and the description is not updated. To update both at once, send HTML containing both tags in a single call.
+Strict input contract: at most ONE of each tag per call. Multiple of any one type returns an error and the description is not updated. To touch more than one zone at once, send HTML containing all the tags in a single call.
 
 Anything outside these tags is silently dropped — the user's prose elsewhere on the page is sacred and never modified by this tool. Do NOT use the description for status updates, error logs, or transient state; status updates go via send_message.
+
+BACKGROUND / SCHEDULED EXECUTION: when this turn is a scheduled-fire or background run (not a live chat with the user), the tool will REJECT <plan> and <outcome> writes. Only <log> and \`clearLog\` are allowed — the plan is frozen until the user is back in the loop. Use <log> for per-run data; if the recurring runbook says "send and clear" at a boundary, set \`clearLog: true\` to wipe the log after delivery.
 
 REPARENTING: Pass newParentId to move a task under a different parent (or null to make it a root task). This deletes the task and recreates it under the new parent — the task gets a new displayId. Subtasks are also deleted.`,
       inputSchema: z.object({
@@ -543,13 +549,19 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
           .string()
           .optional()
           .describe(
-            "Task description as HTML — provide <plan>...</plan> and/or <outcome>...</outcome> tags to upsert those sections. At most one of each per call. Other content is dropped.",
+            "Task description as HTML — provide <plan>...</plan>, <outcome>...</outcome>, and/or <log>...</log> tags to upsert those sections. At most one of each per call. <plan>/<outcome> replace; <log> appends. Other content is dropped. On background/scheduled runs, <plan> and <outcome> are rejected — use <log> only.",
           ),
         replaceDescription: z
           .boolean()
           .optional()
           .describe(
-            "Set true to replace the entire description verbatim (only valid for task creation flows where the agent writes the user's prose from a brief). Default: false — description is merged via <plan>/<outcome> upsert.",
+            "Set true to replace the entire description verbatim (only valid for task creation flows where the agent writes the user's prose from a brief). Default: false — description is merged via <plan>/<outcome>/<log> upsert. Rejected on background/scheduled runs.",
+          ),
+        clearLog: z
+          .boolean()
+          .optional()
+          .describe(
+            "Set true to wipe the <log> zone only (leaves <plan>, <outcome>, and the user's prose untouched). Use at the end of a recurring cycle (e.g. weekly send → clear). Allowed on background/scheduled runs.",
           ),
         schedule: z.string().optional().describe("New RRule schedule string"),
         isActive: z
@@ -575,6 +587,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
         title,
         description,
         replaceDescription,
+        clearLog,
         schedule,
         isActive,
         maxOccurrences,
@@ -604,6 +617,24 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
           const currentTask = await getTaskById(resolvedTaskId);
           const isRecurring = !!currentTask?.schedule;
 
+          // BACKGROUND GUARD: when this turn is a scheduled-fire or background
+          // run, the plan is frozen — only <log> writes (and clearLog) are
+          // allowed. Reject <plan>/<outcome> writes and replaceDescription
+          // before they touch the page. <log>-only descriptions still pass.
+          if (isBackgroundExecution) {
+            if (replaceDescription) {
+              return `Description update rejected: replaceDescription is not allowed on background/scheduled runs. The plan is frozen until the user is in the loop. Use <log>...</log> for per-run data, or omit description entirely.`;
+            }
+            if (description !== undefined) {
+              const hasPlanOrOutcome = /<(plan|outcome|output)\b/i.test(
+                description,
+              );
+              if (hasPlanOrOutcome) {
+                return `Description update rejected: <plan> and <outcome> writes are not allowed on background/scheduled runs. The plan is frozen until the user is in the loop. Use <log>...</log> for per-run data; if the runbook says to clear at a cycle boundary, pass clearLog: true.`;
+              }
+            }
+          }
+
           // Description updates go through the same safeguards regardless of
           // whether scheduling fields are also being changed — never let the
           // scheduling branch wholesale-replace the page.
@@ -614,12 +645,16 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
               if (existingHtml.length > 0) {
                 const similarity = textSimilarity(existingHtml, description);
                 if (similarity < 0.3) {
-                  return `Description update rejected: the new content is too different from the existing description (similarity: ${Math.round(similarity * 100)}%). Omit replaceDescription and pass <plan>/<outcome> tags to upsert sections instead.`;
+                  return `Description update rejected: the new content is too different from the existing description (similarity: ${Math.round(similarity * 100)}%). Omit replaceDescription and pass <plan>/<outcome>/<log> tags to upsert sections instead.`;
                 }
               }
               await setPageContentFromHtml(currentTask.pageId, description);
             } else {
-              await upsertPageSection(currentTask.pageId, description);
+              try {
+                await upsertPageSection(currentTask.pageId, description);
+              } catch (err) {
+                return `Description update failed: ${err instanceof Error ? err.message : String(err)}`;
+              }
             }
           }
 
@@ -631,6 +666,10 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             endDate !== undefined ||
             updateChannel !== undefined
           ) {
+            // Scheduling fields and description go through different code paths
+            // — updateScheduledTask handles scheduling, while description must
+            // route through upsertPageSection (the zone-aware merger) so we
+            // don't wholesale-replace the page and obliterate <plan>.
             await updateScheduledTask(resolvedTaskId, workspaceId, {
               title,
               schedule,
@@ -641,6 +680,14 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
             });
           } else if (title) {
             await updateTask(resolvedTaskId, { title }, false);
+          }
+
+          // Clear the rolling <log> zone, if requested. Runs after description
+          // upsert so a single call can append a final log entry, deliver via
+          // send_message elsewhere, then wipe — though typical usage is one or
+          // the other.
+          if (clearLog && currentTask?.pageId) {
+            await clearPageSection(currentTask.pageId, "log");
           }
 
           if (status) {
@@ -679,6 +726,7 @@ REPARENTING: Pass newParentId to move a task under a different parent (or null t
           if (status) parts.push(`status → ${status}`);
           if (title) parts.push(`title updated`);
           if (description !== undefined) parts.push(`description updated`);
+          if (clearLog) parts.push(`log cleared`);
           if (schedule) parts.push(`schedule updated`);
           if (isActive !== undefined)
             parts.push(isActive ? "resumed" : "paused");

--- a/apps/webapp/app/services/coding-task.server.ts
+++ b/apps/webapp/app/services/coding-task.server.ts
@@ -13,22 +13,34 @@ import { logger } from "~/services/logger.service";
 // tag, so both incoming HTML variants resolve to `type: "outcome"` by
 // the time we get here. The set is keyed on tiptap node types, not HTML
 // tag names.
-const STRUCTURED_TYPES = new Set(["plan", "outcome"]);
+const REPLACE_TYPES = new Set(["plan", "outcome"]);
+const APPEND_TYPES = new Set(["log"]);
+const STRUCTURED_TYPES = new Set([...REPLACE_TYPES, ...APPEND_TYPES]);
 
 type DocNode = { type: string; content?: DocNode[]; [key: string]: unknown };
 
 /**
- * Merge structured agent sections (`plan`, `outcome`) from `input` into `existing`.
+ * Merge structured agent sections from `input` into `existing`.
  *
- * Strict input contract: at most one top-level <plan> and at most one
- * top-level <outcome> per call. Multiple of either throws — the agent sees
- * the error and self-corrects. The legacy <output> tag is still accepted
- * on input (OutcomeNode.parseHTML maps it to type "outcome").
+ * Zones and their semantics:
+ * - <plan>, <outcome> — REPLACE: each call overwrites the zone's content.
+ *   Designed for "current plan" and "current outcome" snapshots.
+ * - <log> — APPEND: the input's <log> children are concatenated onto the
+ *   existing <log>'s children. Designed for rolling per-run data (e.g. a
+ *   recurring task accumulating daily entries).
  *
- * For each (≤1) plan/outcome node in the input: replace the FIRST matching
- * node in `existing` in place (position preserved); append at end if no
- * match exists. Everything else in `input` is dropped — the user's prose
- * is never modified. Pre-existing duplicates in `existing` are NOT deduped.
+ * Strict input contract: at most one top-level node per structured type per
+ * call. Multiple of any one type throws — the agent sees the error and
+ * self-corrects. The legacy <output> tag is still accepted on input
+ * (OutcomeNode.parseHTML maps it to type "outcome").
+ *
+ * For each (≤1) structured node in the input:
+ *   - REPLACE types: overwrite the FIRST matching node in `existing` in
+ *     place (position preserved); append at end if no match exists.
+ *   - APPEND types: concatenate children onto the FIRST matching node in
+ *     `existing`; insert the new node at end if no match exists.
+ * Everything else in `input` is dropped — the user's prose is never
+ * modified. Pre-existing duplicates in `existing` are NOT deduped.
  *
  * Returns a new document; inputs are not mutated.
  */
@@ -66,8 +78,17 @@ export function mergeStructuredSections(
       inputStructured.has(cloned.type) &&
       !usedTypes.has(cloned.type)
     ) {
-      const replacement = inputStructured.get(cloned.type)!;
-      merged.push({ ...cloned, content: replacement.content ?? [] });
+      const incoming = inputStructured.get(cloned.type)!;
+      if (APPEND_TYPES.has(cloned.type)) {
+        const existingChildren = (cloned.content ?? []) as DocNode[];
+        const incomingChildren = (incoming.content ?? []) as DocNode[];
+        merged.push({
+          ...cloned,
+          content: [...existingChildren, ...incomingChildren],
+        });
+      } else {
+        merged.push({ ...cloned, content: incoming.content ?? [] });
+      }
       usedTypes.add(cloned.type);
     } else {
       merged.push(cloned);
@@ -80,6 +101,29 @@ export function mergeStructuredSections(
   }
 
   return { type: existing.type ?? "doc", content: merged };
+}
+
+/**
+ * Remove a specific structured zone from the page document, leaving
+ * everything else (user prose, other zones) untouched. Used by the
+ * `clearLog` flag on `update_task` to wipe the rolling log without
+ * touching plan/outcome or the user's content.
+ */
+export async function clearPageSection(
+  pageId: string,
+  zoneType: "log" | "plan" | "outcome",
+): Promise<void> {
+  const existingHtml = (await getPageContentAsHtml(pageId)) || "";
+  if (!existingHtml) return;
+  const existingDoc = htmlToTiptapJson(existingHtml) as {
+    type: string;
+    content?: DocNode[];
+  };
+  const filtered = (existingDoc.content ?? []).filter(
+    (node) => node.type !== zoneType,
+  );
+  const next = { type: existingDoc.type ?? "doc", content: filtered };
+  await setPageContentFromHtml(pageId, tiptapJsonToHtml(next));
 }
 
 // ─── upsertPageSection ───────────────────────────────────────────────

--- a/apps/webapp/app/services/hocuspocus/content.server.ts
+++ b/apps/webapp/app/services/hocuspocus/content.server.ts
@@ -94,6 +94,19 @@ const ServerOutcomeNode = Node.create({
   },
 });
 
+const ServerLogNode = Node.create({
+  name: "log",
+  group: "block",
+  content: "block+",
+  defining: true,
+  parseHTML() {
+    return [{ tag: "log" }];
+  },
+  renderHTML() {
+    return ["log", 0];
+  },
+});
+
 /**
  * Returns server-safe TipTap extensions (no React renderers).
  */
@@ -110,6 +123,7 @@ export function getServerExtensions(): Extensions {
     TableCell,
     ServerPlanNode,
     ServerOutcomeNode,
+    ServerLogNode,
   ];
 }
 

--- a/apps/webapp/app/services/task.server.ts
+++ b/apps/webapp/app/services/task.server.ts
@@ -781,7 +781,12 @@ export async function updateScheduledTask(
       existing.userId,
       taskId,
     );
-    await setPageContentFromHtml(page.id, data.description);
+    // Merge structured zones (<plan>/<outcome>/<log>) rather than wholesale
+    // replace — wholesale replace here was the bug that let scheduling-field
+    // updates obliterate the rest of the task body (including <plan>) on
+    // recurring tasks.
+    const { upsertPageSection } = await import("~/services/coding-task.server");
+    await upsertPageSection(page.id, data.description);
   }
 
   // Only touch the queue when a scheduling-relevant field actually changed.


### PR DESCRIPTION
Recurring tasks were overwriting their description each fire because the agent kept rewriting <plan>/<outcome> zones (replace semantics) and any update bundling a scheduling field with description still wholesale- replaced the page via setPageContentFromHtml.

- Add <log> as a third structured zone with APPEND semantics, alongside <plan>/<outcome> (replace). Server parser, client editor node, and the zone merger all updated.
- Add clearLog flag on update_task to wipe <log> only — for the accumulate-daily, send-weekly, clear pattern.
- Gate <plan>/<outcome> writes behind isBackgroundExecution: scheduled fires and background runs may only append to <log> (or clearLog). Live chat unchanged. The plan is frozen unless the user is in the loop.
- Route updateScheduledTask description writes through upsertPageSection instead of setPageContentFromHtml so scheduling-bundled updates can't obliterate <plan>.
- Update capabilities and trigger_context prompts with the new zone model and background restriction.
- Add 28 unit tests covering the merger (replace vs append, validation, user-prose preservation) and the background gate (rejection paths, allowed paths, scheduling+description regression).