### PR TITLE
fix(butler): anchor send_message in context; voice-only catchup

### DIFF
--- a/apps/webapp/app/routes/api.v1.inbox.summarise.tsx
+++ b/apps/webapp/app/routes/api.v1.inbox.summarise.tsx
@@ -2,21 +2,16 @@
  * Inbox — summarise and clear.
  *
  *   POST /api/v1/inbox/summarise
- *     body: { mode?: "voice" | "text" }
  *     → { summary, count }
  *
- * Loads the user's inbox, runs it through the shared summariser in the
- * requested mode (defaults to "voice" since the Mac pill is the only caller
- * today), deletes the rows, and returns the spoken/displayed text.
- *
- * Every catchup — single or multi — goes through the summariser. The voice
- * prompt is already tuned for short single-item catchups, and skipping the
- * LLM for one row meant the user heard the raw agent message verbatim,
- * which is too long for a butler-style update.
+ * Loads the user's inbox, runs it through the shared voice-focused
+ * summariser, stamps the rows checked, and returns the catchup. The
+ * same `summary` is both spoken via TTS and shown on the on-screen
+ * card under the pill — voice is the optimisation target, the card
+ * just mirrors what's being said.
  */
 
 import { json } from "@remix-run/node";
-import { z } from "zod";
 
 import { UserTypeEnum } from "@core/types";
 import { createHybridActionApiRoute } from "~/services/routeBuilders/apiBuilder.server";
@@ -26,21 +21,15 @@ import { upsertConversationHistory } from "~/services/conversation.server";
 import { getOrCreateQuickChat } from "~/services/voice-conversation.server";
 import { logger } from "~/services/logger.service";
 
