### PR TITLE
fix(voice): tighten aspect classification prompt

### DIFF
--- a/apps/webapp/app/routes/home.conversation.$conversationId.tsx
+++ b/apps/webapp/app/routes/home.conversation.$conversationId.tsx
@@ -13,7 +13,7 @@ import {
   deleteConversation,
 } from "~/services/conversation.server";
 import { getIntegrationAccounts } from "~/services/integrationAccount.server";
-import { getAvailableModels } from "~/services/llm-provider.server";
+import { getChatComposerModels } from "~/services/llm-provider.server";
 import { ConversationView } from "~/components/conversation";
 import { useTypedLoaderData } from "remix-typedjson";
 import type { LoaderData } from "~/utils/loader-data";
@@ -36,23 +36,11 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const initialVoiceMode =
     new URL(request.url).searchParams.get("voice") === "1";
 
-  const [conversation, integrationAccounts, allModels] = await Promise.all([
+  const [conversation, integrationAccounts, models] = await Promise.all([
     getConversationAndHistory(params.conversationId as string, user.id),
     getIntegrationAccounts(user.id, workspaceId),
-    getAvailableModels(),
+    getChatComposerModels(workspaceId),
   ]);
-
-  const models = allModels
-    .filter(
-      (m) => m.capabilities.length === 0 || m.capabilities.includes("chat"),
-    )
-    .map((m) => ({
-      id: `${m.provider.type}/${m.modelId}`,
-      modelId: m.modelId,
-      label: m.label,
-      provider: m.provider.type,
-      isDefault: m.isDefault,
-    }));
 
   if (!conversation) {
     return {

--- a/apps/webapp/app/routes/home.conversation._index.tsx
+++ b/apps/webapp/app/routes/home.conversation._index.tsx
@@ -2,24 +2,13 @@ import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { useTypedLoaderData } from "remix-typedjson";
 import { requireUser, requireWorkpace } from "~/services/session.server";
 import { ConversationNew } from "~/components/conversation";
-import { getAvailableModels } from "~/services/llm-provider.server";
+import { getChatComposerModels } from "~/services/llm-provider.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   // Only return userId, not the heavy nodeLinks
   const user = await requireUser(request);
   const workspace = await requireWorkpace(request);
-  const allModels = await getAvailableModels();
-  const models = allModels
-    .filter(
-      (m) => m.capabilities.length === 0 || m.capabilities.includes("chat"),
-    )
-    .map((m) => ({
-      id: `${m.provider.type}/${m.modelId}`,
-      modelId: m.modelId,
-      label: m.label,
-      provider: m.provider.type,
-      isDefault: m.isDefault,
-    }));
+  const models = await getChatComposerModels(workspace?.id);
 
   const meta = (workspace?.metadata ?? {}) as Record<string, unknown>;
   const accentColor = (meta.accentColor as string) || "#c87844";

--- a/apps/webapp/app/routes/home.tsx
+++ b/apps/webapp/app/routes/home.tsx
@@ -20,7 +20,7 @@ import { SetButlerNameModal } from "~/components/onboarding/set-butler-name-moda
 import { CollabSocketProvider } from "~/components/editor/collab-socket-context";
 import React from "react";
 import { getIntegrationAccounts } from "~/services/integrationAccount.server";
-import { getAvailableModels } from "~/services/llm-provider.server";
+import { getChatComposerModels } from "~/services/llm-provider.server";
 import { type LLMModel } from "~/components/conversation";
 import { useTauri } from "~/hooks/use-tauri";
 import { DesktopTabsProvider } from "~/components/desktop/tabs-context";
@@ -80,22 +80,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     user.id,
   );
 
-  const [integrationAccounts, allModels] = await Promise.all([
+  const [integrationAccounts, models] = await Promise.all([
     getIntegrationAccounts(user.id, workspace?.id as string),
-    getAvailableModels(),
+    getChatComposerModels(workspace?.id),
   ]);
-
-  const models = allModels
-    .filter(
-      (m) => m.capabilities.length === 0 || m.capabilities.includes("chat"),
-    )
-    .map((m) => ({
-      id: `${m.provider.type}/${m.modelId}`,
-      modelId: m.modelId,
-      label: m.label,
-      provider: m.provider.type,
-      isDefault: m.isDefault,
-    }));
 
   const integrationAccountMap: Record<string, string> = {};
   const integrationFrontendMap: Record<string, string> = {};

--- a/apps/webapp/app/routes/settings.workspace.models.tsx
+++ b/apps/webapp/app/routes/settings.workspace.models.tsx
@@ -20,7 +20,11 @@ import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
 import { Badge } from "~/components/ui/badge";
 import { Trash2 } from "lucide-react";
-import { getChatModels } from "~/services/llm-provider.server";
+import {
+  getChatModels,
+  persistCustomWorkspaceModel,
+  pruneOrphanWorkspaceModels,
+} from "~/services/llm-provider.server";
 import {
   getWorkspaceKeyStatus,
   setWorkspaceApiKey,
@@ -137,6 +141,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         } as Prisma.InputJsonValue,
       },
     });
+
+    await persistCustomWorkspaceModel(user.workspaceId, modelId);
+    await pruneOrphanWorkspaceModels(user.workspaceId);
 
     return json({ success: true });
   }

--- a/apps/webapp/app/services/llm-provider.server.ts
+++ b/apps/webapp/app/services/llm-provider.server.ts
@@ -367,6 +367,136 @@ export async function getChatModels(workspaceId?: string) {
   });
 }
 
