### PR TITLE
fix(agent): deliver compact summary to the model in long conversations

### DIFF
--- a/apps/webapp/app/jobs/session/session-compaction.logic.ts
+++ b/apps/webapp/app/jobs/session/session-compaction.logic.ts
@@ -270,6 +270,7 @@ async function upsertDocumentFromCompaction(
   userId: string,
   workspaceId: string,
   episodes: EpisodicNode[],
+  priorCoveredUntil?: string | null,
 ): Promise<Document | undefined> {
   try {
     // Extract label IDs from first episode (if available)
@@ -282,6 +283,30 @@ async function upsertDocumentFromCompaction(
       episodes,
       workspaceId,
     );
+
+    // Coverage watermark (consumed by selectModelMessages, #2): the latest
+    // episode time folded into this summary. Monotonic — never regress below a
+    // prior watermark even if an older episode arrives late, so the consumer
+    // never under-reports coverage and opens a gap.
+    const batchMaxValidAtMs = episodes.reduce((max, e) => {
+      const t = new Date(e.validAt as unknown as string).getTime();
+      return Number.isFinite(t) && t > max ? t : max;
+    }, 0);
+    const priorMs = priorCoveredUntil
+      ? new Date(priorCoveredUntil).getTime()
+      : 0;
+    const coveredUntilMs = Math.max(
+      Number.isFinite(priorMs) ? priorMs : 0,
+      batchMaxValidAtMs,
+    );
+    const coveredUntil =
+      coveredUntilMs > 0 ? new Date(coveredUntilMs).toISOString() : undefined;
+
+    const metadata = {
+      episodeCount: episodes.length,
+      compactedAt: new Date().toISOString(),
+      ...(coveredUntil ? { coveredUntil } : {}),
+    };
 
     const document = await prisma.document.upsert({
       where: {
@@ -297,10 +322,7 @@ async function upsertDocumentFromCompaction(
         labelIds,
         source,
         type: "conversation",
-        metadata: {
-          episodeCount: episodes.length,
-          compactedAt: new Date().toISOString(),
-        },
+        metadata,
         editedBy: userId,
         workspaceId,
       },
@@ -309,10 +331,7 @@ async function upsertDocumentFromCompaction(
         sessionId,
         content: summary,
         updatedAt: new Date(),
-        metadata: {
-          episodeCount: episodes.length,
-          compactedAt: new Date().toISOString(),
-        },
+        metadata,
       },
     });
 
@@ -390,6 +409,14 @@ async function updateCompaction(
     workspaceId,
   );
 
+  // Carry the prior coverage watermark forward so it stays monotonic across
+  // incremental merges (see upsertDocumentFromCompaction).
+  const priorMeta = existingCompact.metadata as Record<string, unknown> | null;
+  const priorCoveredUntil =
+    typeof priorMeta?.coveredUntil === "string"
+      ? priorMeta.coveredUntil
+      : undefined;
+
   // Update graph, vector DB, and Document table in parallel
   const document = await upsertDocumentFromCompaction(
     existingCompact.sessionId as string,
@@ -398,6 +425,7 @@ async function updateCompaction(
     userId,
     workspaceId,
     newEpisodes,
+    priorCoveredUntil,
   );
 
   logger.info(`Compaction updated and stored in vector DB and Document table`, {

--- a/apps/webapp/app/routes/api.v1.conversation._index.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation._index.tsx
@@ -35,6 +35,7 @@ import { type OutputProcessor, type Processor } from "@mastra/core/processors";
 import { patchArgsDeep } from "~/services/agent/tool-args-patch-processor";
 import {
   selectModelMessages,
+  compactSurvivedInModelMessages,
   describeAgentError,
   prepareHistoryParts,
   type MessageEntry,
@@ -223,7 +224,7 @@ const { loader, action } = createHybridActionApiRoute(
           history.role ?? (history.userType === "Agent" ? "assistant" : "user");
         const normalized = normalizeParts(history.parts);
         const parts = prepareHistoryParts(role, normalized);
-        return { parts, role, id: history.id };
+        return { parts, role, id: history.id, createdAt: history.createdAt };
       },
     );
 
@@ -232,6 +233,7 @@ const { loader, action } = createHybridActionApiRoute(
     );
 
     let finalMessages: MessageEntry[];
+    let selectionMode: string | undefined;
     if (isAssistantApproval) {
       // Resume path: use exactly what the client sent — the suspended run
       // already has its own message list and we mustn't change it.
@@ -284,6 +286,7 @@ const { loader, action } = createHybridActionApiRoute(
         compactTokens: selection.stats.compactTokens,
       });
       finalMessages = selection.messages;
+      selectionMode = selection.mode;
     }
 
     logHeap("handler:context-selected", {
@@ -327,6 +330,24 @@ const { loader, action } = createHybridActionApiRoute(
       modelConfig,
       mode: body.mode,
     });
+
+    // Delivery invariant: in compact+recent mode the compact summary MUST reach
+    // the model. It is the agent's only view of everything older than the recent
+    // window — if a converter/provider change ever drops it again, the agent
+    // silently loses that context and re-asks. Surface it loudly rather than
+    // letting it regress unnoticed.
+    if (selectionMode === "compact+recent") {
+      const compactPresent = compactSurvivedInModelMessages(
+        modelMessages as any[],
+      );
+      if (!compactPresent) {
+        logger.error("Compact summary missing from model messages (stream)", {
+          conversationId: body.id,
+          mode: selectionMode,
+          modelMessageCount: (modelMessages as any[]).length,
+        });
+      }
+    }
 
     const subagents: Record<string, Agent> = {
       gather_context: gatherContextAgent,

--- a/apps/webapp/app/services/agent/__tests__/context-window.test.ts
+++ b/apps/webapp/app/services/agent/__tests__/context-window.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { convertMessages } from "@mastra/core/agent";
+import { logger } from "~/services/logger.service";
 import {
+  COMPACT_PROMPT_MARKER,
+  compactSurvivedInModelMessages,
   describeAgentError,
   estimateMessageTokens,
   generateWithRetry,
+  parseCoveredUntil,
   selectModelMessages,
   type MessageEntry,
 } from "~/services/agent/context-window";
@@ -168,8 +173,10 @@ describe("selectModelMessages — compact+recent mode", () => {
     });
 
     expect(result.mode).toBe("compact+recent");
-    // First message is a system role holding the compact.
-    expect(result.messages[0].role).toBe("system");
+    // First message is a leading user-role context block holding the compact.
+    // (A system-role message here is silently stripped by convertMessages — see
+    // the "compact delivery — survives the convertMessages boundary" test.)
+    expect(result.messages[0].role).toBe("user");
     expect(result.messages[0].parts[0].type).toBe("text");
     expect(result.messages[0].parts[0].text).toContain(
       "Earlier in this conversation",
@@ -203,6 +210,229 @@ describe("selectModelMessages — compact+recent mode", () => {
     });
     // Falls through to budget-trim (still works even though no compact).
     expect(result.mode).toBe("budget-trim");
+  });
+});
+
+describe("compact delivery — survives the convertMessages boundary", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.document.findUnique).mockReset();
+  });
+
+  // Reproduces the exact production chain for a long conversation:
+  //   selectModelMessages -> finalMessages -> convertMessages().to("AIV5.Model")
+  // (the conversion at services/agent/context.ts:764). selectModelMessages
+  // injects the compact as a mid-array role:"system" message; the real system
+  // prompt is passed separately as the agent's `instructions`. This test asks
+  // the decisive question: does the compact's content actually reach the model?
+  it("keeps the compact summary in the model messages after .to('AIV5.Model')", async () => {
+    const history: MessageEntry[] = [];
+    for (let i = 0; i < 15; i++) {
+      history.push(msg(`m${i}`, i % 2 === 0 ? "user" : "assistant", `msg ${i}`));
+    }
+    const current = msg("current", "user", "what's my deadline again?");
+
+    const COMPACT_MARKER = "Earlier in this conversation";
+    const COMPACT_FACT = "User's deadline is March 3rd.";
+    vi.mocked(prisma.document.findUnique).mockResolvedValue({
+      content: COMPACT_FACT,
+    } as any);
+
+    const selection = await selectModelMessages({
+      workspaceId: "ws1",
+      conversationId: "c1",
+      history,
+      currentMessage: current,
+    });
+
+    // Precondition: the compact is present in selectModelMessages' own output.
+    expect(selection.mode).toBe("compact+recent");
+    expect(JSON.stringify(selection.messages)).toContain(COMPACT_FACT);
+
+    // The exact conversion buildAgentContext performs before the model call.
+    const modelMessages = convertMessages(selection.messages as any).to(
+      "AIV5.Model",
+    );
+
+    // The decisive assertion: the compact's content must survive into what the
+    // model actually receives. If convertMessages strips the mid-array system
+    // message, these fail — confirming the compact never reaches the LLM.
+    const serialized = JSON.stringify(modelMessages);
+    expect(serialized).toContain(COMPACT_FACT);
+    expect(serialized).toContain(COMPACT_MARKER);
+    // The delivery invariant used at runtime must agree.
+    expect(compactSurvivedInModelMessages(modelMessages as any)).toBe(true);
+  });
+});
+
+describe("compactSurvivedInModelMessages — delivery invariant", () => {
+  it("detects the compact across model and UI message shapes", () => {
+    const withMarker = `## ${COMPACT_PROMPT_MARKER}\n\nUser lives in Berlin.`;
+    // content: string (model shape)
+    expect(
+      compactSurvivedInModelMessages([{ role: "user", content: withMarker }]),
+    ).toBe(true);
+    // content: [{ text }] (model shape)
+    expect(
+      compactSurvivedInModelMessages([
+        { role: "user", content: [{ type: "text", text: withMarker }] },
+      ]),
+    ).toBe(true);
+    // parts: [{ text }] (pre-convert UI shape)
+    expect(
+      compactSurvivedInModelMessages([
+        { role: "user", parts: [{ type: "text", text: withMarker }] },
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when no message carries the compact", () => {
+    expect(
+      compactSurvivedInModelMessages([
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+        { role: "assistant", content: "hi there" },
+      ]),
+    ).toBe(false);
+    expect(compactSurvivedInModelMessages([])).toBe(false);
+    expect(compactSurvivedInModelMessages(undefined as any)).toBe(false);
+  });
+});
+
+describe("parseCoveredUntil", () => {
+  it("parses an ISO string and an epoch number; rejects junk/absent", () => {
+    const iso = "2026-01-01T00:00:00.000Z";
+    expect(parseCoveredUntil({ coveredUntil: iso })).toBe(
+      new Date(iso).getTime(),
+    );
+    expect(parseCoveredUntil({ coveredUntil: 1000 })).toBe(1000);
+    expect(parseCoveredUntil({})).toBeNull();
+    expect(parseCoveredUntil(null)).toBeNull();
+    expect(parseCoveredUntil({ coveredUntil: "not-a-date" })).toBeNull();
+  });
+});
+
+describe("selectModelMessages — compact+recent watermark tiling (#2)", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.document.findUnique).mockReset();
+  });
+
+  function historyWithTimes(n: number, stepMs = 1_000): MessageEntry[] {
+    const h: MessageEntry[] = [];
+    for (let i = 0; i < n; i++) {
+      h.push({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `msg ${i}` }],
+        createdAt: new Date((i + 1) * stepMs).toISOString(),
+      });
+    }
+    return h;
+  }
+
+  it("fast case: watermark past all history → tail is the last RECENT_MESSAGE_WINDOW", async () => {
+    const history = historyWithTimes(20); // times 1000..20000
+    const current = msg("current", "user", "now");
+    vi.mocked(prisma.document.findUnique).mockResolvedValue({
+      content: "summary",
+      metadata: { coveredUntil: new Date(1_000_000).toISOString() },
+    } as any);
+
+    const result = await selectModelMessages({
+      workspaceId: "ws1",
+      conversationId: "c1",
+      history,
+      currentMessage: current,
+    });
+
+    expect(result.mode).toBe("compact+recent");
+    expect(result.messages.slice(1, 11).map((m) => m.id)).toEqual(
+      history.slice(-10).map((m) => m.id),
+    );
+    expect(result.messages.at(-1)).toBe(current);
+    expect(result.stats.keptMessages).toBe(12);
+  });
+
+  it("lag case: stale watermark bridges the gap → keeps uncovered messages older than the recent window", async () => {
+    const history = historyWithTimes(20); // times 1000..20000
+    const current = msg("current", "user", "now");
+    // Compact only covers through time 6000 (m0..m5). m6..m19 are uncovered.
+    vi.mocked(prisma.document.findUnique).mockResolvedValue({
+      content: "summary",
+      metadata: { coveredUntil: new Date(6_000).toISOString() },
+    } as any);
+
+    const result = await selectModelMessages({
+      workspaceId: "ws1",
+      conversationId: "c1",
+      history,
+      currentMessage: current,
+    });
+
+    expect(result.mode).toBe("compact+recent");
+    const verbatimIds = result.messages.slice(1, -1).map((m) => m.id);
+    // m6 is older than the last-10 window (m10..m19) yet uncovered → must be kept.
+    expect(verbatimIds).toContain("m6");
+    expect(verbatimIds[0]).toBe("m6"); // tail starts exactly at the first uncovered
+    // m5 is covered by the compact → not also sent verbatim.
+    expect(verbatimIds).not.toContain("m5");
+    expect(result.messages.at(-1)).toBe(current);
+  });
+
+  it("missing watermark (pre-#2 docs): falls back to the last RECENT_MESSAGE_WINDOW", async () => {
+    const history = historyWithTimes(20);
+    const current = msg("current", "user", "now");
+    vi.mocked(prisma.document.findUnique).mockResolvedValue({
+      content: "summary", // no metadata
+    } as any);
+
+    const result = await selectModelMessages({
+      workspaceId: "ws1",
+      conversationId: "c1",
+      history,
+      currentMessage: current,
+    });
+
+    expect(result.mode).toBe("compact+recent");
+    expect(result.messages.slice(1, 11).map((m) => m.id)).toEqual(
+      history.slice(-10).map((m) => m.id),
+    );
+    expect(result.stats.coveredUntil).toBeNull();
+  });
+
+  it("budget cap: trims oldest of the bridged tail and alarms when dropping uncovered messages", async () => {
+    const errorSpy = vi
+      .spyOn(logger, "error")
+      .mockImplementation(() => undefined as any);
+    // 20 big messages (~5k tokens each), all uncovered (watermark covers nothing).
+    const history: MessageEntry[] = [];
+    for (let i = 0; i < 20; i++) {
+      history.push({
+        id: `m${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: "x".repeat(20_000) }],
+        createdAt: new Date((i + 1) * 1_000).toISOString(),
+      });
+    }
+    const current = msg("current", "user", "now");
+    vi.mocked(prisma.document.findUnique).mockResolvedValue({
+      content: "summary",
+      metadata: { coveredUntil: new Date(1).toISOString() },
+    } as any);
+
+    const result = await selectModelMessages({
+      workspaceId: "ws1",
+      conversationId: "c1",
+      history,
+      currentMessage: current,
+    });
+
+    expect(result.mode).toBe("compact+recent");
+    const verbatimIds = result.messages.slice(1, -1).map((m) => m.id);
+    expect(verbatimIds.length).toBeLessThan(20); // capped
+    expect(verbatimIds.length).toBeGreaterThan(0);
+    expect(verbatimIds).toContain("m19"); // newest kept
+    expect(verbatimIds).not.toContain("m0"); // oldest dropped
+    expect(errorSpy).toHaveBeenCalled(); // dropped messages were uncovered → gap alarm
+    errorSpy.mockRestore();
   });
 });
 
@@ -431,5 +661,45 @@ describe("generateWithRetry", () => {
       expect(call[0].role).toBe("system");
       expect(call.at(-1).parts[0].text).toBe("current");
     }
+  });
+
+  it("pins the compact summary across context-length retries (never drops it)", async () => {
+    const compactText = `## ${COMPACT_PROMPT_MARKER}\n\nUser's flight is on Friday.`;
+    let callCount = 0;
+    const calledWith: any[][] = [];
+    const agent = makeFakeAgent(async (messages) => {
+      callCount++;
+      calledWith.push(messages);
+      if (callCount <= 2) throw new Error("context length exceeded");
+      return { text: "ok", steps: [] };
+    });
+
+    // Mirrors compact+recent after convertMessages: a leading USER-role compact
+    // (no system message), then real rounds, then the current turn.
+    const modelMessages = [
+      { role: "user", content: [{ type: "text", text: compactText }] },
+      { role: "user", content: [{ type: "text", text: "u1" }] },
+      { role: "assistant", content: [{ type: "text", text: "a1" }] },
+      { role: "user", content: [{ type: "text", text: "u2" }] },
+      { role: "assistant", content: [{ type: "text", text: "a2" }] },
+      { role: "user", content: [{ type: "text", text: "current" }] },
+    ];
+
+    await generateWithRetry({
+      agent,
+      modelMessages,
+      generateOptions: {},
+      conversationId: "c1",
+    });
+
+    expect(callCount).toBe(3);
+    // The compact must survive every attempt and stay at the front; the current
+    // turn must always be last. Oldest *real* rounds are dropped instead.
+    for (const call of calledWith) {
+      expect(compactSurvivedInModelMessages(call)).toBe(true);
+      expect(call[0].content[0].text).toContain(COMPACT_PROMPT_MARKER);
+      expect(call.at(-1).content[0].text).toBe("current");
+    }
+    expect(calledWith[2].length).toBeLessThan(modelMessages.length);
   });
 });

--- a/apps/webapp/app/services/agent/context-window.ts
+++ b/apps/webapp/app/services/agent/context-window.ts
@@ -26,6 +26,12 @@ export interface MessageEntry {
   id: string;
   role: "user" | "assistant" | "system";
   parts: MessagePart[];
+  /**
+   * When the message was created (ConversationHistory.createdAt). Optional —
+   * used to bridge the compact's coverage watermark to the verbatim tail. When
+   * absent, selection falls back to the fixed recent window.
+   */
+  createdAt?: string | Date;
 }
 
 /**
@@ -64,6 +70,8 @@ export interface SelectionResult {
     keptMessages: number;
     estimatedTokens: number;
     compactTokens: number | null;
+    /** Compact coverage watermark (ISO) when known — observability for #2. */
+    coveredUntil?: string | null;
   };
 }
 