-const BodySchema = z.object({
-  mode: z.enum(["voice", "text"]).optional(),
-});
-
 const { loader, action } = createHybridActionApiRoute(
   {
-    body: BodySchema,
     allowJWT: true,
     corsStrategy: "all",
     method: "POST",
   },
-  async ({ body, authentication }) => {
+  async ({ authentication }) => {
     const userId = authentication.userId;
     const workspaceId = authentication.workspaceId as string | undefined;
-    const mode = body.mode ?? "voice";
 
     const items = await prisma.voiceInboxMessage.findMany({
       where: { userId, checked: null },
@@ -58,7 +47,8 @@ const { loader, action } = createHybridActionApiRoute(
         return `${idx + 1}.${taskTag} ${it.message}`;
       })
       .join("\n");
-    const summary = await summarize({ text: rendered, mode });
+
+    const summary = await summarize({ text: rendered });
 
     // Stamp instead of delete: the rows stay around as a history of
     // what the user has been caught up on. Only unstamped rows are
@@ -69,10 +59,10 @@ const { loader, action } = createHybridActionApiRoute(
     });
 
     // Append the catchup to today's Quick Chat as an Agent turn so the
-    // user can scroll back and re-read what was just spoken to them. We
-    // never block the response on this — if the workspace isn't on the
-    // auth payload (some token paths) or the write fails, the catchup
-    // still goes out.
+    // user can scroll back and re-read what was just spoken to them.
+    // We never block the response on this — if the workspace isn't on
+    // the auth payload (some token paths) or the write fails, the
+    // catchup still goes out.
     if (summary && workspaceId) {
       try {
         const conversationId = await getOrCreateQuickChat(workspaceId, userId);

--- a/apps/webapp/app/routes/inbox-pill.tsx
+++ b/apps/webapp/app/routes/inbox-pill.tsx
@@ -392,8 +392,6 @@ export default function InboxPill() {
       const res = await fetch("/api/v1/inbox/summarise", {
         method: "POST",
         credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode: "voice" }),
       });
       if (!res.ok) throw new Error(`summarise ${res.status}`);
       const data = (await res.json()) as SummariseResponse;
@@ -478,7 +476,7 @@ export default function InboxPill() {
 
       {status === "speaking" && summary && (
         <div
-          className="border-border bg-background-3 text-foreground max-h-[100px] max-w-[320px] overflow-y-auto rounded-lg border px-2.5 py-1.5 leading-snug shadow-md"
+          className="border-border bg-background-3 text-foreground max-h-[140px] max-w-[320px] overflow-y-auto whitespace-pre-line rounded-lg border px-2.5 py-1.5 leading-snug shadow-md"
           aria-live="polite"
         >
           {summary}

--- a/apps/webapp/app/routes/scratchpad-pill.tsx
+++ b/apps/webapp/app/routes/scratchpad-pill.tsx
@@ -409,8 +409,6 @@ export default function ScratchpadLauncher() {
       const res = await fetch("/api/v1/inbox/summarise", {
         method: "POST",
         credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ mode: "voice" }),
       });
       if (!res.ok) throw new Error(`summarise ${res.status}`);
       const data = (await res.json()) as SummariseResponse;
@@ -603,7 +601,7 @@ export default function ScratchpadLauncher() {
 
           {status === "speaking" && summary && (
             <div
-              className="text-foreground mt-1 max-h-[140px] overflow-y-auto px-2.5 py-1.5 text-xs leading-snug"
+              className="text-foreground mt-1 max-h-[160px] overflow-y-auto whitespace-pre-line px-2.5 py-1.5 text-xs leading-snug"
               aria-live="polite"
             >
               {summary}

--- a/apps/webapp/app/services/__tests__/summarize-catchup.test.ts
+++ b/apps/webapp/app/services/__tests__/summarize-catchup.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Live-LLM catchup preview.
+ *
+ * Skipped by default — flip on with `SUMMARIZE_LIVE=1` to actually hit
+ * the model. Use it to eyeball how the inbox-pill catchup sounds (and
+ * looks — the on-screen card mirrors the spoken text now) for realistic
+ * agent messages. Voice is the only optimisation target; the same
+ * output drives TTS and the card under the pill.
+ *
+ *   SUMMARIZE_LIVE=1 pnpm --filter webapp test summarize-catchup
+ *
+ * Add new scenarios to FIXTURES; each one renders the way the inbox
+ * route does (numbered with [task: …] tags) so what you see here is
+ * exactly what the user would hear after clicking the pill.
+ */
+
+import { describe, it } from "vitest";
+
+import { summarize } from "../summarize.server";
+
+const RUN_LIVE = process.env.SUMMARIZE_LIVE === "1";
+
+interface InboxItem {
+  task?: string;
+  message: string;
+}
+
+interface Fixture {
+  name: string;
+  items: InboxItem[];
+}
+
+function render(items: InboxItem[]): string {
+  return items
+    .map((it, idx) => {
+      const taskTag = it.task ? ` [task: ${it.task}]` : "";
+      return `${idx + 1}.${taskTag} ${it.message}`;
+    })
+    .join("\n");
+}
+
+const FIXTURES: Fixture[] = [
+  {
+    name: "single coding-task completion (the boot-loader case)",
+    items: [
+      {
+        task: "Fix boot loader showing OS before boot screen",
+        message:
+          "Boot-only loader fix is in and pushed, sir.\n\n" +
+          "What changed:\n" +
+          "- components/os/desktop.tsx: boot state now starts null (unknown), so the OS desktop is never rendered until after the boot check. Render is mutually exclusive: dark screen → boot → desktop, eliminating the OS → boot → OS flash.\n" +
+          "- components/os/boot-screen.tsx: added rotating funny loader texts tied to boot progress.\n\n" +
+          "Commit: 96f1bd2 on fix-boot-loader-no-os-screen.\n\n" +
+          "PR: I have created it here: https://github.com/example/core/pull/1234\n\n" +
+          "Note: the gateway worktree lacked pnpm, so lint/typecheck were not run in that environment. If you want, I can rerun checks from a proper node environment next.",
+      },
+    ],
+  },
+  {
+    name: "multi-message catchup (review + blocked + scheduled nudge)",
+    items: [
+      {
+        task: "Refactor contact summary model",
+        message:
+          "Re: Refactor contact summary model — done. Switched the summariser from Chat to Memory Ingestion model so it matches the other contact-side calls. PR: https://github.com/example/core/pull/1240. Lint + typecheck green.",
+      },
+      {
+        task: "Schedule Goa trip planning",
+        message:
+          "Re: Schedule Goa trip planning — blocked on you. I drafted the itinerary across booking.com and Skyscanner but I need a budget ceiling before I can shortlist hotels. Day-trip or overnight? Reply with both and I'll proceed.",
+      },
+      {
+        message:
+          "Reminder: Manik's quarterly review is tomorrow at 10am IST. You haven't opened the prep doc — want me to summarise the last 90 days of his commits and PR comments now?",
+      },
+    ],
+  },
+  {
+    name: "trigger-driven scheduled fire (recurring sales nudge)",
+    items: [
+      {
+        task: "Weekly outbound follow-up sweep",
+        message:
+          "Re: Weekly outbound follow-up sweep — 4 leads went 7+ days without a reply: Sabid (third pitch, no fit signal), Tara at Linear (warm, asked about pricing), Adam Stein (cold), Priya M (responded once, ghosted). I'd filter Sabid; the other three are worth a one-line nudge. Want me to draft them?",
+      },
+    ],
+  },
+];
+
+describe.skipIf(!RUN_LIVE)("summarize — live catchup preview", () => {
+  for (const fixture of FIXTURES) {
+    it(fixture.name, async () => {
+      const rendered = render(fixture.items);
+      const summary = await summarize({ text: rendered });
+
+      // eslint-disable-next-line no-console
+      console.log(
+        [
+          "",
+          "━".repeat(72),
+          `▶ ${fixture.name}`,
+          "━".repeat(72),
+          "",
+          "── INPUT ──",
+          rendered,
+          "",
+          "── CATCHUP (spoken + shown) ──",
+          summary,
+          "",
+        ].join("\n"),
+      );
+    }, 60_000);
+  }
+});
+
+describe.skipIf(RUN_LIVE)("summarize — live catchup preview (skipped)", () => {
+  it("set SUMMARIZE_LIVE=1 to run", () => {
+    // No-op: surfaced as a passing test that documents the gate.
+  });
+});

--- a/apps/webapp/app/services/agent/prompts/capabilities.ts
+++ b/apps/webapp/app/services/agent/prompts/capabilities.ts
@@ -408,6 +408,11 @@ When you're running in a background task or a triggered scheduled task, you have
 
 The channel is resolved automatically from the trigger's config or the user's default. Just compose your message naturally and call send_message.
 
+ALWAYS lead with a context anchor. The message lands in a feed (Slack, WhatsApp, email) where the user has no prior context loaded — they're scanning notifications, not continuing your thread. First line names WHAT this is about: the task title, the PR / branch, or the topic. Then the update.
+- Good: "Re: fix boot loader OS-flash → fix is in on \`fix-boot-loader-no-os-screen\` (commit 96f1bd2). PR opened. Lint/typecheck skipped — no pnpm in the gateway worktree. Rerun?"
+- Bad: "Boot-only loader fix is in and pushed, sir." (which fix? in what repo? user has to reverse-engineer it.)
+Format the anchor naturally — "Re: …", "On …", "About the … task:" all work. Pick what reads cleanest for the channel.
+
 When to use:
 - Background task completes → send a concise summary of what was accomplished
 - Task blocked (needs approval, stuck, error) → send what's needed from them

--- a/apps/webapp/app/services/agent/tools/message-tools.ts
+++ b/apps/webapp/app/services/agent/tools/message-tools.ts
@@ -54,7 +54,11 @@ export function getMessageTools(
   return {
     send_message: tool({
       description:
-        "Send a message to the user on their messaging channel. Use this to notify, update, or deliver results. Compose a natural, concise message — not a system notification.",
+        "Send a message to the user on their messaging channel. Use this to notify, update, or deliver results. " +
+        "Open with a one-line context anchor naming WHAT the message is about — task title, PR / branch, or topic — because this lands in a feed (Slack, WhatsApp, email) alongside many other notifications and the user has no prior context loaded. " +
+        'Format: first line "Re: <task / PR / topic>" (or natural equivalent like "On <task title>:"), then the actual update. ' +
+        'Do NOT open with the conclusion alone (e.g. "Fix is in and pushed") — the user can\'t tell which fix. ' +
+        "Compose a natural, concise message — not a system notification.",
       inputSchema: z.object({
         message: z.string().describe("The message to send to the user"),
         subject: z

--- a/apps/webapp/app/services/summarize.server.ts
+++ b/apps/webapp/app/services/summarize.server.ts
@@ -1,23 +1,23 @@
 /**
- * Common summariser. Takes arbitrary text and produces a tight summary
- * tuned for a delivery mode:
+ * Common summariser. Takes arbitrary text (inbox rows, agent messages,
+ * notifications) and produces a tight catchup tuned for the user's voice
+ * pill: one-breath spoken cadence that ALSO reads cleanly on the
+ * on-screen card while playback is happening.
  *
- *   - "voice"  : 1–2 spoken sentences, conversational, no markdown,
- *                no greeting/sign-off. Drives the Mac voice pill readout.
- *   - "text"   : a concise paragraph; can use light structure (lists, bold)
- *                when it improves scannability.
+ * Voice is the focus. The same output is both spoken (TTS) and shown
+ * (whitespace-pre-line div under the pill), so the prompt is tuned for
+ * spoken cadence but emits one sentence per line so the card scans
+ * while the user listens along.
  *
- * Uses the project's "low" complexity chat model (Haiku-equivalent), wrapped
- * via createAgent so caching/BYOK routing applies the same way as other
- * lightweight calls in the codebase.
+ * Uses the project's "low" complexity chat model (Haiku-equivalent),
+ * wrapped via createAgent so caching/BYOK routing applies the same way
+ * as other lightweight calls in the codebase.
  */
 
 import { createAgent, resolveModelString } from "~/lib/model.server";
 import { logger } from "~/services/logger.service";
 
-export type SummarizeMode = "voice" | "text";
-
-const VOICE_INSTRUCTIONS = `You are the user's chief of staff giving a one-breath spoken catchup. You've already read everything — you're surfacing what matters, in the order they should think about it.
+const VOICE_INSTRUCTIONS = `You are the user's chief of staff giving a one-breath spoken catchup. You've already read everything — you're surfacing what matters, in the order they should think about it. Your output is both spoken via TTS AND shown on a card the user reads along with, so each sentence is one beat.
 
 Rules:
 - Lead with what's most time-sensitive or blocking — NOT an inventory of categories. If there's an upcoming meeting, anchor to it ("Before your 10am with Manik…"). If there's a blocker, open with it ("Two PRs are blocking others — #855 and #848"). Never open with "Your X, Y, and Z, sir."
@@ -27,30 +27,21 @@ Rules:
 - Total length: 2 to 4 sentences. Hard ceiling. If tempted to add a fifth, group harder or drop the least urgent.
 - Tone: peer operator, not valet. No "sir," no "here's your summary," no "also/in addition/meanwhile." Direct, declarative, slightly opinionated.
 - Optional closing half-clause only if a real ask is open: "want me to draft the no?" or "say the word and I'll expand." Skip otherwise.
+
+Output format:
+- One sentence per line. Use real newlines between sentences so the card renders each beat on its own line and TTS reads naturally.
+- No bullet markers ("-", "•"), no numbering, no markdown. Just sentences separated by newlines.
 - Output the catchup text only. Nothing else.`;
 
-const TEXT_INSTRUCTIONS = `You summarise messages for on-screen display.
-
-Rules:
-- Output a concise paragraph. A short bulleted list is fine if it reads better.
-- Keep task titles, drop URLs and IDs unless they're essential.
-- No greeting, no sign-off. Just the summary itself.`;
-
-export async function summarize(params: {
-  text: string;
-  mode: SummarizeMode;
-}): Promise<string> {
-  const { text, mode } = params;
+export async function summarize(params: { text: string }): Promise<string> {
+  const { text } = params;
 
   const trimmed = text.trim();
   if (!trimmed) return "";
 
-  const instructions =
-    mode === "voice" ? VOICE_INSTRUCTIONS : TEXT_INSTRUCTIONS;
-
   try {
     const modelString = await resolveModelString("chat", "low");
-    const agent = createAgent(modelString, instructions);
+    const agent = createAgent(modelString, VOICE_INSTRUCTIONS);
     const { text: out } = await agent.generate(trimmed);
     return (out ?? "").trim();
   } catch (error) {


### PR DESCRIPTION
## Summary

Two quality fixes for the butler's outbound communication, both motivated by a real-world incident where a coding-task completion landed in Slack as **"Boot-only loader fix is in and pushed, sir."** and was followed by a barely-readable on-screen catchup.

### 1. \`send_message\` now leads with a context anchor

The butler's \`send_message\` tool used to compose freeform replies that opened with the conclusion ("Boot-only loader fix is in and pushed, sir"). In a feed (Slack, WhatsApp, email) the user has no prior context — they're scanning notifications, not continuing a thread.

- **\`apps/webapp/app/services/agent/tools/message-tools.ts\`** — tool description now requires a first-line context anchor (\`Re: <task / PR / topic>\` or natural equivalent) before the update, with a bad-example callout.
- **\`apps/webapp/app/services/agent/prompts/capabilities.ts\`** — SENDING MESSAGES section mirrors the rule with good/bad examples so the orchestrator and core agent both pick it up.

### 2. Catchup summariser is voice-only

The inbox-pill and scratchpad-pill catchup used to run TWO LLM passes per click (voice prompt → TTS, text prompt → on-screen bullets) and the bullets read like a JIRA log. Voice is the optimisation target — the card just mirrors what's being said.

- **\`apps/webapp/app/services/summarize.server.ts\`** — single chief-of-staff voice prompt, drops the \`mode\` param. Outputs one sentence per line so the card renders each beat cleanly while TTS plays.
- **\`apps/webapp/app/routes/api.v1.inbox.summarise.tsx\`** — drops the parallel text call, the \`display\` field, and the \`mode\` body schema. Returns \`{ summary, count }\`. QuickChat history stores the same voice line.
- **\`apps/webapp/app/routes/inbox-pill.tsx\`**, **\`scratchpad-pill.tsx\`** — both speak and show \`summary\`. POST body dropped.

### 3. Live preview test

- **\`apps/webapp/app/services/__tests__/summarize-catchup.test.ts\`** — gated behind \`SUMMARIZE_LIVE=1\`. Three fixtures (boot-loader completion, multi-message catchup, sales nudge) print the input + the catchup so prompt tweaks can be eyeballed end-to-end.

Sample output for the boot-loader fixture:
> Before merging example/core #1234, rerun lint and typecheck—gateway worktree lacked pnpm so checks didn't run.
> Commit 96f1bd2 on fix-boot-loader-no-os-screen makes desktop render start null, eliminating the OS→boot→OS flash.
> I'll rerun checks in a proper Node environment and push results if you want.

## Test plan

- [ ] \`SUMMARIZE_LIVE=1 pnpm --filter webapp test summarize-catchup\` — eyeball the three fixtures; check time-sensitive items lead, blockers come before completed-FYI, and the closing line is a real yes/no when there's an ask
- [ ] Trigger a background task that completes → verify the Slack/email message opens with \`Re: <task or PR>\` and not "Done, sir."
- [ ] Click the bottom-left scratchpad pill with 1 inbox row → verify the spoken text and the visible card match line-for-line
- [ ] Click the inbox pill with 3+ inbox rows → verify the catchup orders time-sensitive items first, blocked second, completed last
- [ ] Confirm QuickChat scroll-back shows the same voice text the user just heard

🤖 Generated with [Claude Code](https://claude.com/claude-code)