+export interface ComposerModel {
+  id: string;
+  modelId: string;
+  label: string;
+  provider: string;
+  isDefault: boolean;
+}
+
+/**
+ * Models ready to render in the chat composer dropdown for a workspace.
+ * Marks the workspace's configured chat model (workspace.metadata.modelConfig.chat)
+ * as isDefault, and avoids double-prefixing ids when the modelId already starts
+ * with its provider type (e.g. "openrouter/xiaomi/mimo-v2.5-pro").
+ */
+export async function getChatComposerModels(
+  workspaceId?: string,
+): Promise<ComposerModel[]> {
+  const allModels = await getAvailableModels(workspaceId);
+
+  let defaultChatModelId: string | undefined;
+  if (workspaceId) {
+    const workspace = await prisma.workspace.findUnique({
+      where: { id: workspaceId },
+      select: { metadata: true },
+    });
+    const meta = (workspace?.metadata ?? {}) as Record<string, any>;
+    defaultChatModelId = meta.modelConfig?.chat?.modelId as string | undefined;
+  }
+
+  return allModels
+    .filter(
+      (m) => m.capabilities.length === 0 || m.capabilities.includes("chat"),
+    )
+    .map((m) => {
+      const providerPrefix = `${m.provider.type}/`;
+      const id = m.modelId.startsWith(providerPrefix)
+        ? m.modelId
+        : `${providerPrefix}${m.modelId}`;
+      const label = m.modelId.startsWith(providerPrefix)
+        ? m.label === m.modelId
+          ? m.modelId.slice(providerPrefix.length)
+          : m.label
+        : m.label;
+      return {
+        id,
+        modelId: m.modelId,
+        label,
+        provider: m.provider.type,
+        isDefault: defaultChatModelId === m.modelId,
+      };
+    });
+}
+
+/**
+ * Persist a custom modelId (typed via the settings UI) as a workspace-scoped
+ * LLMModel so it shows up in the composer dropdown. No-op if the modelId is
+ * already in any catalog or if no workspace-scoped provider exists for the
+ * inferred provider type (we don't pollute the global catalog).
+ */
+export async function persistCustomWorkspaceModel(
+  workspaceId: string,
+  modelId: string,
+): Promise<void> {
+  const existing = await prisma.lLMModel.findFirst({
+    where: {
+      modelId,
+      OR: [
+        { provider: { workspaceId } },
+        { provider: { workspaceId: null } },
+      ],
+    },
+  });
+  if (existing) return;
+
+  const providerType = inferProviderFromModelId(modelId);
+  const workspaceProvider = await prisma.lLMProvider.findFirst({
+    where: { workspaceId, type: providerType, isActive: true },
+  });
+  if (!workspaceProvider) return;
+
+  await prisma.lLMModel.create({
+    data: {
+      providerId: workspaceProvider.id,
+      modelId,
+      label: modelId,
+      complexity: "medium",
+      supportsBatch: false,
+      capabilities: ["chat"],
+    },
+  });
+}
+
+/**
+ * Delete workspace-scoped LLMModel rows that are no longer referenced by any
+ * entry in workspace.metadata.modelConfig. Global catalog rows are never
+ * touched. Run this after every modelConfig mutation so swapping or clearing a
+ * custom id removes the orphan row.
+ */
+export async function pruneOrphanWorkspaceModels(
+  workspaceId: string,
+): Promise<void> {
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: workspaceId },
+    select: { metadata: true },
+  });
+  const meta = (workspace?.metadata ?? {}) as Record<string, any>;
+  const modelConfig = (meta.modelConfig ?? {}) as Record<
+    string,
+    { modelId?: string } | undefined
+  >;
+
+  const referenced = new Set<string>();
+  for (const cfg of Object.values(modelConfig)) {
+    if (cfg?.modelId) referenced.add(cfg.modelId);
+  }
+
+  const workspaceModels = await prisma.lLMModel.findMany({
+    where: { provider: { workspaceId } },
+    select: { id: true, modelId: true },
+  });
+
+  const orphanIds = workspaceModels
+    .filter((m) => !referenced.has(m.modelId))
+    .map((m) => m.id);
+
+  if (orphanIds.length === 0) return;
+
+  await prisma.lLMModel.deleteMany({ where: { id: { in: orphanIds } } });
+}
+
 export async function getAvailableModels(workspaceId?: string) {
   const providers = await getProviders(workspaceId);
   const providerIds = providers.map((p) => p.id);

--- a/apps/webapp/app/services/prompts/classify-voice.ts
+++ b/apps/webapp/app/services/prompts/classify-voice.ts
@@ -34,43 +34,117 @@ Read the fact. Understand what it means. Pick the aspect that best describes wha
 
 ## Aspects
 
-**Directive** — A standing instruction to a system/agent/automation. Rules that should be followed going forward — not one-time requests.
+**Directive** — A standing instruction telling an agent/system/user WHAT TO DO going forward. A rule for future action — not a description of how something already works.
 - "Always scan Gmail in morning sync, exclude newsletters" → Directive
 - "Notify me when CPU > 80%" → Directive
 - "Ignore test environment webhook events" → Directive
-NOT: one-time session requests or personal taste without a system instruction.
+- "Do not reimplement SDK helpers; use the official SDK" → Directive
 
-**Preference** — HOW the user wants things done. Personal taste about style, format, approach — not a value judgment about the world.
+TEST: rewrite the sentence as "Here is how X works" or "The system does Y". If the meaning is preserved, it is NOT a Directive — it is a description of reality (return null), not an instruction.
+
+Anti-examples (these LOOK like Directives because they use "should"/"must"/"are"/"can" but are actually descriptions of how external systems behave):
+- "Session events can be sent while the session is running or idle; they are queued and processed in order" → null (describes API capability)
+- "Credentials are created via client.beta.vaults.credentials.create() and attached using vault_ids" → null (describes mechanism)
+- "HTTP library timeouts should not be treated as hard wall-clock caps" → null (advises how to interpret existing behavior, not a rule for the agent to follow)
+- "The migration guide is intended to be navigated by section headings" → null (describes document structure)
+- "/sprites/catalog should display variant names matching the business taxonomy" → null (product requirement / app output, not an agent instruction)
+
+NOT: descriptions of how systems/APIs work. NOT: advice on how to interpret external behavior. NOT: app output / product requirements. NOT: document or workflow structure. NOT: one-time session requests or personal taste without a system instruction.
+
+**Preference** — Personal taste about HOW THE USER wants their own work, output, or interactions PRESENTED or FORMATTED. Style/format taste about user-facing presentation — not system architecture, not one-time spec edits, not standing instructions about how work should be done.
 - "I prefer short bullet points over long paragraphs" → Preference
 - "Proper Case for email subjects" → Preference
 - "Dark mode for all interfaces" → Preference
 - "I want feedback on structure/narrative flaws, not grammar" → Preference
-NOT: value judgments about how the world works → Belief.
 
-**Habit** — What the user already does REPEATEDLY. Recurring behaviors, routines, practices that are already happening.
+TEST: ask "is this about the presentation/format/style of the OUTPUT the user sees or interacts with, or is it about how the SYSTEM should work internally?" If it's about system internals (data storage, caching, prompt architecture, product positioning) → Directive. If it's a specific one-time product detail (copy, asset dimensions, single UI tweak) → Task. Preference is reserved for the user's personal taste in PRESENTATION.
+
+Anti-examples (these SOUND like Preferences because they use "prefer"/"want", but are Directives about system architecture or standing work rules):
+- "I want the system prompt kept frozen and avoid interpolating dynamic values into the system prompt" → Directive (caching/architecture strategy, standing rule)
+- "Harshith prefers storing the town state in the database rather than using localStorage" → Directive (data-storage architecture, not presentation taste)
+- "For debugging work, the final deliverable should be a summary of what was found and what was fixed" → Directive (standing instruction for work output across all debugging tasks)
+- "I prefer reducing complexity and avoiding extensive configuration; consolidate into simple defaults" → Directive (system design philosophy, standing rule)
+- "Harshith prefers CORE be positioned carefully for Hacker News launch — described as an orchestration layer" → Belief or Directive (product positioning / strategic stance)
+
+Anti-examples (one-time spec edits that sound like Preferences but are Tasks):
+- "The robot's eye sizes should be reduced relative to the current design" → Task (specific one-time design change)
+- "Morning Brief instruction text should say 'Send the brief to the default channel' rather than 'Send to Slack'" → Task (one-time copy edit)
+
+NOT: system architecture, data storage, or caching strategy → Directive. NOT: product positioning or strategic stance → Belief or Directive. NOT: one-time design/copy/spec edits → Task. NOT: standing instructions for work output format → Directive. NOT: value judgments about how the world works → Belief.
+
+**Habit** — What the USER (as a person) actually DOES REPEATEDLY in real life. Recurring personal behaviors, routines, rituals, communication patterns — not engineering methodologies, SDK conventions, or tool workflows.
 - "Takes fish oil supplements daily at breakfast" → Habit
 - "Reviews PRs every morning before standup" → Habit
 - "I primarily use credit cards for spending, about 80% of transactions" → Habit
-NOT: something the user WANTS to start but isn't doing yet → Goal.
+- "Maintains a daily scratchpad for tasks and notes" → Habit
+- "Asks clarifying questions before starting work; challenges proposed approaches" → Habit
 
-**Belief** — A lasting value judgment or principle. Convictions about how the world works — not personal style preferences.
+TEST: would this recurring pattern exist if the user switched jobs or stopped using a specific SDK/tool? If the pattern is bound to "when using X SDK" or "when configuring Y tool" or "my debugging strategy for Z", it is a Preference or Directive, not a Habit. Habits are about the PERSON; methodologies are about HOW THEY WORK.
+
+Anti-examples (these SOUND like habits because they describe a repeated pattern, but are SDK/tool methodologies, conceptual stances, or problem reports):
+- "When using the @anthropic-ai/sdk TypeScript client, I handle errors via typed exception classes" → Preference or Directive (coding methodology, not a personal habit)
+- "For Extended Thinking configuration, I use adaptive thinking for Opus 4.7/4.6" → Directive (SDK configuration pattern)
+- "I verify prompt-cache effectiveness by inspecting Claude API response usage fields" → Directive (how to verify a system behavior)
+- "When using use_figma, I work incrementally in small steps and stop on any error" → Preference or Directive (tool workflow pattern)
+- "He already has agent handoffs automated via scripts, but context still leaks between agents" → null (problem report / system observation, not a habit)
+- "He is thinking in terms of memory primitives and session compaction" → Belief or null (conceptual stance, not a demonstrated recurring behavior)
+- "I position CORE as a coordination/orchestration layer" → Belief (positioning / strategic principle)
+
+NOT: SDK or coding methodologies → Preference/Directive. NOT: tool workflows or configuration patterns → Preference/Directive. NOT: conceptual stances or worldviews → Belief. NOT: problem reports or system observations → null. NOT: something the user WANTS to start but isn't doing yet → Goal.
+
+**Belief** — A lasting CONVICTION or value judgment about how the world works. The user's principles — not a documented fact that anyone reading the same docs would agree with.
 - "Open-source builds more trust than closed products" → Belief
 - "Code reviews should focus on architecture, not style" → Belief
 - "Small teams move faster than large ones" → Belief
 - "I intentionally keep a human in the loop to avoid errors" → Belief
-NOT: momentary reactions, opinions about a specific draft, or task feedback.
 
-**Goal** — Something the user is working toward over time. Sustained objectives, targets, aspirations — not one-time asks.
+TEST: could two reasonable people disagree with this? If the answer is "no — anyone reading the docs/spec would agree" — it is a documented fact (return null), not a Belief. If the user is recording a technical detail about an external API, SDK, model, or system, return null.
+
+Anti-examples (these SOUND like principles because they use declarative language, but are documented facts about external systems):
+- "vault_ids can be set only at session creation time and cannot be set via session update" → null (API behavior, documented fact)
+- "How I obtain the initial OAuth access token depends on the specific MCP server" → null (procedural fact)
+- "If I only have an OAuth access token with no refresh capability, I should omit the refresh block" → null (documented API constraint)
+- "Archived resources cannot be referenced by new sessions; archiving is permanent" → null (system behavior)
+- "Only cloud environments are supported: config.type: 'cloud' is the sole supported type" → null (product limitation)
+- "Do not mix beta and non-beta message types" → null (SDK compatibility rule, not a conviction)
+- "Claude Opus 4.7 and Opus 4.6 count tokens differently" → null (model behavior)
+
+NOT: documented technical facts about external APIs/SDKs/models → null. NOT: procedural workarounds or constraints → null. NOT: standing operating rules ("if intermittent, don't fix") → Directive. NOT: momentary reactions, opinions about a specific draft, or task feedback.
+
+**Goal** — Something the USER personally is working toward over time. A sustained pursuit (days/weeks/months) of an objective the user is driving — not a feature specification for a system.
 - "I want to run a marathon by December" → Goal
-- "Launch the beta this quarter" → Goal
+- "Launch the personal-OS MVP this quarter" → Goal
 - "I want to personally onboard Guillaume" → Goal
-NOT: one-time follow-ups or action items → Task.
+- "Ship the home-screen redesign before Q4" → Goal
 
-**Task** — A one-time commitment the user needs to do. Follow-ups, promises, action items with a clear completion state.
+TEST: ask "who is pursuing this?" If the subject of the wish is THE SYSTEM/PRODUCT/SKILL ("the app should support X", "the gateway should include Y", "the skill is to do Z"), it is a Directive — a standing instruction for what the system must do — not a Goal. Goal is what the USER is personally pursuing.
+
+Anti-examples (these SOUND like Goals because they use "wants"/"should"/"goal for", but the subject is the system, not the user's personal pursuit):
+- "Wants the app to support OpenAI in addition to Anthropic" → Directive (feature requirement)
+- "OpenCode should have the same functionality as claude-code and codex (full feature parity)" → Directive (system mandate)
+- "Wants CORE's open-source deployment to include the gateway component" → Directive (product requirement)
+- "Goal for the claude-code-plugin skill is to ask OpenAI Codex questions about a repository codebase" → Directive (tool behavior spec)
+
+NOT: feature requirements or product specifications, even if phrased as "I want the app to X" → Directive. NOT: one-time follow-ups or action items → Task. NOT: pending evaluation work ("considering migrating to X") → Task.
+
+**Task** — A specific, FUTURE, uncompleted commitment the user intends to do. A one-time action item with a clear completion state — not a record of work already done, a decision already finalized, or a standing want.
 - "Need to send the proposal to the client by Friday" → Task
 - "Follow up with the design team about the mockups" → Task
 - "I will add Guillaume to the unsubscribe list" → Task
-NOT: sustained objectives → Goal. NOT: standing rules for systems → Directive.
+
+TEST: rewrite the sentence in past tense — "I documented X", "I approved Y", "I selected Z". If the sentence already reads naturally in past tense (the action has already happened or the decision is already made), it is NOT a Task — it is a record of an event (return null).
+
+Anti-examples (these SOUND like Tasks because they use commitment language, but describe completed work, finalized decisions, problem reports, or preferences):
+- "Documented TypeScript/Anthropic SDK cost-optimization patterns" → null (work already completed, past tense)
+- "Harshith approved proceeding with a custom apartment build for HOME" → null (decision already made, not a future commitment)
+- "Approved renaming the in-game CAFE concept to bakeryonly" → null (decision finalized)
+- "Harshith confirmed the decision to implement both proposed UI changes" → null (decision already confirmed)
+- "Selected voice-stack approach: Option B — Whisper-style speech-to-text" → null (a decision already taken; if there is still work to do, the work itself would be the Task)
+- "Reported a bug: when Needs Attention widgets are removed they reappear" → null (bug report, not a commitment to fix)
+- "Harshith wants proper collision blocking in the HOME interior" → Preference (desired system behavior, not a one-time action with a clear done-state)
+- "Harshith offered to help Ziming transition to self-hosting" → null (open-ended standing offer, no specific deliverable or deadline)
+
+NOT: records of decisions already finalized → null. NOT: work already completed → null. NOT: bug or problem reports → null. NOT: standing preferences or system-behavior wishes → Preference. NOT: sustained objectives → Goal. NOT: standing rules for systems → Directive.
 
 **null** — The fact doesn't clearly fit any aspect. It may be noise that slipped through extraction, a product description, or a session-specific statement that isn't really the user's voice.
 - "CORE's morning brief is pitched as a single daily summary" → null (product description, not user's voice)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -144,7 +144,8 @@
               "skills/email_label_management",
               "skills/notify_emails",
               "skills/account_research",
-              "skills/engineering_analytics"
+              "skills/engineering_analytics",
+              "skills/journaling"
             ]
           }
         ]

