### PR TITLE
fix(chat): concatenate all text parts in conversation item rendering

### DIFF
--- a/apps/webapp/app/components/conversation/conversation-item.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-item.client.tsx
@@ -42,7 +42,10 @@ const ConversationItemComponent = ({
   className,
 }: AIConversationItemProps) => {
   const isUser = message.role === "user" || false;
-  const textPart = message.parts.find((part) => part.type === "text");
+  const combinedText = message.parts
+    .filter((part: any) => part.type === "text" && part.text)
+    .map((p: any) => p.text)
+    .join("");
   const [showAllTools, setShowAllTools] = useState(false);
   const formattedTime = createdAt
     ? new Date(createdAt).toLocaleTimeString([], {
@@ -54,12 +57,12 @@ const ConversationItemComponent = ({
   const editor = useEditor({
     extensions: [...extensionsForConversation],
     editable: false,
-    content: textPart ? textPart.text : "",
+    content: combinedText ? combinedText : "",
   });
 
   useEffect(() => {
-    if (textPart) {
-      editor?.commands.setContent(textPart.text);
+    if (combinedText) {
+      editor?.commands.setContent(combinedText);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [message]);


### PR DESCRIPTION
### Problem
`message.parts.find(p => p.type === "text")` returns the **first** text chunk, which is empty in multi-step agent turns. After a tool call, the AI SDK produces a `step-start` + empty `text` part for the tool-use step, followed by another `step-start` + the real response text. `.find()` grabs the empty one → editor gets `""` → blank message.

### Solution
Replace `.find()` with `.filter()` + `.map().join()` to concatenate all non-empty text parts into a single string for the TipTap editor.

### Changes
- `apps/webapp/app/components/conversation/conversation-item.client.tsx`
- Replace `.find()` with `.filter()` to collect all non-empty text parts
- Update `useEditor` initial content and `useEffect` to use the combined string


https://github.com/user-attachments/assets/fc2aa152-8df4-4646-91ff-216e8b9ff156

Fix #900