### PR TITLE
fix(models): make structured-output calls resilient to weak OpenRouter models

### DIFF
--- a/apps/webapp/app/lib/model.server.ts
+++ b/apps/webapp/app/lib/model.server.ts
@@ -398,12 +398,24 @@ function tryParseJsonFromText(raw: string): unknown | undefined {
   }
 }
 
-function needsTolerantParsing(): boolean {
+/**
+ * Whether to skip native structured-output enforcement and instead prompt for
+ * JSON manually, parse leniently, and repair on failure.
+ *
+ * Required for Ollama and self-hosted OpenAI-compatible proxies, which don't
+ * support the Responses API's structured output. Also required for OpenRouter:
+ * it routes to a huge range of third-party models with wildly inconsistent
+ * tool-calling/JSON-schema support, so the app can't assume any given
+ * OpenRouter model honors strict structured output the way OpenAI does.
+ */
+function needsTolerantParsing(model: string): boolean {
+  const provider = getProvider(model);
   const openaiConfig = getProviderConfig("openai");
   const apiMode = openaiConfig.apiMode ?? "responses";
   const isProxyChatMode = apiMode === "chat_completions" && !!openaiConfig.baseUrl;
-  const isOllama = getDefaultChatProviderType() === "ollama";
-  return isProxyChatMode || isOllama;
+  const isOllama = provider === "ollama" || getDefaultChatProviderType() === "ollama";
+  const isOpenRouter = provider === "openrouter";
+  return isProxyChatMode || isOllama || isOpenRouter;
 }
 
 export async function makeStructuredModelCall<T extends z.ZodType>(
@@ -425,8 +437,8 @@ export async function makeStructuredModelCall<T extends z.ZodType>(
 
   const agentApiOptions = apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined;
 
-  // Proxy/Ollama: manual JSON extraction (no structured output support)
-  if (needsTolerantParsing()) {
+  // Proxy/Ollama/OpenRouter: manual JSON extraction (no guaranteed structured output support)
+  if (needsTolerantParsing(model)) {
     const { object, usage } = await structuredCallWithTolerantParsing(
       schema,
       messages,

--- a/apps/webapp/app/services/contacts/contact-summary.server.ts
+++ b/apps/webapp/app/services/contacts/contact-summary.server.ts
@@ -119,9 +119,10 @@ export async function generateContactSummary(
     ContactSummarySchema,
     messages,
     "medium",
-    undefined,
+    "contact-summary",
     undefined,
     workspaceId,
+    "memory",
   );
   return {
     headline: object.headline,


### PR DESCRIPTION
## Background

Follow-up to #918. That PR fixed contact summaries silently using the wrong model slot (Chat instead of Memory Ingestion). But even with the right model slot selected, if that slot is configured with an OpenRouter model that isn't great at strict structured output (e.g. a small/reasoning-tuned model like `openrouter/xiaomi/mimo-v2.5-pro`), the same class of bug can resurface: partial or blank structured responses that silently pass validation because most schema fields default to `""`.

This branch includes #918's commit so it has no merge conflicts with it — it's meant to land after/alongside that PR.

## Bug

`makeStructuredModelCall` (`apps/webapp/app/lib/model.server.ts`) has two ways of getting JSON out of a model:

1. **Strict path** — relies on the model's native structured-output / tool-calling enforcement (used by default).
2. **Tolerant path** — explicitly writes the JSON schema into the prompt, parses leniently, and runs a repair pass if parsing/validation fails. Previously only used for Ollama and self-hosted OpenAI-compatible proxies.

`needsTolerantParsing()` decided which path to use by checking only the **global default chat provider** (Ollama) and an OpenAI-proxy config flag — it never looked at which provider the *actual model for this call* resolves to, and it had no special handling for OpenRouter at all. So any OpenRouter model, regardless of how good or bad it is at structured output, went through the strict path, which assumes a level of native JSON-schema/tool-calling reliability that OpenRouter can't guarantee (it routes to hundreds of different third-party models).

Result: a less capable OpenRouter model can fail structured output outright, or return a half-filled JSON object that still validates successfully (since most fields default to `""`), producing a silently incomplete result instead of a visible failure.

## Fix

- `needsTolerantParsing` now takes the resolved model string for the current call and checks its actual provider (via the existing `getProvider()` helper), not just the global default.
- Added `isOpenRouter` to the tolerant-parsing condition, so any call resolving to an `openrouter/...` model now goes through the same schema-hinted prompt + lenient parse + repair-pass flow Ollama already gets, instead of assuming native structured-output support it may not have.

This makes structured-output calls resilient to whichever model a workspace has configured via OpenRouter, rather than requiring the operator to hand-pick a model known to support strict structured output well.

## Testing

- `pnpm exec vitest run app/services/contacts/__tests__/contact-summary.test.ts app/services/contacts/__tests__/reconcile.test.ts` — 13/13 passing (these mock `makeStructuredModelCall` directly, unaffected by the change, included to confirm no regression).
- `pnpm exec tsc --noEmit` in `apps/webapp` — no new type errors (7 pre-existing failures in unrelated files, none touching `model.server.ts`).