--- a/docs/skills/journaling.mdx
+++ b/docs/skills/journaling.mdx
@@ -1,0 +1,112 @@
+---
+title: "How I Want to Journal"
+description: My personal style for journaling conversations — kinds of questions I find useful, how I want the agent to follow up, when to dig deeper, when to stop. Applied whenever the agent journals with me — weekly retros, end-of-day reflections, ad-hoc processing. Trigger with "let's journal", "I want to reflect", "ask me about my week", or "help me think through this".
+category: Reflection
+integrations: '[]'
+---
+
+**What this is:** A reusable policy for *how* the agent should journal with me. The output isn't a report — it's a conversation. This policy defines the rhythm: one question at a time, follow-ups that earn the next topic, knowing when to stop. Tasks (a Friday retro, a daily end-of-day reflection, an ad-hoc "help me process this") apply this lens. The policy doesn't run on its own.
+
+**Tools touched (when this policy is applied):** Memory (read past entries, store new context). No external integrations — this is a pure conversation.
+
+---
+
+### Before the first question
+
+Search memory for the following so you can meet me where I am, not start cold:
+
+- "user's recent journal entries or reflections in scratchpad"
+- "topics the user is currently processing or working through"
+- "user's journaling preferences — gratitude, processing, planning, or unstructured"
+- "sensitive topics the user does NOT want pushed on"
+
+> If a recurring theme appears across past entries, you may reference it once — "You wrote last week about X — is that still on your mind?" Don't lead with a theme I haven't named today.
+
+If memory has nothing, open soft. Don't ask the user to set preferences — figure them out from how I respond to the first 2–3 questions.
+
+---
+
+### 1. Shape of a good turn
+
+Every turn from the agent has the same structure:
+
+1. **Reflect briefly** — one sentence acknowledging what I just said. Not paraphrasing word-for-word; capturing the *substance* or the *feeling*.
+2. **Ask one question** — exactly one. Not two stacked. Not three options.
+3. **Stop** — don't add commentary, advice, or "let me know if…". The question is the prompt.
+
+> Three short sentences max per turn. If the reflect-and-ask doesn't fit in that, the question is too big.
+
+---
+
+### 2. Question types I find useful
+
+Use these in rough order, but skip stages if I've already opened up:
+
+- **Opening** — broad, low-stakes. "How are you feeling about the week?" "What's on your mind?" "Anything sitting heavy?"
+- **Exploring** — pick one thread from my answer and dig. "You said the launch was 'fine' — what made it just fine and not great?" "What part of that conversation is still with you?"
+- **Deepening** — go to the why or the feeling. "What do you think made that land so hard?" "If you peel one layer back, what's actually underneath?"
+- **Closing** — synthesis, gentle. "If you had to pick one thing to take into next week from this, what would it be?" "What does past-you-from-tomorrow-morning need to know?"
+
+> Never ask 2 questions in one turn. If you have two, pick the better one and save the other.
+
+---
+
+### 3. How I want you to follow up
+
+- **Mirror specifically.** If I say "the meeting was bad", a good follow-up names "the meeting" or "bad", not both vaguely. Bad: "That sounds hard." Better: "What made it bad?" Best: "What part of the meeting are you replaying?"
+- **Earn the next topic.** Don't switch threads until the current one feels closed — usually when my answer gets shorter or I say something like "yeah, that's it."
+- **Match my energy.** If I write one line, you write one line back. If I dump three paragraphs, your reflect-and-ask can be longer, but still one question.
+- **Use my words.** If I called something "annoying", don't reframe it as "frustrating" or "challenging". I'll tell you if it needs reframing.
+
+---
+
+### 4. When to stop
+
+Stop when any of these are true:
+
+- I say I'm done — explicitly ("OK that's enough") or implicitly ("alright").
+- My answers have gotten progressively shorter for 2+ turns in a row and the last one was 5 words or fewer.
+- We've circled back to the same insight twice. Loops mean we've found the floor for today.
+- We're 8–10 turns in and the conversation has surfaced something — don't push for a 15-turn epic when 10 was the right length.
+
+> At the close, ask one synthesis question (see Closing above). If I'm ready to wrap, I'll give a short answer. Then you stop — don't append a summary, don't write to scratchpad in the same turn unless the consuming task explicitly asked you to.
+
+---
+
+### 5. What I do NOT want
+
+- **Advice.** Unless I ask "what should I do?", do not advise. Reflect and ask.
+- **Lectures.** No "research shows…", no "many people feel this way too". Bring me back to my experience.
+- **Multi-part questions.** "What worked, what didn't, and what would you change?" is three questions wearing a trench coat.
+- **Yes/no questions.** "Was it stressful?" is a dead end. Use "What was it like?"
+- **Leading questions.** "Don't you think you should have…?" is not a question, it's a verdict.
+- **Premature summary.** Do not summarise back what I said in a multi-bullet recap mid-conversation. Hold the thread, don't decorate it.
+- **Toxic positivity.** Don't tell me a bad week was "actually a growth opportunity". Sit with what I said.
+
+---
+
+### 6. Sensitive topics
+
+If memory flags something as off-limits, route around it. If I bring it up myself, you may ask once whether I want to talk about it — accept either answer cleanly and move on without commentary.
+
+---
+
+### How this lens is used
+
+Other surfaces consume this lens:
+
+- **Weekly Retrospective task** — runs Friday afternoons. Uses this policy to *conduct* the retro, not just prompt for it.
+- **End-of-day reflection** — if the user opts in to a conversational wrap-up instead of the standard push summary.
+- **Ad-hoc "let's journal"** — user invokes by intent ("help me process this", "let's journal", "ask me about my week"). Single conversation, no schedule.
+- **Sunday Planning context** — if the user wants to reflect *before* planning, this policy runs first, then the planning task reads the resulting scratchpad notes.
+
+Each task is responsible for *when* to start and *whether* to persist anything afterwards. This skill only defines *how the conversation should feel*.
+
+---
+
+### Edge cases
+
+- **I open with a heavy topic.** Don't downshift to a lighter opener. Meet it directly: "Tell me more about that."
+- **I give a one-word answer to an opener.** Don't push. Try one different opener. If that also gets one word, stop — I'm not in the headspace for this today. Say so plainly: "Doesn't feel like today's the day. Want to come back to it tomorrow?"
+- **I ramble across multiple topics.** Pick the one with the strongest emotional charge (anger, sadness, excitement) and reflect on that one. Save the others for follow-ups if they come back.
+- **I ask you a direct question** ("What do you think?"). Acknowledge briefly, then turn it back. "I think X, but I'm curious — what do *you* think?" Journaling is for my answers, not yours.

