### PR TITLE
fix(contacts): populate email/phone/category fields and fix description format

### DIFF
--- a/apps/webapp/app/jobs/contacts/contact-sync.logic.ts
+++ b/apps/webapp/app/jobs/contacts/contact-sync.logic.ts
@@ -116,6 +116,7 @@ export async function syncContactForEntity(
   if (extractedFields.company) fieldUpdates.company = extractedFields.company;
   if (extractedFields.role) fieldUpdates.role = extractedFields.role;
   if (extractedFields.location) fieldUpdates.location = extractedFields.location;
+  if (extractedFields.category) fieldUpdates.category = extractedFields.category;
   const newHandles = [extractedFields.linkedin, extractedFields.twitter].filter(Boolean);
   if (newHandles.length > 0) fieldUpdates.handles = newHandles;
 

--- a/apps/webapp/app/services/contacts/__tests__/contact-summary.test.ts
+++ b/apps/webapp/app/services/contacts/__tests__/contact-summary.test.ts
@@ -86,3 +86,43 @@ describe("renderDescription", () => {
     expect(body).toBe("");
   });
 });
+
+describe("buildSummaryMessages date handling", () => {
+  it("handles validAt as ISO string from unparsed Neo4j results without throwing", () => {
+    const messages = buildSummaryMessages({
+      userName: "Manik",
+      personName: "Abhishek",
+      today: new Date("2026-06-19T00:00:00Z"),
+      episodes: [
+        {
+          content: "Abhishek is a close friend.",
+          validAt: "2026-01-15T00:00:00.000Z" as any,
+        },
+      ],
+      priorDescription: null,
+      descriptionEdited: false,
+    });
+    const text = JSON.stringify(messages);
+    expect(text).toContain("2026-01-15");
+  });
+});
+
+describe("category extraction", () => {
+  it("includes category instruction in the system prompt", () => {
+    const messages = buildSummaryMessages({
+      userName: "Manik",
+      personName: "Abhishek",
+      today: new Date("2026-06-19T00:00:00Z"),
+      episodes: [
+        {
+          content: "Abhishek is a close college friend from IIT KGP.",
+          validAt: new Date("2026-01-01T00:00:00Z"),
+        },
+      ],
+      priorDescription: null,
+      descriptionEdited: false,
+    });
+    const systemMessage = JSON.stringify(messages[0]);
+    expect(systemMessage).toContain("category");
+  });
+});

--- a/apps/webapp/app/services/contacts/__tests__/reconcile.test.ts
+++ b/apps/webapp/app/services/contacts/__tests__/reconcile.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("~/services/logger.service", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(), log: vi.fn() },
@@ -23,7 +23,7 @@ vi.mock("~/services/contacts/contact-summary.server", () => ({
   generateContactSummary: vi.fn(),
 }));
 
