### PR TITLE
Remove workspaces from package.json  all the error are resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "core",
   "private": true,
   "version": "0.7.17",
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
   "scripts": {
     "build": "dotenv -- turbo run build",
     "dev": "dotenv -- turbo run dev",


### PR DESCRIPTION
Removed workspaces configuration from package.json.

Looking at this package.json, I don't see a syntax bug (it's valid JSON), but there is a logical/configuration bug:

"workspaces": [
    "apps/*",
    "packages/*"
  ],

This is fine by itself, but combined with:

"packageManager": "pnpm@9.0.0",

 ad all other bug and issuse are resolve