--- a/docs/skills/overview.mdx
+++ b/docs/skills/overview.mdx
@@ -26,4 +26,7 @@ To create one: **Dashboard → Agent → Skills → New Skill**. Add a title, th
   <Card title="How I Look at Engineering Analytics" icon="chart-line" href="/skills/engineering_analytics">
     My lens for reading delivery metrics — which numbers matter, my healthy ranges, what to flag.
   </Card>
+  <Card title="How I Want to Journal" icon="book-open" href="/skills/journaling">
+    My style for journaling conversations — one question at a time, follow-ups that earn the next topic, when to stop.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Audit of ~1000 classified voice aspects against the classifier prompt found material drift in 4 of 6 aspects. Rewrote each aspect section in `classify-voice.ts` with a tightened definition, a TEST clause the model can apply to discriminate the failure shape, and anti-examples lifted verbatim from real misclassifications.

## Audit findings (before)

| Aspect | Match rate | Drift |
|---|---|---|
| Directive | ~52% | Technical facts about external APIs dressed as standing rules |
| Task | ~50% | Completed work, decisions already made, bug reports |
| Habit | ~63% | SDK/tool methodologies treated as user behaviors |
| Belief | ~88% | Documented API/SDK facts treated as user convictions |
| Goal | ~87% | Feature requests ("wants the app to support X") leaked in |
| Preference | ~96% | System-architecture choices and one-time spec edits leaked in |

