### PR TITLE
People list: delete icon with confirmation modal

### DIFF
--- a/apps/webapp/app/routes/home.memory.people._index.tsx
+++ b/apps/webapp/app/routes/home.memory.people._index.tsx
@@ -1,7 +1,19 @@
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
-import { useLoaderData, useSearchParams, Link } from "@remix-run/react";
+import { useState } from "react";
+import { json, type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData, useSearchParams, Link, useFetcher } from "@remix-run/react";
+import { Trash } from "lucide-react";
 import { getWorkspaceId, requireUser } from "~/services/session.server";
-import { listContacts } from "~/services/contacts/contact.server";
+import { listContacts, hideContact } from "~/services/contacts/contact.server";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await requireUser(request);
@@ -16,9 +28,48 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return json({ contacts, q });
 }
 
+export async function action({ request }: ActionFunctionArgs) {
+  const user = await requireUser(request);
+  const workspaceId = (await getWorkspaceId(
+    request,
+    user?.id as string,
+    user.workspaceId,
+  )) as string;
+  const form = await request.formData();
+  const intent = form.get("intent");
+
+  if (intent === "delete") {
+    const contactId = form.get("contactId") as string;
+    await hideContact(workspaceId, contactId);
+    return json({ ok: true });
+  }
+
+  return json({ ok: false }, { status: 400 });
+}
+
 export default function PeopleIndex() {
   const { contacts, q } = useLoaderData<typeof loader>();
   const [params, setParams] = useSearchParams();
+  const fetcher = useFetcher();
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [confirmContact, setConfirmContact] = useState<{ id: string; name: string } | null>(null);
+
+  const submittingId =
+    fetcher.state !== "idle"
+      ? (fetcher.formData?.get("contactId") as string | null)
+      : null;
+
+  const visibleContacts = contacts.filter((c) => c.id !== submittingId && c.id !== pendingDeleteId);
+
+  const handleConfirmDelete = () => {
+    if (!confirmContact) return;
+    setPendingDeleteId(confirmContact.id);
+    fetcher.submit(
+      { intent: "delete", contactId: confirmContact.id },
+      { method: "post" },
+    );
+    setConfirmContact(null);
+  };
 
   return (
     <div className="p-6">
@@ -44,20 +95,21 @@ export default function PeopleIndex() {
             <th>Contact</th>
             <th>Description</th>
             <th>Status</th>
+            <th />
           </tr>
         </thead>
         <tbody>
-          {contacts.length === 0 && (
+          {visibleContacts.length === 0 && (
             <tr>
-              <td colSpan={4} className="text-muted-foreground py-6">
+              <td colSpan={5} className="text-muted-foreground py-6">
                 {q
                   ? `No people match "${q}".`
                   : "No people yet. They appear here as CORE learns about the people you interact with."}
               </td>
             </tr>
           )}
-          {contacts.map((c) => (
-            <tr key={c.id} className="border-t">
+          {visibleContacts.map((c) => (
+            <tr key={c.id} className="border-t group">
               <td className="py-2">
                 <Link
                   to={`/home/memory/people/${c.id}`}
@@ -73,10 +125,41 @@ export default function PeopleIndex() {
               </td>
               <td className="max-w-md truncate">{c.headline ?? ""}</td>
               <td>{c.status === "Researching" ? "Researching" : "Active"}</td>
+              <td className="text-right pr-1">
+                <button
+                  type="button"
+                  onClick={() => setConfirmContact({ id: c.id, name: c.name })}
+                  className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity p-1 rounded"
+                  aria-label={`Remove ${c.name}`}
+                >
+                  <Trash size={14} />
+                </button>
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+
+      <AlertDialog
+        open={!!confirmContact}
+        onOpenChange={(open) => { if (!open) setConfirmContact(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove {confirmContact?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove them from your People list. They may reappear if
+              new memories mention them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmDelete}>
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Objective
Add a delete icon at right end of each contact in Memory → People list view so contacts can be removed without opening detail.

## Behavior
- Each contact row shows a delete icon on the right.
- Clicking it prompts a confirmation modal.
- On confirm, the contact is removed using the existing hideContact/Hidden flow, and the list updates immediately.
