### PR TITLE
fix(contacts): use Memory Ingestion model for contact summary, not Chat

### DIFF
--- a/apps/webapp/app/services/contacts/contact-summary.server.ts
+++ b/apps/webapp/app/services/contacts/contact-summary.server.ts
@@ -119,9 +119,10 @@ export async function generateContactSummary(
     ContactSummarySchema,
     messages,
     "medium",
-    undefined,
+    "contact-summary",
     undefined,
     workspaceId,
+    "memory",
   );
   return {
     headline: object.headline,


### PR DESCRIPTION
## Bug

Refreshing a contact (or auto-creating one from memory) calls `generateContactSummary()` to build the CRM profile — email, company, role, location, headline, and a narrative description — from memory episodes. That function calls `makeStructuredModelCall()` but never passed a `useCase`, which defaults to `"chat"`. So instead of using the workspace's configured **Memory Ingestion** model (Settings → Models), it silently used the **Chat** model.

In production, Chat is set to `openrouter/xiaomi/mimo-v2.5-pro` (a smaller model, reasonably chosen for cheap conversational replies), while Memory Ingestion is correctly set to GPT-5 for structured-extraction tasks like this one. Mimo isn't reliable at filling out a strict multi-field JSON schema, and because most `ContactSummarySchema` fields default to `""` and pass validation even when left empty, contacts ended up either:
- Completely blank (no headline, no description) when the model's output couldn't be parsed at all, or
- Only a one-line `headline` with everything else empty, when it partially complied.

This didn't reproduce locally because local dev calls OpenAI directly with native structured-output enforcement, which is far more reliable regardless of which "slot" ends up used.

## Fix

`generateContactSummary` now explicitly passes `useCase: "memory"` to `makeStructuredModelCall`, matching every other extraction job in the codebase (label-assignment, knowledgeGraph extraction, aspect-resolution). This routes the call through the workspace's configured Memory Ingestion model instead of Chat.

Also gives the call its own prompt-cache key (`"contact-summary"`) instead of sharing the generic `structured-medium` bucket with unrelated calls.

## Testing

`pnpm exec vitest run app/services/contacts/__tests__/contact-summary.test.ts` — 6/6 passing.

## Follow-up (tracked separately, not in this PR)

Even with the right model slot selected, `makeStructuredModelCall` currently assumes any provider other than Ollama or a self-hosted OpenAI-compatible proxy reliably supports strict structured-output enforcement the way OpenAI does. That assumption doesn't hold for OpenRouter, which routes to a huge range of models with very different tool-calling/JSON reliability. Planning a follow-up PR to route OpenRouter through the same tolerant-parsing + repair-pass path Ollama already gets, so a less reliable model degrades gracefully instead of returning a blank profile. Keeping that as a separate PR since it's a more fundamental change worth its own review.