### PR TITLE
feat(contacts): use episode content for richer contact summaries with 3-section format

### DIFF
--- a/apps/webapp/app/jobs/contacts/contact-sync.logic.ts
+++ b/apps/webapp/app/jobs/contacts/contact-sync.logic.ts
@@ -1,9 +1,7 @@
 import { logger } from "~/services/logger.service";
 import { prisma } from "~/db.server";
-import {
-  getPersonContactCandidates,
-  getEntityFacts,
-} from "~/services/graphModels/entity";
+import { getPersonContactCandidates } from "~/services/graphModels/entity";
+import { getEpisodesForEntity } from "~/services/graphModels/episode";
 import {
   upsertContactForEntity,
   updateContactFields,
@@ -69,40 +67,42 @@ export async function syncContactForEntity(
     return "skipped";
   }
 
-  const facts = await getEntityFacts(entityUuid, userId, workspaceId);
-  if (facts.length === 0) {
-    // Nothing to summarize. Leave the row in place (it was just created or
-    // already exists) and try again on the next fact.
+  const episodes = await getEpisodesForEntity(entityUuid, userId, workspaceId, 30);
+  if (episodes.length === 0) {
+    // Nothing to summarize yet — leave the row in place and retry on the next episode.
     return isNew ? "created" : "skipped";
   }
 
-  const { headline, description } = await generateContactSummary(
+  const { headline, description, extractedFields } = await generateContactSummary(
     {
       userName,
       personName: name,
       today: new Date(),
-      contactFields: {
-        emails: contact.emails,
-        phones: contact.phones,
-        company: contact.company ?? null,
-        role: contact.role ?? null,
-        location: contact.location ?? null,
-        handles: contact.handles,
-      },
-      facts,
+      episodes: episodes.map((e) => ({ content: e.content, validAt: e.validAt })),
       priorDescription: contact.description ?? null,
       descriptionEdited: contact.descriptionEdited,
     },
     workspaceId,
   );
 
-  await updateContactFields(workspaceId, contact.id, {
+  // Build field updates: only overwrite a structured field when the LLM
+  // extracted a non-empty value, so manually edited values aren't cleared.
+  const fieldUpdates: Record<string, any> = {
     headline,
     description,
     status: "Active",
     lastMemoryAt: latestFactAt ?? new Date(),
     lastSummarizedAt: new Date(),
-  });
+  };
+  if (extractedFields.email) fieldUpdates.emails = [extractedFields.email];
+  if (extractedFields.phone) fieldUpdates.phones = [extractedFields.phone];
+  if (extractedFields.company) fieldUpdates.company = extractedFields.company;
+  if (extractedFields.role) fieldUpdates.role = extractedFields.role;
+  if (extractedFields.location) fieldUpdates.location = extractedFields.location;
+  const newHandles = [extractedFields.linkedin, extractedFields.twitter].filter(Boolean);
+  if (newHandles.length > 0) fieldUpdates.handles = newHandles;
+
+  await updateContactFields(workspaceId, contact.id, fieldUpdates);
 
   return isNew ? "created" : "refreshed";
 }

--- a/apps/webapp/app/jobs/contacts/contact-sync.logic.ts
+++ b/apps/webapp/app/jobs/contacts/contact-sync.logic.ts
@@ -1,7 +1,7 @@
 import { logger } from "~/services/logger.service";
 import { prisma } from "~/db.server";
 import { getPersonContactCandidates } from "~/services/graphModels/entity";
-import { getEpisodesForEntity } from "~/services/graphModels/episode";
+import { getEpisodesForEntity, getEpisode } from "~/services/graphModels/episode";
 import {
   upsertContactForEntity,
   updateContactFields,
@@ -42,6 +42,9 @@ export interface SyncContactForEntityInput {
   name: string;
   latestFactAt: Date | null;
   force?: boolean;
+  // UUID of the episode that triggered this sync — guaranteed to be included
+  // in the context window even if the provenance link isn't indexed yet.
+  episodeUuid?: string;
 }
 
 export type SyncOutcome = "skipped" | "created" | "refreshed";
@@ -49,7 +52,7 @@ export type SyncOutcome = "skipped" | "created" | "refreshed";
 export async function syncContactForEntity(
   input: SyncContactForEntityInput,
 ): Promise<SyncOutcome> {
-  const { workspaceId, userId, userName, entityUuid, name, latestFactAt, force } = input;
+  const { workspaceId, userId, userName, entityUuid, name, latestFactAt, force, episodeUuid } = input;
 
   if (isSelf(userName, name)) return "skipped";
 
@@ -67,7 +70,16 @@ export async function syncContactForEntity(
     return "skipped";
   }
 
-  const episodes = await getEpisodesForEntity(entityUuid, userId, workspaceId, 30);
+  const episodes = await getEpisodesForEntity(entityUuid, userId, workspaceId, 5);
+
+  // Guarantee the triggering episode is always in the context window.
+  // If the provenance link isn't indexed yet it may be missing from the query.
+  if (episodeUuid && !episodes.some((e) => e.uuid === episodeUuid)) {
+    const current = await getEpisode(episodeUuid);
+    if (current) episodes.unshift(current);
+    if (episodes.length > 5) episodes.length = 5;
+  }
+
   if (episodes.length === 0) {
     // Nothing to summarize yet — leave the row in place and retry on the next episode.
     return isNew ? "created" : "skipped";

--- a/apps/webapp/app/jobs/ingest/graph-resolution.logic.ts
+++ b/apps/webapp/app/jobs/ingest/graph-resolution.logic.ts
@@ -310,6 +310,7 @@ export async function processGraphResolution(
               entityUuid,
               name,
               latestFactAt,
+              episodeUuid: payload.episodeUuid,
             }),
           ),
         );

--- a/apps/webapp/app/services/contacts/__tests__/contact-summary.test.ts
+++ b/apps/webapp/app/services/contacts/__tests__/contact-summary.test.ts
@@ -8,20 +8,21 @@ vi.mock("~/lib/model.server", () => ({
 }));
 
 import {
-  ContactSummarySchema,
   buildSummaryMessages,
   renderDescription,
 } from "../contact-summary.server";
 
 describe("buildSummaryMessages", () => {
-  it("includes the user name, person name, today's date and the facts", () => {
+  it("includes the user name, person name, today's date and episode content", () => {
     const messages = buildSummaryMessages({
       userName: "Manik",
       personName: "Abhishek",
       today: new Date("2026-06-19T00:00:00Z"),
-      contactFields: { emails: ["a@b.com"], phones: [], company: null, role: null, location: null, handles: [] },
-      facts: [
-        { fact: "Abhishek is a college friend", aspect: "Relationship", validAt: new Date("2026-01-01T00:00:00Z") },
+      episodes: [
+        {
+          content: "Abhishek is a college friend who works as an ML engineer.",
+          validAt: new Date("2026-01-01T00:00:00Z"),
+        },
       ],
       priorDescription: null,
       descriptionEdited: false,
@@ -33,13 +34,12 @@ describe("buildSummaryMessages", () => {
     expect(text).toContain("college friend");
   });
 
-  it("marks prior description as authoritative when userEdited is true", () => {
+  it("marks prior description as authoritative when descriptionEdited is true", () => {
     const messages = buildSummaryMessages({
       userName: "Manik",
       personName: "Abhishek",
       today: new Date("2026-06-19T00:00:00Z"),
-      contactFields: { emails: [], phones: [], company: null, role: null, location: null, handles: [] },
-      facts: [],
+      episodes: [],
       priorDescription: "Founder of Morsebiz.",
       descriptionEdited: true,
     });
@@ -50,18 +50,39 @@ describe("buildSummaryMessages", () => {
 });
 
 describe("renderDescription", () => {
-  it("renders only the sections that have content, labeled", () => {
+  it("renders Basic Info section with contact details", () => {
     const body = renderDescription({
-      whoTheyAre: "ML engineer at Observe.ai",
-      relationshipToYou: "Close college friend",
-      recentAndOpen: "",
-      cadenceChannel: "",
-      communicationStyle: "",
-      sharedGroups: "",
+      email: "abhishek@observe.ai",
+      phone: "",
+      linkedin: "linkedin.com/in/abhishek",
+      twitter: "",
+      company: "Observe.ai",
+      role: "ML Engineer",
+      location: "Bangalore",
+      relationshipWithUser: "Close college friend",
+      additionalInformation: "",
     });
-    expect(body).toContain("Who they are: ML engineer at Observe.ai");
-    expect(body).toContain("Relationship: Close college friend");
-    expect(body).not.toContain("Recent");
-    expect(body).not.toContain("Cadence");
+    expect(body).toContain("### Basic Info");
+    expect(body).toContain("- Email: abhishek@observe.ai");
+    expect(body).toContain("- LinkedIn: linkedin.com/in/abhishek");
+    expect(body).toContain("- Company: Observe.ai");
+    expect(body).toContain("### Relationship with User");
+    expect(body).toContain("Close college friend");
+    expect(body).not.toContain("### Additional Information");
+  });
+
+  it("omits sections that have no content", () => {
+    const body = renderDescription({
+      email: "",
+      phone: "",
+      linkedin: "",
+      twitter: "",
+      company: "",
+      role: "",
+      location: "",
+      relationshipWithUser: "",
+      additionalInformation: "",
+    });
+    expect(body).toBe("");
   });
 });

--- a/apps/webapp/app/services/contacts/__tests__/reconcile.test.ts
+++ b/apps/webapp/app/services/contacts/__tests__/reconcile.test.ts
@@ -11,7 +11,9 @@ vi.mock("~/lib/model.server", () => ({
 }));
 vi.mock("~/services/graphModels/entity", () => ({
   getPersonContactCandidates: vi.fn(),
-  getEntityFacts: vi.fn(),
+}));
+vi.mock("~/services/graphModels/episode", () => ({
+  getEpisodesForEntity: vi.fn(),
 }));
 vi.mock("~/services/contacts/contact.server", () => ({
   upsertContactForEntity: vi.fn(),

--- a/apps/webapp/app/services/contacts/contact-summary.server.ts
+++ b/apps/webapp/app/services/contacts/contact-summary.server.ts
@@ -4,81 +4,77 @@ import { makeStructuredModelCall } from "~/lib/model.server";
 
 export const ContactSummarySchema = z.object({
   headline: z.string().describe("one line: role + how they relate to you"),
-  whoTheyAre: z.string().default(""),
-  relationshipToYou: z.string().default(""),
-  recentAndOpen: z.string().default(""),
-  cadenceChannel: z.string().default(""),
-  communicationStyle: z.string().default(""),
-  sharedGroups: z.string().default(""),
+  email: z.string().default("").describe("primary email address if found in episodes"),
+  phone: z.string().default("").describe("primary phone number if found in episodes"),
+  linkedin: z.string().default("").describe("LinkedIn URL or handle if found"),
+  twitter: z.string().default("").describe("X/Twitter handle if found"),
+  company: z.string().default("").describe("employer or organization if found"),
+  role: z.string().default("").describe("job title or role if found"),
+  location: z.string().default("").describe("city, country, or region if found"),
+  relationshipWithUser: z.string().default("").describe("how the user knows this person — how they met, shared history, nature of relationship"),
+  additionalInformation: z.string().default("").describe("recent interactions with timing, open loops, communication patterns, shared groups"),
 });
 
 export type ContactSummary = z.infer<typeof ContactSummarySchema>;
 
-export interface ContactFields {
-  emails: string[];
-  phones: string[];
-  company: string | null;
-  role: string | null;
-  location: string | null;
-  handles: string[];
+export interface ExtractedContactFields {
+  email: string;
+  phone: string;
+  linkedin: string;
+  twitter: string;
+  company: string;
+  role: string;
+  location: string;
 }
 
 export interface BuildSummaryInput {
   userName: string;
   personName: string;
   today: Date;
-  contactFields: ContactFields;
-  facts: Array<{ fact: string; aspect: string | null; validAt: Date }>;
+  episodes: Array<{ content: string; validAt: Date }>;
   priorDescription: string | null;
   descriptionEdited: boolean;
 }
 
-const SYSTEM = `You build a compact CRM profile of one person from the user's MEMORY ONLY.
+const SYSTEM = `You build a CRM profile of one person from the user's raw memory episodes.
 
 RULES
-- Use ONLY the facts provided. Never invent, never infer beyond what is stated.
-  If something is unknown, omit it or say "not known". No age/DOB guessing.
-- Compact: each section AT MOST 1-2 short lines. Leave a section empty ("") if no facts support it.
-- Address the user as "you". Give recent items rough timing vs today.
-- If a prior profile is marked AUTHORITATIVE, preserve its facts and fold in new
-  memory without contradicting it.
+- Extract information ONLY from the episodes provided. Never invent or assume.
+- If a field is not present in the episodes, leave it as an empty string "".
+- Address the user as "you". Give recent interactions rough timing relative to today.
+- For email/phone/linkedin/twitter: copy the exact value as written in the episodes.
+- If a prior profile is marked AUTHORITATIVE, preserve its facts in
+  relationshipWithUser and additionalInformation, folding in new details without
+  contradicting it. Structured fields (email, phone, etc.) should still be
+  extracted fresh from the latest episodes.
 
 OUTPUT FIELDS
-headline: one line - role + how they relate to you (for the list)
-whoTheyAre: identity, background, what they do
-relationshipToYou: how you know them, shared history
-recentAndOpen: last few interactions w/ timing + any open loop / follow-up
-cadenceChannel: how often & main channel you interact through
-communicationStyle: one line on tone/register
-sharedGroups: shared group(s) / mutual people`;
+headline: one line — job title / role + how they relate to the user (shown on contact list card)
+email: primary email address (e.g. "john@acme.com"), empty string if not found
+phone: primary phone number (e.g. "+1-234-567-8900"), empty string if not found
+linkedin: LinkedIn URL or username (e.g. "linkedin.com/in/john-smith"), empty string if not found
+twitter: X/Twitter handle (e.g. "@johnsmith"), empty string if not found
+company: employer or organization name, empty string if not found
+role: job title or role, empty string if not found
+location: city, country, or region, empty string if not found
+relationshipWithUser: 2–4 sentences on how the user knows this person — how they met, shared history, nature of the relationship
+additionalInformation: recent interactions with timing, any open loops or follow-ups needed, communication frequency and channel, shared groups or mutual connections`;
 
 export function buildSummaryMessages(input: BuildSummaryInput): ModelMessage[] {
   const today = input.today.toISOString().slice(0, 10);
-  const factLines = input.facts
-    .map((f) => `- [${f.aspect ?? "Fact"}] ${f.validAt.toISOString().slice(0, 10)}: ${f.fact}`)
-    .join("\n");
-  const cf = input.contactFields;
-  const contactBlock = [
-    cf.emails.length ? `emails: ${cf.emails.join(", ")}` : "emails: not known",
-    cf.phones.length ? `phones: ${cf.phones.join(", ")}` : "phones: not known",
-    cf.company ? `company: ${cf.company}` : null,
-    cf.role ? `role: ${cf.role}` : null,
-    cf.location ? `location: ${cf.location}` : null,
-    cf.handles.length ? `handles: ${cf.handles.join(", ")}` : null,
-  ].filter(Boolean).join("\n");
+  const episodeLines = input.episodes
+    .map((e) => `[${e.validAt.toISOString().slice(0, 10)}]\n${e.content}`)
+    .join("\n\n---\n\n");
 
   const prior = input.priorDescription
-    ? `\n\nPrior profile (${input.descriptionEdited ? "AUTHORITATIVE - preserve these facts" : "for reference"}):\n${input.priorDescription}`
+    ? `\n\nPrior profile (${input.descriptionEdited ? "AUTHORITATIVE — preserve these facts" : "for reference"}):\n${input.priorDescription}`
     : "";
 
   const user = `Your user: ${input.userName}   Today: ${today}
 Person: ${input.personName}
 
-Known contact fields:
-${contactBlock}
-
-Memory facts (newest first):
-${factLines || "(none)"}${prior}`;
+Memory episodes (newest first):
+${episodeLines || "(none)"}${prior}`;
 
   return [
     { role: "system", content: SYSTEM },
@@ -87,24 +83,30 @@ ${factLines || "(none)"}${prior}`;
 }
 
 export function renderDescription(s: Omit<ContactSummary, "headline">): string {
-  const rows: Array<[string, string]> = [
-    ["Who they are", s.whoTheyAre],
-    ["Relationship", s.relationshipToYou],
-    ["Recent & open", s.recentAndOpen],
-    ["Cadence", s.cadenceChannel],
-    ["Style", s.communicationStyle],
-    ["Shared groups", s.sharedGroups],
-  ];
-  return rows
-    .filter(([, v]) => v && v.trim())
-    .map(([label, v]) => `${label}: ${v.trim()}`)
-    .join("\n");
+  const infoLines = [
+    s.email ? `- Email: ${s.email}` : null,
+    s.phone ? `- Contact: ${s.phone}` : null,
+    s.linkedin ? `- LinkedIn: ${s.linkedin}` : null,
+    s.twitter ? `- X: ${s.twitter}` : null,
+    s.location ? `- Location: ${s.location}` : null,
+    s.company ? `- Company: ${s.company}` : null,
+    s.role ? `- Role: ${s.role}` : null,
+  ].filter(Boolean).join("\n");
+
+  const sections: string[] = [];
+  if (infoLines) sections.push(`### Basic Info\n${infoLines}`);
+  if (s.relationshipWithUser?.trim())
+    sections.push(`### Relationship with User\n${s.relationshipWithUser.trim()}`);
+  if (s.additionalInformation?.trim())
+    sections.push(`### Additional Information\n${s.additionalInformation.trim()}`);
+
+  return sections.join("\n\n");
 }
 
 export async function generateContactSummary(
   input: BuildSummaryInput,
   workspaceId: string,
-): Promise<{ headline: string; description: string }> {
+): Promise<{ headline: string; description: string; extractedFields: ExtractedContactFields }> {
   const messages = buildSummaryMessages(input);
   const { object } = await makeStructuredModelCall(
     ContactSummarySchema,
@@ -114,5 +116,17 @@ export async function generateContactSummary(
     undefined,
     workspaceId,
   );
-  return { headline: object.headline, description: renderDescription(object) };
+  return {
+    headline: object.headline,
+    description: renderDescription(object),
+    extractedFields: {
+      email: object.email,
+      phone: object.phone,
+      linkedin: object.linkedin,
+      twitter: object.twitter,
+      company: object.company,
+      role: object.role,
+      location: object.location,
+    },
+  };
 }

--- a/apps/webapp/app/services/graphModels/episode.ts
+++ b/apps/webapp/app/services/graphModels/episode.ts
@@ -190,6 +190,20 @@ export async function getStatementsInvalidatedByEpisode(params: {
   );
 }
 
+export async function getEpisodesForEntity(
+  entityUuid: string,
+  userId: string,
+  workspaceId: string,
+  maxEpisodes: number = 30,
+): Promise<EpisodicNode[]> {
+  return graphProvider().getEpisodesForEntities({
+    entityUuids: [entityUuid],
+    userId,
+    workspaceId,
+    maxEpisodes,
+  });
+}
+
 export async function getEpisodesByUserId(params: {
   userId: string;
   startTime?: string;


### PR DESCRIPTION
## What changed

This PR improves the People/CRM contact summary pipeline on three fronts: richer source data, structured field extraction, and a well-formatted description.

### 1. Use full episode content instead of graph facts

**Before:** `syncContactForEntity` called `getEntityFacts`, which returns individual extracted `Statement` nodes from the knowledge graph (atomic facts like `"John works at Acme"`). Email, phone, LinkedIn, and location were only present if the extraction pipeline happened to create a statement for them — which was unreliable, causing those fields to always show blank.

**After:** We now call `getEpisodesForEntity` (last 5 episodes connected to the Person entity), which returns the raw memory text the user originally wrote. The LLM sees the full natural-language content and can reliably extract emails, phone numbers, LinkedIn/X handles, company, role, and location directly.

A `getEpisodesForEntity` helper was added to `graphModels/episode.ts` wrapping the existing `provider.getEpisodesForEntities` method.

### 2. Guarantee the triggering episode is always included

The current episode UUID (`payload.episodeUuid`) is now passed from `graph-resolution.logic.ts` into `syncContactForEntity`. After fetching the 5 most recent episodes for the entity, if the triggering episode isn't among them (e.g. provenance link not indexed yet at query time), it is fetched directly and prepended — keeping the window at 5 total.

### 3. Structured field extraction written back to the Contact row

The `ContactSummarySchema` was redesigned from a set of narrative blobs (`whoTheyAre`, `relationshipToYou`, etc.) to named structured fields:

```
email, phone, linkedin, twitter, company, role, location
relationshipWithUser
additionalInformation
```

After LLM extraction, non-empty values are written back to the Contact row (`emails`, `phones`, `company`, `role`, `location`, `handles`). This means keyword search and the agent `contact_search` tool also benefit. Existing manually-edited values are not overwritten if the LLM returns nothing.

### 4. 3-section formatted description

**Before:** `renderDescription` produced flat `Key: value` lines with no hierarchy.

**After:** The description field is now rendered as structured markdown:

```markdown
### Basic Info
- Email: john@acme.com
- Contact: +1-234-567-8900
- LinkedIn: linkedin.com/in/john
- Location: San Francisco
- Company: Acme Corp
- Role: VP Engineering

### Relationship with User
Met at YC W22 batch. John is a close collaborator on ...

### Additional Information
Last spoke 2 weeks ago about the Series A. Follow up needed on ...
```

Empty sections are omitted. This is what's shown on the contact detail page when you click a contact in People.

## Why

The previous approach of using extracted graph statements as LLM input meant email/phone/LinkedIn were almost never populated (the extraction pipeline doesn't consistently create statements for raw contact info). Using the original episode text gives the LLM full context to extract exactly what the user wrote. Capping at 5 episodes (instead of 30) keeps the context window tight and cost low while still covering recent history.

## Files changed

| File | Change |
|---|---|
| `services/graphModels/episode.ts` | Add `getEpisodesForEntity` wrapper |
| `services/contacts/contact-summary.server.ts` | New schema, SYSTEM prompt, `renderDescription` |
| `jobs/contacts/contact-sync.logic.ts` | Use 5 episodes + guarantee current episode, write back structured fields |
| `jobs/ingest/graph-resolution.logic.ts` | Pass `episodeUuid` into `syncContactForEntity` |
| `services/contacts/__tests__/contact-summary.test.ts` | Updated for new interface |
| `services/contacts/__tests__/reconcile.test.ts` | Updated mocks (`getEntityFacts` → `getEpisodesForEntity`) |

## Reviewer notes

- The `descriptionEdited` flag still protects the prior description — when `true` it's passed as AUTHORITATIVE to the LLM so user-edited relationship notes are preserved.
- Structured fields (email, phones, etc.) are only overwritten when the LLM returns a non-empty value, so manual edits to those fields aren't cleared.
- The 24h throttle and `force` refresh (Refresh button on detail page) behaviour is unchanged.
- `getEntityFacts` still exists in `entity.ts` as a general-purpose utility; it's just no longer called by the contact sync path.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)