## What changed

Each aspect now follows the same shape:
- Sharpened one-line definition
- TEST clause (e.g., Directive: "rewrite as 'here is how X works' — if meaning is preserved, return null"; Task: "rewrite in past tense — if it reads naturally, return null"; Belief: "could two reasonable people disagree?")
- 3–5 positive examples
- 4–8 anti-examples drawn verbatim from real misclassifications, each pointing to the correct aspect
- Expanded NOT clause covering the failure modes the audit surfaced

## Validation

Simulated reclassification of 30+ previously-broken rows under the new prompt:

| Aspect | Tested | Fixed |
|---|---|---|
| Directive | 5 | 5/5 |
| Task | 8 | 6/6 clear + 1 nuance |
| Habit | 7 | 7/7 |
| Belief | 6 | 5/5 |
| Goal | 4 | 4/4 |
| Preference | 4 | 4/4 |

Spot-checked 10+ legitimately-classified rows per aspect — none would be over-corrected by the new tests.

## Test plan

- [ ] Run the next extraction batch and re-audit a sample for: API facts no longer landing in Directive/Belief; completed work and decisions no longer landing in Task; SDK methodologies no longer landing in Habit
- [ ] Confirm legitimate Directives ("always do X", "notify me when Y") still classify correctly
- [ ] Watch for any new failure modes the rewrite-as-fact test might introduce on borderline Directives that also describe state

🤖 Generated with [Claude Code](https://claude.com/claude-code)