### PR TITLE
feat(models): cap free workspaces to low-tier models

### DIFF
--- a/apps/webapp/app/routes/api.v1.conversation._index.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation._index.tsx
@@ -10,7 +10,7 @@ import {
   clearActiveStreamId,
 } from "~/services/conversation.server";
 import {
-  getDefaultChatModelId,
+  resolveDefaultChatModelId,
   resolveModelConfig,
 } from "~/services/llm-provider.server";
 import { UserTypeEnum } from "@core/types";
@@ -305,7 +305,8 @@ const { loader, action } = createHybridActionApiRoute(
       conversationHistory.length === 0 && !isTaskConversation;
 
     const workspaceId = authentication.workspaceId as string;
-    const modelString = body.modelId ?? getDefaultChatModelId();
+    const modelString =
+      body.modelId ?? (await resolveDefaultChatModelId(workspaceId));
 
     const { modelConfig, isBYOK } = await resolveModelConfig(
       modelString,

--- a/apps/webapp/app/routes/api.v1.voice.turn.tsx
+++ b/apps/webapp/app/routes/api.v1.voice.turn.tsx
@@ -27,7 +27,7 @@ import {
   clearActiveStreamId,
 } from "~/services/conversation.server";
 import {
-  getDefaultChatModelId,
+  resolveDefaultChatModelId,
   resolveModelConfig,
 } from "~/services/llm-provider.server";
 import { buildAgentContext } from "~/services/agent/context";
@@ -99,7 +99,8 @@ const { loader, action } = createHybridActionApiRoute(
       },
     );
 
-    const modelString = body.modelId ?? getDefaultChatModelId();
+    const modelString =
+      body.modelId ?? (await resolveDefaultChatModelId(workspaceId));
     const { modelConfig, isBYOK } = await resolveModelConfig(
       modelString,
       workspaceId,

--- a/apps/webapp/app/services/__tests__/llm-provider-plan-tier.test.ts
+++ b/apps/webapp/app/services/__tests__/llm-provider-plan-tier.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Plan-aware model tiering.
+ *
+ * Free workspaces (when billing is enabled) must be forced to the "low"
+ * complexity tier for every use case, unless they set an explicit per-use-case
+ * model override. Paid plans (PRO/MAX), self-hosted (billing disabled), and
+ * calls without a workspace keep the requested complexity.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const state = vi.hoisted(() => ({
+  billingEnabled: true,
+}));
+
+const prismaMocks = vi.hoisted(() => ({
+  workspace: { findUnique: vi.fn() },
+  lLMProvider: { findFirst: vi.fn() },
+  lLMModel: { findFirst: vi.fn() },
+}));
+
+vi.mock("~/db.server", () => ({ prisma: prismaMocks }));
+
+vi.mock("~/env.server", () => ({
+  env: { MODEL: "env-default-model", CHAT_PROVIDER: "openai" },
+}));
+
+vi.mock("~/services/logger.service", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("~/config/billing.server", () => ({
+  isBillingEnabled: () => state.billingEnabled,
+  isPaidPlan: (planType: string) => planType === "PRO" || planType === "MAX",
+}));
+
+// Pulls in @core/types (unresolvable under vitest) and is irrelevant here.
+vi.mock("~/services/byok.server", () => ({
+  resolveWorkspaceApiKey: vi.fn(),
+  resolveWorkspaceProviderBaseUrl: vi.fn(),
+}));
+
+import {
+  getModelForUseCase,
+  resolveDefaultChatModelId,
+} from "~/services/llm-provider.server";
+
+// A provider exists, and the DB returns a model whose id encodes the complexity
+// that was queried — so the resolved id reveals which tier actually won.
+function wireProviderWithTieredModels() {
+  prismaMocks.lLMProvider.findFirst.mockResolvedValue({ id: "prov-1" });
+  prismaMocks.lLMModel.findFirst.mockImplementation(async (args: any) => ({
+    modelId: `${args.where.complexity}-model`,
+  }));
+}
+
+function mockWorkspace(opts: {
+  planType?: string | null;
+  modelConfig?: Record<string, { modelId: string }>;
+}) {
+  prismaMocks.workspace.findUnique.mockResolvedValue({
+    metadata: opts.modelConfig ? { modelConfig: opts.modelConfig } : {},
+    Subscription: opts.planType ? { planType: opts.planType } : null,
+  });
+}
+
+beforeEach(() => {
+  state.billingEnabled = true;
+  vi.clearAllMocks();
+  wireProviderWithTieredModels();
+});
+
+describe("getModelForUseCase — free-plan cap", () => {
+  it("forces a FREE workspace from high to the low tier", async () => {
+    mockWorkspace({ planType: "FREE" });
+    const model = await getModelForUseCase("chat", "ws-1", "high");
+    expect(model).toBe("low-model");
+  });
+
+  it("honors an explicit per-use-case override for a FREE workspace (no cap)", async () => {
+    mockWorkspace({
+      planType: "FREE",
+      modelConfig: { chat: { modelId: "override-model" } },
+    });
+    const model = await getModelForUseCase("chat", "ws-1", "high");
+    expect(model).toBe("override-model");
+    expect(prismaMocks.lLMModel.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("treats a workspace with no subscription as FREE", async () => {
+    mockWorkspace({ planType: null });
+    const model = await getModelForUseCase("memory", "ws-1", "medium");
+    expect(model).toBe("low-model");
+  });
+
+  it("keeps the requested tier for a PRO workspace", async () => {
+    mockWorkspace({ planType: "PRO" });
+    const model = await getModelForUseCase("chat", "ws-1", "high");
+    expect(model).toBe("high-model");
+  });
+
+  it("keeps the requested tier for a MAX workspace", async () => {
+    mockWorkspace({ planType: "MAX" });
+    const model = await getModelForUseCase("chat", "ws-1", "high");
+    expect(model).toBe("high-model");
+  });
+
+  it("does not downgrade when billing is disabled (self-hosted)", async () => {
+    state.billingEnabled = false;
+    mockWorkspace({ planType: "FREE" });
+    const model = await getModelForUseCase("chat", "ws-1", "high");
+    expect(model).toBe("high-model");
+  });
+
+  it("does not downgrade when there is no workspace", async () => {
+    const model = await getModelForUseCase("chat", null, "high");
+    expect(model).toBe("high-model");
+    expect(prismaMocks.workspace.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveDefaultChatModelId", () => {
+  it("returns a low-tier model for a FREE workspace", async () => {
+    mockWorkspace({ planType: "FREE" });
+    const model = await resolveDefaultChatModelId("ws-1");
+    expect(model).toBe("low-model");
+  });
+
+  it("returns the FREE workspace's explicit chat override when set", async () => {
+    mockWorkspace({
+      planType: "FREE",
+      modelConfig: { chat: { modelId: "override-model" } },
+    });
+    const model = await resolveDefaultChatModelId("ws-1");
+    expect(model).toBe("override-model");
+  });
+
+  it("returns env.MODEL for a PRO workspace", async () => {
+    mockWorkspace({ planType: "PRO" });
+    const model = await resolveDefaultChatModelId("ws-1");
+    expect(model).toBe("env-default-model");
+  });
+
+  it("returns env.MODEL when billing is disabled", async () => {
+    state.billingEnabled = false;
+    mockWorkspace({ planType: "FREE" });
+    const model = await resolveDefaultChatModelId("ws-1");
+    expect(model).toBe("env-default-model");
+  });
+
+  it("returns env.MODEL when there is no workspace", async () => {
+    const model = await resolveDefaultChatModelId(undefined);
+    expect(model).toBe("env-default-model");
+    expect(prismaMocks.workspace.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/services/agent/no-stream-process.ts
+++ b/apps/webapp/app/services/agent/no-stream-process.ts
@@ -12,7 +12,7 @@ import { buildAgentContext } from "./context";
 import { getMastra } from "./mastra";
 import { logger } from "~/services/logger.service";
 import {
-  getDefaultChatModelId,
+  resolveDefaultChatModelId,
   resolveModelConfig,
 } from "~/services/llm-provider.server";
 import {
@@ -159,7 +159,7 @@ export async function noStreamProcess(
     finalMessages = body.messages as any;
   }
 
-  const modelString = getDefaultChatModelId();
+  const modelString = await resolveDefaultChatModelId(workspaceId);
   const { modelConfig, isBYOK } = await resolveModelConfig(
     modelString,
     workspaceId,

--- a/apps/webapp/app/services/llm-provider.server.ts
+++ b/apps/webapp/app/services/llm-provider.server.ts
@@ -1,6 +1,7 @@
 import { prisma } from "~/db.server";
 import { env } from "~/env.server";
 import { logger } from "~/services/logger.service";
+import { isBillingEnabled, isPaidPlan } from "~/config/billing.server";
 import seedData from "~/config/llm-models.json";
 
 // ---------------------------------------------------------------------------
@@ -265,18 +266,28 @@ export async function getEmbeddingDimensions(): Promise<number> {
  *   1. workspace.metadata.modelConfig[useCase].modelId  (explicit workspace override)
  *   2. LLMModel with env.CHAT_PROVIDER + complexity     (DB complexity routing)
  *   3. env.MODEL                                        (final fallback)
+ *
+ * Plan tiering: when billing is enabled, a workspace on a free plan is forced
+ * to the "low" complexity tier (step 2) regardless of the requested complexity.
+ * Explicit overrides (step 1) still win; paid plans and self-hosted instances
+ * (billing disabled) are unaffected.
  */
 export async function getModelForUseCase(
   useCase: UseCase,
   workspaceId: string | null | undefined,
   complexity: ModelComplexity = "medium",
 ): Promise<string> {
+  let effectiveComplexity = complexity;
+
   // 1. Workspace override — always check when workspace has explicit model config.
   // This ensures BYOK workspaces use their chosen model at every complexity tier.
   if (workspaceId) {
     const workspace = await prisma.workspace.findUnique({
       where: { id: workspaceId },
-      select: { metadata: true },
+      select: {
+        metadata: true,
+        Subscription: { select: { planType: true } },
+      },
     });
     const meta = (workspace?.metadata ?? {}) as Record<string, any>;
     const modelConfig = meta.modelConfig as
@@ -284,6 +295,18 @@ export async function getModelForUseCase(
       | undefined;
     const modelId = modelConfig?.[useCase]?.modelId;
     if (modelId) return modelId;
+
+    // Free plans are capped to the low tier. Explicit overrides above win;
+    // paid plans and self-hosted (billing disabled) keep the requested tier.
+    if (isBillingEnabled()) {
+      const planType = (workspace?.Subscription?.planType ?? "FREE") as
+        | "FREE"
+        | "PRO"
+        | "MAX";
+      if (!isPaidPlan(planType)) {
+        effectiveComplexity = "low";
+      }
+    }
   }
 
   // 2. DB complexity routing via env.CHAT_PROVIDER
@@ -294,7 +317,7 @@ export async function getModelForUseCase(
     const model = await prisma.lLMModel.findFirst({
       where: {
         providerId: provider.id,
-        complexity,
+        complexity: effectiveComplexity,
         capabilities: { has: "chat" },
         isEnabled: true,
         isDeprecated: false,
@@ -305,6 +328,32 @@ export async function getModelForUseCase(
 
   // 3. env fallback
   return env.MODEL;
+}
+
+/**
+ * Resolve the default chat model id for a workspace, applying plan tiering.
+ *
+ * The main conversational agent historically used env.MODEL for every plan.
+ * Paid plans, self-hosted (billing disabled), and call sites without a
+ * workspace keep that behavior. Free workspaces drop to a low-tier chat model,
+ * honoring an explicit modelConfig.chat override first (via getModelForUseCase).
+ */
+export async function resolveDefaultChatModelId(
+  workspaceId: string | null | undefined,
+): Promise<string> {
+  if (!workspaceId || !isBillingEnabled()) return env.MODEL;
+
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: workspaceId },
+    select: { Subscription: { select: { planType: true } } },
+  });
+  const planType = (workspace?.Subscription?.planType ?? "FREE") as
+    | "FREE"
+    | "PRO"
+    | "MAX";
+  if (isPaidPlan(planType)) return env.MODEL;
+
+  return getModelForUseCase("chat", workspaceId, "low");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Free workspaces were resolving to top-tier models for chat and most LLM work. This change forces free plans to the `"low"` model tier when billing is enabled. **PRO/MAX, self-hosted (billing disabled), and explicit model overrides are unaffected.**

Two paths sent free users to top-tier models; both are fixed at their chokepoints in `apps/webapp/app/services/llm-provider.server.ts`:

**Part A — routed path (`getModelForUseCase`)** — memory, search, sub-agents, titles, summaries, etc. After the explicit-override check, if billing is enabled and the workspace isn't on a paid plan, the effective complexity is forced to `"low"`. `planType` is read from the existing workspace query (added `Subscription` to the `select` — no extra round-trip).

**Part B — main chat agent** — previously used `getDefaultChatModelId()` = `env.MODEL` for every plan (the real "high model for everything"). New `resolveDefaultChatModelId(workspaceId)`:
- free → DB `"low"` tier (honoring a `modelConfig.chat` override)
- paid / billing-off / no-workspace → `env.MODEL` (unchanged)

Wired into the 3 chat entry points (`api.v1.conversation._index.tsx`, `no-stream-process.ts`, `api.v1.voice.turn.tsx`), keeping `body.modelId` precedence so an explicit per-request model still wins.

## Decisions encoded
- **Cap level:** free → `"low"` for everything
- **Billing disabled (self-hosted):** no downgrade
- **Explicit overrides:** honored over the cap
- **Low model source:** existing DB `"low"` complexity routing (no new env var)

## Net effect
PRO/MAX and self-hosted are byte-for-byte unchanged; only free hosted workspaces drop to low-tier.

## Test plan
- New `llm-provider-plan-tier.test.ts` — 12 tests, written test-first (confirmed RED → GREEN). Covers FREE cap, override honored, PRO/MAX untouched, billing-off, no-workspace, and the chat resolver.
- Typecheck: **0 new** type errors (296 pre-existing, identical with/without this change).
- Lint: 0 errors in touched files.
- All runnable unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)