-import { isSelf, needsRefresh } from "~/jobs/contacts/contact-sync.logic";
+import { isSelf, needsRefresh, syncContactForEntity } from "~/jobs/contacts/contact-sync.logic";
 
 describe("isSelf", () => {
   it("matches the user's own name case-insensitively", () => {
@@ -44,5 +44,130 @@ describe("needsRefresh", () => {
   });
   it("returns false when there is no memory at all", () => {
     expect(needsRefresh(new Date("2026-02-01"), null)).toBe(false);
+  });
+});
+
+describe("syncContactForEntity", () => {
+  const baseContact = {
+    id: "c1",
+    workspaceId: "ws1",
+    userId: "u1",
+    entityUuid: "e1",
+    name: "Abhishek",
+    emails: [],
+    phones: [],
+    handles: [],
+    company: null,
+    role: null,
+    location: null,
+    category: null,
+    headline: null,
+    description: null,
+    descriptionEdited: false,
+    status: "Researching" as const,
+    source: "Auto" as const,
+    lastMemoryAt: null,
+    lastSummarizedAt: null,
+    avatarUrl: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    editedAt: null,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("writes back category when the LLM extracts it from episodes", async () => {
+    const { prisma } = await import("~/db.server");
+    const { upsertContactForEntity, updateContactFields } = await import(
+      "~/services/contacts/contact.server"
+    );
+    const { getEpisodesForEntity } = await import("~/services/graphModels/episode");
+    const { generateContactSummary } = await import(
+      "~/services/contacts/contact-summary.server"
+    );
+
+    vi.mocked(prisma.contact.findUnique).mockResolvedValue(null);
+    vi.mocked(upsertContactForEntity).mockResolvedValue(baseContact as any);
+    vi.mocked(getEpisodesForEntity).mockResolvedValue([
+      {
+        uuid: "ep1",
+        content: "Abhishek is a close college friend from IIT KGP.",
+        validAt: new Date("2026-01-01"),
+      } as any,
+    ]);
+    vi.mocked(generateContactSummary).mockResolvedValue({
+      headline: "ML Engineer; college friend",
+      description: "### Relationship with User\nClose college friend.",
+      extractedFields: {
+        email: "abhishek@observe.ai",
+        phone: "",
+        linkedin: "",
+        twitter: "",
+        company: "Observe.ai",
+        role: "ML Engineer",
+        location: "Bangalore",
+        category: "Friend",
+      },
+    });
+
+    await syncContactForEntity({
+      workspaceId: "ws1",
+      userId: "u1",
+      userName: "Manik",
+      entityUuid: "e1",
+      name: "Abhishek",
+      latestFactAt: new Date("2026-01-01"),
+    });
+
+    expect(updateContactFields).toHaveBeenCalledWith(
+      "ws1",
+      "c1",
+      expect.objectContaining({ category: "Friend" }),
+    );
+  });
+
+  it("does not overwrite category when the LLM returns an empty string", async () => {
+    const { prisma } = await import("~/db.server");
+    const { upsertContactForEntity, updateContactFields } = await import(
+      "~/services/contacts/contact.server"
+    );
+    const { getEpisodesForEntity } = await import("~/services/graphModels/episode");
+    const { generateContactSummary } = await import(
+      "~/services/contacts/contact-summary.server"
+    );
+
+    vi.mocked(prisma.contact.findUnique).mockResolvedValue(null);
+    vi.mocked(upsertContactForEntity).mockResolvedValue(baseContact as any);
+    vi.mocked(getEpisodesForEntity).mockResolvedValue([
+      { uuid: "ep1", content: "Some episode content.", validAt: new Date("2026-01-01") } as any,
+    ]);
+    vi.mocked(generateContactSummary).mockResolvedValue({
+      headline: "Unknown",
+      description: "",
+      extractedFields: {
+        email: "",
+        phone: "",
+        linkedin: "",
+        twitter: "",
+        company: "",
+        role: "",
+        location: "",
+        category: "",
+      },
+    });
+
+    await syncContactForEntity({
+      workspaceId: "ws1",
+      userId: "u1",
+      userName: "Manik",
+      entityUuid: "e1",
+      name: "Abhishek",
+      latestFactAt: new Date("2026-01-01"),
+    });
+
+    const call = vi.mocked(updateContactFields).mock.calls[0][2] as Record<string, any>;
+    expect(call).not.toHaveProperty("category");
   });
 });

--- a/apps/webapp/app/services/contacts/contact-summary.server.ts
+++ b/apps/webapp/app/services/contacts/contact-summary.server.ts
@@ -11,6 +11,7 @@ export const ContactSummarySchema = z.object({
   company: z.string().default("").describe("employer or organization if found"),
   role: z.string().default("").describe("job title or role if found"),
   location: z.string().default("").describe("city, country, or region if found"),
+  category: z.string().default("").describe("relationship category: one of Friend, Colleague, Family, Investor, Vendor — infer from relationship context, empty string if unclear"),
   relationshipWithUser: z.string().default("").describe("how the user knows this person — how they met, shared history, nature of relationship"),
   additionalInformation: z.string().default("").describe("recent interactions with timing, open loops, communication patterns, shared groups"),
 });
@@ -25,13 +26,15 @@ export interface ExtractedContactFields {
   company: string;
   role: string;
   location: string;
+  category: string;
 }
 
 export interface BuildSummaryInput {
   userName: string;
   personName: string;
   today: Date;
-  episodes: Array<{ content: string; validAt: Date }>;
+  // validAt can be a Date or an ISO string (raw Neo4j string values are accepted)
+  episodes: Array<{ content: string; validAt: Date | string }>;
   priorDescription: string | null;
   descriptionEdited: boolean;
 }
@@ -43,6 +46,9 @@ RULES
 - If a field is not present in the episodes, leave it as an empty string "".
 - Address the user as "you". Give recent interactions rough timing relative to today.
 - For email/phone/linkedin/twitter: copy the exact value as written in the episodes.
+- Keep structured fields (email, phone, linkedin, twitter, company, role, location) strictly
+  in their own fields. Do NOT repeat or mention them inside relationshipWithUser or
+  additionalInformation — those two fields are for narrative only.
 - If a prior profile is marked AUTHORITATIVE, preserve its facts in
   relationshipWithUser and additionalInformation, folding in new details without
   contradicting it. Structured fields (email, phone, etc.) should still be
@@ -57,13 +63,14 @@ twitter: X/Twitter handle (e.g. "@johnsmith"), empty string if not found
 company: employer or organization name, empty string if not found
 role: job title or role, empty string if not found
 location: city, country, or region, empty string if not found
-relationshipWithUser: 2–4 sentences on how the user knows this person — how they met, shared history, nature of the relationship
-additionalInformation: recent interactions with timing, any open loops or follow-ups needed, communication frequency and channel, shared groups or mutual connections`;
+category: relationship category — exactly one of: Friend, Colleague, Family, Investor, Vendor. Infer from the nature of the relationship described in episodes. Empty string if the relationship is unclear.
+relationshipWithUser: 2–4 sentences covering ONLY how the user knows this person — how they met, shared history, nature of the relationship. No contact details here.
+additionalInformation: ONLY recent interactions with timing, open loops or follow-ups needed, communication frequency and channel, shared groups or mutual connections. No contact details here.`;
 
 export function buildSummaryMessages(input: BuildSummaryInput): ModelMessage[] {
   const today = input.today.toISOString().slice(0, 10);
   const episodeLines = input.episodes
-    .map((e) => `[${e.validAt.toISOString().slice(0, 10)}]\n${e.content}`)
+    .map((e) => `[${new Date(e.validAt).toISOString().slice(0, 10)}]\n${e.content}`)
     .join("\n\n---\n\n");
 
   const prior = input.priorDescription
@@ -127,6 +134,7 @@ export async function generateContactSummary(
       company: object.company,
       role: object.role,
       location: object.location,
+      category: object.category,
     },
   };
 }


### PR DESCRIPTION
## Bug Identified

When a new contact was created in the People CRM from a memory episode, three things were broken:

1. **Email, phone, and category fields were always blank** — even when the information was clearly present in the memory episode (e.g. "Email: arjun@acme.com, Phone: +91-9999999999").

2. **The contact description was missing the `Basic Info` section** — the description was being generated, but it only had `### Relationship with User` and `### Additional Information`. The `### Basic Info` section (which shows email, phone, company, role, location) was absent.

3. **`category` field was never extracted or saved** — the AI was never asked to infer the relationship category (Friend, Colleague, Family, etc.), so it was always empty regardless of what the episode said.

## Why It Was Happening

### Bug 1 — Date crash causing silent failure on repeated syncs

The contact sync fetches recent memory episodes from the database (Neo4j), then passes them to the AI to extract contact details. Episodes come back from the database with `validAt` stored as a plain ISO string (e.g. `"2026-01-15T00:00:00Z"`).

The code then tried to call `.toISOString()` on that value — a method that only exists on JavaScript `Date` objects, not strings. This threw a `TypeError` that was caught silently by an outer error handler. The AI was never called, so no fields were ever extracted or saved.

The first sync worked because it used a separately fetched episode (the one that triggered the sync) which had already been parsed into a proper `Date` object. Subsequent syncs — using the batch episode fetch — always crashed, so fields were never updated.

**Fix:** Changed `e.validAt.toISOString()` to `new Date(e.validAt).toISOString()` in `contact-summary.server.ts`. `new Date()` safely handles both a `Date` object and an ISO string, so the crash no longer happens.

### Bug 2 — AI putting contact details in prose instead of structured fields

Even when the AI ran successfully, it was writing email, phone, company etc. as prose inside `relationshipWithUser` ("His email is arjun@acme.com and he works at Acme...") rather than in their dedicated fields. The system prompt did not explicitly forbid this.

Since the dedicated `email`/`phone` fields were empty, `renderDescription` skipped the `### Basic Info` section entirely. The description only had the prose sections, and the email/phone database columns stayed blank.

**Fix:** Added an explicit rule to the AI system prompt: *"Keep structured fields strictly in their own fields. Do NOT repeat or mention them inside `relationshipWithUser` or `additionalInformation`."* Also tightened the description of those two fields to make their scope unambiguous.

### Bug 3 — `category` field missing end to end

The `category` field (Friend, Colleague, Family, Investor, Vendor) was not defined in the AI output schema, not mentioned in the system prompt, not returned from `generateContactSummary`, and not written back to the database. The field existed in the DB but was never populated.

**Fix:** Added `category` to the Zod schema, the system prompt, the `ExtractedContactFields` interface, the `generateContactSummary` return value, and the write-back in `syncContactForEntity`.

## What Changed

| File | Change |
|------|--------|
| `contact-summary.server.ts` | Added `category` to schema + system prompt; fixed `new Date(e.validAt)` for safe date handling; tightened `relationshipWithUser`/`additionalInformation` field descriptions to exclude contact details |
| `contact-sync.logic.ts` | Added `category` write-back to DB after AI extraction |
| `__tests__/contact-summary.test.ts` | Tests for string `validAt` handling and category in system prompt |
| `__tests__/reconcile.test.ts` | Tests for category write-back and no-overwrite when AI returns empty string |

## Test with This Episode

Add the following as a memory episode locally to verify all three fields are populated and the description has all 3 sections:

```
Adding a new contact to the network.

Name: Arjun Mehta
Relationship: Close college friend, batch of 2018
Company: Acme
Role: Senior Product Manager
Work Email: arjun@acme.com
Phone: +91-9999999999
Location: Bangalore, India

Notes: Arjun and I were college friends and lived in the same hostel. We worked on the annual
tech fest together. He joined Acme 3 years ago and moved to Bangalore. We meet whenever I visit.
Last caught up in April 2026 — he mentioned wanting to explore a potential collaboration.
Priority: P1 contact.
```

Expected outcome:
- Email pill → `arjun@acme.com`
- Phone pill → `+91-9999999999`
- Category pill → `Friend`
- Description with all 3 sections: `### Basic Info`, `### Relationship with User`, `### Additional Information`

🤖 Generated with [Claude Code](https://claude.com/claude-code)