@@ -94,6 +102,15 @@ export const IMAGE_TOKEN_COST = 1500;
 
 /** Max retries on context-length errors inside generateWithRetry. */
 export const CONTEXT_RETRY_MAX = 2;
+
+/**
+ * Header prepended to the compact summary when it is injected into the prompt.
+ * Exported so the delivery invariant (compactSurvivedInModelMessages) and the
+ * retry-path pin (dropOldestRound) can recognise the compact AFTER it has been
+ * through convertMessages — its `id` is lost in that conversion, but this
+ * marker text survives.
+ */
+export const COMPACT_PROMPT_MARKER = "Earlier in this conversation";
 
 // ─── Token estimation ───────────────────────────────────────────────
 
@@ -132,7 +149,20 @@ export function estimateMessageTokens(message: MessageEntry): number {
   return total;
 }
 
-// ─── Stubs (filled in by later tasks) ───────────────────────────────
+/**
+ * Read the compact's coverage watermark from Document.metadata — the max
+ * episode validAt folded into the summary at the last compaction, written by
+ * session-compaction. Returns epoch ms, or null if absent/unparseable (e.g.
+ * documents compacted before #2 shipped), in which case selection falls back to
+ * the fixed recent window.
+ */
+export function parseCoveredUntil(metadata: unknown): number | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const raw = (metadata as Record<string, unknown>).coveredUntil;
+  if (typeof raw !== "string" && typeof raw !== "number") return null;
+  const t = new Date(raw).getTime();
+  return Number.isFinite(t) ? t : null;
+}
 
 export async function selectModelMessages(params: {
   workspaceId: string;
@@ -163,16 +193,19 @@ export async function selectModelMessages(params: {
   }
 
   // Over threshold: try compact+recent, fall back to budget-trim.
-  let compact: { content: string } | null = null;
+  let compact: { content: string; coveredUntil: number | null } | null = null;
   try {
     const doc = await prisma.document.findUnique({
       where: {
         sessionId_workspaceId: { sessionId: conversationId, workspaceId },
       },
-      select: { content: true },
+      select: { content: true, metadata: true },
     });
     if (doc && typeof doc.content === "string" && doc.content.length > 0) {
-      compact = { content: doc.content };
+      compact = {
+        content: doc.content,
+        coveredUntil: parseCoveredUntil(doc.metadata),
+      };
     }
   } catch (error) {
     logger.warn("selectModelMessages: compact lookup failed, falling through", {
@@ -182,19 +215,80 @@ export async function selectModelMessages(params: {
   }
 
   if (compact) {
-    const compactText = `## Earlier in this conversation\n\n${compact.content}`;
+    const coveredUntil = compact.coveredUntil;
+    const compactText = `## ${COMPACT_PROMPT_MARKER}\n\n${compact.content}`;
+    // Deliver the compact as a leading USER message, NOT a system message.
+    // (See COMPACT_PROMPT_MARKER: convertMessages strips role:"system" entries,
+    // so a system-role compact never reaches the model. A user-role context
+    // block survives, mirroring how a /compact summary becomes the leading turn.)
     const compactMessage: MessageEntry = {
       id: `compact-${conversationId}`,
-      role: "system",
+      role: "user",
       parts: [{ type: "text", text: compactText }],
     };
-    const recent = history.slice(-RECENT_MESSAGE_WINDOW);
-    const messages = [compactMessage, ...recent, currentMessage];
+
+    // Hybrid verbatim tail: always keep the last RECENT_MESSAGE_WINDOW messages
+    // for recency fidelity, AND extend further back to bridge any gap between
+    // what the compact actually covers (coveredUntil) and that window — so a
+    // lagging compaction can never drop messages that are in neither the compact
+    // nor the verbatim tail. Biases to overlap (safe), never to a gap. When the
+    // watermark is absent (docs compacted before #2), this is exactly the old
+    // last-N behaviour.
+    let tailStart = Math.max(0, history.length - RECENT_MESSAGE_WINDOW);
+    if (coveredUntil != null) {
+      const firstUncovered = history.findIndex(
+        (m) =>
+          m.createdAt != null &&
+          new Date(m.createdAt).getTime() > coveredUntil,
+      );
+      if (firstUncovered >= 0) {
+        tailStart = Math.min(tailStart, firstUncovered);
+      }
+    }
+
+    // Budget cap: keep the tail newest-first under BUDGET_TRIM_TOKENS (minus the
+    // compact + current). If the cap forces dropping messages the compact does
+    // NOT cover, that is real context loss — surface it loudly (it must not
+    // regress silently the way the original delivery bug did).
     const compactTokens = estimateMessageTokens(compactMessage);
-    const estimatedTokens = messages.reduce(
-      (sum, m) => sum + estimateMessageTokens(m),
-      0,
-    );
+    const currentTokens = estimateMessageTokens(currentMessage);
+    const tailBudget = BUDGET_TRIM_TOKENS - compactTokens - currentTokens;
+    const fullTail = history.slice(tailStart);
+    const keptTail: MessageEntry[] = [];
+    let tailUsed = 0;
+    let droppedOldest = 0;
+    for (let i = fullTail.length - 1; i >= 0; i--) {
+      const cost = estimateMessageTokens(fullTail[i]);
+      if (keptTail.length > 0 && tailUsed + cost > tailBudget) {
+        droppedOldest = i + 1;
+        break;
+      }
+      keptTail.unshift(fullTail[i]);
+      tailUsed += cost;
+    }
+
+    if (droppedOldest > 0 && coveredUntil != null) {
+      const lostUncovered = fullTail
+        .slice(0, droppedOldest)
+        .some(
+          (m) =>
+            m.createdAt != null &&
+            new Date(m.createdAt).getTime() > coveredUntil,
+        );
+      if (lostUncovered) {
+        logger.error(
+          "selectModelMessages: budget cap dropped messages not covered by the compact (context gap)",
+          {
+            conversationId,
+            droppedOldest,
+            coveredUntil: new Date(coveredUntil).toISOString(),
+          },
+        );
+      }
+    }
+
+    const messages = [compactMessage, ...keptTail, currentMessage];
+    const estimatedTokens = compactTokens + currentTokens + tailUsed;
     return {
       messages,
       mode: "compact+recent",
@@ -203,6 +297,8 @@ export async function selectModelMessages(params: {
         keptMessages: messages.length,
         estimatedTokens,
         compactTokens,
+        coveredUntil:
+          coveredUntil != null ? new Date(coveredUntil).toISOString() : null,
       },
     };
   }
@@ -235,16 +331,58 @@ export async function selectModelMessages(params: {
 }
 
 /**
- * Drop the oldest user-assistant pair from a message array. Preserves the
- * first message (system/compact) and the last message (current user turn).
- * If no pair exists to drop, returns the input unchanged.
+ * Does this message carry the compact summary? Recognises both the pre-convert
+ * UI shape (`parts: [{ text }]`) and the post-convert model shape
+ * (`content: string` or `content: [{ text }]`), since the compact's `id` does
+ * not survive convertMessages but COMPACT_PROMPT_MARKER does.
+ */
+function messageHasCompactMarker(message: any): boolean {
+  if (!message) return false;
+  const { content, parts } = message;
+  if (typeof content === "string" && content.includes(COMPACT_PROMPT_MARKER)) {
+    return true;
+  }
+  for (const list of [content, parts]) {
+    if (Array.isArray(list)) {
+      for (const p of list) {
+        if (typeof p?.text === "string" && p.text.includes(COMPACT_PROMPT_MARKER)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Defense-in-depth: confirm the compact summary actually survived into the
+ * messages handed to the model. convertMessages / provider adapters have been
+ * observed silently dropping messages (notably mid-array role:"system"); when
+ * that happens in compact+recent mode the agent loses everything older than the
+ * recent window and re-asks for things it was already told. Only meaningful when
+ * the selection mode is "compact+recent". Short-circuits on the first match
+ * (the compact is the leading message), so it is cheap.
+ */
+export function compactSurvivedInModelMessages(modelMessages: any[]): boolean {
+  for (const m of modelMessages ?? []) {
+    if (messageHasCompactMarker(m)) return true;
+  }
+  return false;
+}
+
+/**
+ * Drop the oldest user-assistant pair from a message array. Preserves leading
+ * pinned messages — system prompts AND the injected compact summary (a leading
+ * user message identified by COMPACT_PROMPT_MARKER) — and the last message
+ * (current user turn). If no droppable pair exists, returns the input unchanged.
  */
 function dropOldestRound(messages: any[]): any[] {
   if (messages.length <= 2) return messages;
-  // Find the oldest non-system message index (skip leading system prompts).
+  // Find the oldest droppable message — skip leading system prompts and the
+  // pinned compact summary so context-length retries never evict them.
   let firstUserIdx = -1;
   for (let i = 0; i < messages.length - 1; i++) {
-    if (messages[i].role !== "system") {
+    if (messages[i].role !== "system" && !messageHasCompactMarker(messages[i])) {
       firstUserIdx = i;
       break;
     }

--- a/apps/webapp/app/services/agent/no-stream-process.ts
+++ b/apps/webapp/app/services/agent/no-stream-process.ts
@@ -24,6 +24,7 @@ import { deductCredits } from "~/trigger/utils/utils";
 import { addToQueue } from "~/lib/ingest.server";
 import {
   selectModelMessages,
+  compactSurvivedInModelMessages,
   generateWithRetry,
   describeAgentError,
   prepareHistoryParts,
@@ -122,12 +123,13 @@ export async function noStreamProcess(
         history.role ?? (history.userType === "Agent" ? "assistant" : "user");
       const normalized = normalizeParts(history.parts);
       const parts = prepareHistoryParts(role, normalized);
-      return { parts, role, id: history.id };
+      return { parts, role, id: history.id, createdAt: history.createdAt };
     })
     .filter((m) => hasNonEmptyParts(m.parts));
 
   const message = body.message?.parts[0].text;
   let finalMessages: MessageEntry[];
+  let selectionMode: string | undefined;
 
   if (!isAssistantApproval) {
     const id = body.message?.id;
@@ -152,6 +154,7 @@ export async function noStreamProcess(
       compactTokens: selection.stats.compactTokens,
     });
     finalMessages = selection.messages;
+    selectionMode = selection.mode;
   } else {
     finalMessages = body.messages as any;
   }
@@ -184,6 +187,23 @@ export async function noStreamProcess(
     modelConfig,
     scratchpadPageId: body.scratchpadPageId,
   });
+
+  // Delivery invariant: in compact+recent mode the compact summary MUST reach
+  // the model — it is the agent's only view of everything older than the recent
+  // window. If a converter/provider change ever drops it, surface it loudly
+  // instead of silently losing context and re-asking.
+  if (selectionMode === "compact+recent") {
+    const compactPresent = compactSurvivedInModelMessages(
+      modelMessages as any[],
+    );
+    if (!compactPresent) {
+      logger.error("Compact summary missing from model messages", {
+        conversationId: body.id,
+        mode: selectionMode,
+        modelMessageCount: (modelMessages as any[]).length,
+      });
+    }
+  }
 
   // Create core agent with subagents — think only present for triggered flows
   const subagents: Record<string, Agent> = {


### PR DESCRIPTION
## Problem

In long conversations the agent re-asked for information already in the conversation document. Root cause: in compact+recent mode the compact was injected as a mid-array role:"system" message; convertMessages(...).to("AIV5.Model") strips system-role entries out of the conversation, so the compact never reached the model, it only saw the last 10 turns.

## Fix
Compact delivered as a leading user-role context block (survives conversion).

1. Delivery invariant: verify the compact reached the model in compact+recent mode, log loudly if not. (stream + no-stream)
2. Coverage watermark (coveredUntil in Document.metadata, no migration) + hybrid tail: keep last N turns and bridge back to the watermark so a lagging compaction can't open a gap. 
3. Pin the compact during context-length retries (dropOldestRound).

## Tests
29 cases in context-window.test.ts, incl. the convertMessages boundary regression proving the compact now reaches the model.