### PR TITLE
feat(google-docs): service-account auth + clone_document

### DIFF
--- a/integrations/google-docs/src/account-create.ts
+++ b/integrations/google-docs/src/account-create.ts
@@ -4,6 +4,50 @@ export async function integrationCreate(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any
 ) {
+  if (data?.service_account_json) {
+    return await createServiceAccountIntegration(data.service_account_json);
+  }
+
+  return await createOAuthIntegration(data);
+}
+
+async function createServiceAccountIntegration(rawJson: string) {
+  let parsed: Record<string, string>;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    throw new Error('service_account_json must be a valid JSON string');
+  }
+
+  if (parsed.type !== 'service_account' || !parsed.client_email || !parsed.private_key) {
+    throw new Error(
+      'service_account_json is not a valid Google service account key (expected type=service_account with client_email and private_key)'
+    );
+  }
+
+  const integrationConfiguration = {
+    auth_mode: 'service_account',
+    service_account_json: rawJson,
+    userEmail: parsed.client_email,
+    projectId: parsed.project_id,
+  };
+
+  return [
+    {
+      type: 'account',
+      data: {
+        settings: { auth_mode: 'service_account' },
+        accountId: parsed.client_email,
+        config: integrationConfiguration,
+      },
+    },
+  ];
+}
+
+async function createOAuthIntegration(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any
+) {
   const { oauthResponse, oauthParams } = data;
 
   // Fetch user information using the access token
@@ -23,8 +67,8 @@ export async function integrationCreate(
     console.error('Error fetching user info:', error);
   }
 
-  // For Gmail OAuth2, we need to store the tokens and user info
   const integrationConfiguration = {
+    auth_mode: 'oauth',
     access_token: oauthResponse.access_token,
     refresh_token: oauthResponse.refresh_token,
     client_id: oauthResponse.client_id,

--- a/integrations/google-docs/src/index.ts
+++ b/integrations/google-docs/src/index.ts
@@ -87,6 +87,17 @@ class GoogleDocCLI extends IntegrationCLI {
             prompt: 'consent',
           },
         },
+        api_key: {
+          fields: [
+            {
+              name: 'service_account_json',
+              label: 'Service Account JSON',
+              placeholder: '{ "type": "service_account", "project_id": "...", ... }',
+              description:
+                'Paste the full JSON key for a Google Cloud service account with Docs + Drive scopes. Documents will be created under the service account and shared publicly (anyone with the link can view). Use this when your OAuth app is not yet verified for the Drive scope.',
+            },
+          ],
+        },
       },
     };
   }

--- a/integrations/google-docs/src/mcp/index.ts
+++ b/integrations/google-docs/src/mcp/index.ts
@@ -4,16 +4,35 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { google, docs_v1 } from 'googleapis';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import { OAuth2Client } from 'google-auth-library';
+import { OAuth2Client, GoogleAuth } from 'google-auth-library';
 import { generatedTools, handleGeneratedTool } from './generated-tools';
+
+const SERVICE_ACCOUNT_SCOPES = [
+  'https://www.googleapis.com/auth/documents',
+  'https://www.googleapis.com/auth/drive',
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AuthClient = OAuth2Client | any;
 
 async function loadCredentials(
   client_id: string,
   client_secret: string,
   callback: string,
   config: Record<string, string>
-): Promise<{ oauth2Client: OAuth2Client; docs: docs_v1.Docs }> {
+): Promise<{ authClient: AuthClient; docs: docs_v1.Docs; authMode: 'oauth' | 'service_account' }> {
   try {
+    if (config.service_account_json) {
+      const credentials = JSON.parse(config.service_account_json);
+      const auth = new GoogleAuth({
+        credentials,
+        scopes: SERVICE_ACCOUNT_SCOPES,
+      });
+      const authClient = await auth.getClient();
+      const docs = google.docs({ version: 'v1', auth: authClient as OAuth2Client });
+      return { authClient, docs, authMode: 'service_account' };
+    }
+
     const credentials = {
       refresh_token: config.refresh_token,
       expiry_date:
@@ -30,11 +49,30 @@ async function loadCredentials(
     oauth2Client.setCredentials(credentials);
     oauth2Client.refreshAccessToken();
     const docs = google.docs({ version: 'v1', auth: oauth2Client });
-    return { oauth2Client, docs };
+    return { authClient: oauth2Client, docs, authMode: 'oauth' };
   } catch (error) {
     console.error('Error loading credentials:', error);
     process.exit(1);
   }
+}
+
+// Accepts a full docs URL or a raw file ID and returns the file ID.
+function extractDocumentId(input: string): string {
+  const trimmed = input.trim();
+  const match = trimmed.match(/\/document\/d\/([a-zA-Z0-9-_]+)/);
+  if (match) return match[1];
+  // Fallback: assume the caller passed the raw ID.
+  return trimmed;
+}
+
+async function shareFilePublicly(
+  drive: ReturnType<typeof google.drive>,
+  fileId: string
+): Promise<void> {
+  await drive.permissions.create({
+    fileId,
+    requestBody: { role: 'reader', type: 'anyone' },
+  });
 }
 
 // Custom tool schemas for common operations
@@ -42,6 +80,30 @@ const ListDocumentsSchema = z.object({});
 
 const CreateDocumentSchema = z.object({
   title: z.string().describe('Title for the new document'),
+  makePublic: z
+    .boolean()
+    .optional()
+    .describe(
+      'If true, share the created document publicly (anyone with the link can view). Required for service-account auth so the resulting URL is reachable by end users. Defaults to true when using service-account auth, false otherwise.'
+    ),
+});
+
+const CloneDocumentSchema = z.object({
+  source: z
+    .string()
+    .describe(
+      'Source document — either a Google Docs URL (e.g. https://docs.google.com/document/d/ABC.../edit) or a raw document ID.'
+    ),
+  title: z
+    .string()
+    .optional()
+    .describe('Title for the cloned copy. Defaults to "Copy of <original title>".'),
+  makePublic: z
+    .boolean()
+    .optional()
+    .describe(
+      'If true, share the cloned document publicly (anyone with the link can view). Defaults to true when using service-account auth, false otherwise.'
+    ),
 });
 
 const ReadDocumentSchema = z.object({
@@ -120,8 +182,16 @@ export async function getTools() {
     },
     {
       name: 'create_document',
-      description: 'Creates a new Google Doc with optional title',
+      description:
+        'Creates a new Google Doc with a title. Optionally shares it publicly (anyone with the link can view).',
       inputSchema: zodToJsonSchema(CreateDocumentSchema),
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+    },
+    {
+      name: 'clone_document',
+      description:
+        'Clones an existing Google Doc into a new document. Accepts either a docs.google.com URL or a raw document ID. The source must be readable by the authenticated account (public link, shared with the account, or owned by it).',
+      inputSchema: zodToJsonSchema(CloneDocumentSchema),
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
     },
     {
@@ -176,7 +246,12 @@ export async function callTool(
   callback: string,
   credentials: Record<string, string>
 ) {
-  const { oauth2Client, docs } = await loadCredentials(client_id, client_secret, callback, credentials);
+  const { authClient, docs, authMode } = await loadCredentials(
+    client_id,
+    client_secret,
+    callback,
+    credentials
+  );
 
   try {
     switch (name) {
@@ -184,7 +259,7 @@ export async function callTool(
         ListDocumentsSchema.parse(args);
 
         // Use Drive API to list all documents
-        const drive = google.drive({ version: 'v3', auth: oauth2Client });
+        const drive = google.drive({ version: 'v3', auth: authClient });
         const response = await drive.files.list({
           q: "mimeType='application/vnd.google-apps.document'",
           fields: 'files(id, name, createdTime, modifiedTime, webViewLink)',
@@ -215,11 +290,54 @@ export async function callTool(
           },
         });
 
+        const documentId = response.data.documentId!;
+        const shouldMakePublic =
+          validatedArgs.makePublic ?? authMode === 'service_account';
+
+        if (shouldMakePublic) {
+          const drive = google.drive({ version: 'v3', auth: authClient });
+          await shareFilePublicly(drive, documentId);
+        }
+
+        const url = `https://docs.google.com/document/d/${documentId}/edit`;
         return {
           content: [
             {
               type: 'text',
-              text: `Document created successfully!\nID: ${response.data.documentId}\nTitle: ${response.data.title}\nURL: https://docs.google.com/document/d/${response.data.documentId}/edit`,
+              text: `Document created successfully!\nID: ${documentId}\nTitle: ${response.data.title}\nURL: ${url}${shouldMakePublic ? '\nVisibility: public (anyone with the link can view)' : ''}`,
+            },
+          ],
+        };
+      }
+
+      case 'clone_document': {
+        const validatedArgs = CloneDocumentSchema.parse(args);
+        const sourceId = extractDocumentId(validatedArgs.source);
+        const drive = google.drive({ version: 'v3', auth: authClient });
+
+        const copyResponse = await drive.files.copy({
+          fileId: sourceId,
+          requestBody: validatedArgs.title ? { name: validatedArgs.title } : {},
+          fields: 'id, name, webViewLink',
+        });
+
+        const newId = copyResponse.data.id!;
+        const shouldMakePublic =
+          validatedArgs.makePublic ?? authMode === 'service_account';
+
+        if (shouldMakePublic) {
+          await shareFilePublicly(drive, newId);
+        }
+
+        const url =
+          copyResponse.data.webViewLink ??
+          `https://docs.google.com/document/d/${newId}/edit`;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Document cloned successfully!\nSource ID: ${sourceId}\nNew ID: ${newId}\nTitle: ${copyResponse.data.name}\nURL: ${url}${shouldMakePublic ? '\nVisibility: public (anyone with the link can view)' : ''}`,
             },
           ],
         };


### PR DESCRIPTION
## Summary
- Adds a second auth path to the `google-docs` integration so it works without OAuth verification for the Drive scope: users paste a Google Cloud **service-account JSON key** on the integration page, and new/cloned docs are shared publicly (anyone-with-link, reader) so the returned URL is usable end-to-end.
- New `clone_document` tool accepts a `docs.google.com` URL (or raw ID), calls `drive.files.copy`, and honors the same public-share default.
- `create_document` gains an optional `makePublic` flag (default `true` under service-account auth, `false` under OAuth) that applies `permissions.create({ role: 'reader', type: 'anyone' })` after creation.

### Why
The Drive scope on our OAuth app isn't approved, which blocks the current OAuth flow for external users. Service-account auth sidesteps that entirely for the "create a public doc" use case.

### Changes
- `src/index.ts` — Spec now declares both `OAuth2` and `api_key` auth. The api_key field is a single `service_account_json`.
- `src/account-create.ts` — SETUP branches on `data.service_account_json` vs the OAuth response. Service-account path validates the JSON (`type === 'service_account'`, `client_email`, `private_key`), uses `client_email` as `accountId`.
- `src/mcp/index.ts` — `loadCredentials` returns `{ authClient, docs, authMode }` and builds either an `OAuth2Client` or a `GoogleAuth` client with Docs + Drive scopes. Adds `clone_document` (URL/ID parsing via `/document/d/{ID}/`), `makePublic` on `create_document`, and a small `shareFilePublicly` helper.

### Caveats
- Files created via service account are **owned by the service account** and live in its Drive. For low-volume use this is fine; if usage grows, switch to a Shared Drive (would need a `driveId` param and `supportsAllDrives: true` on Drive calls).
- Public sharing is `role: 'reader'`. Anyone-can-edit links would be a small extension.
- The published `@redplanethq/sdk`'s `APIKeyParams` type is stale (`{header_name, format}`) and doesn't match the runtime shape (`{ fields: Param[] }`) that every integration + the webapp use. `tsc --noEmit` errors on `api_key.fields` — but the same error already exists in `integrations/ghost` and doesn't affect `bun build`. Worth fixing the SDK types separately.

## Test plan
- [ ] Add a service-account JSON on the integration page → account is created with `client_email` as accountId
- [ ] `create_document({ title: "Test" })` under service-account auth → returns a `docs.google.com` URL viewable in a signed-out browser
- [ ] `create_document({ title: "Test", makePublic: false })` under service-account auth → doc is created but not publicly viewable
- [ ] `clone_document({ source: "https://docs.google.com/document/d/<PUBLIC_ID>/edit" })` → returns a new URL that is publicly viewable
- [ ] `clone_document({ source: "<RAW_ID>", title: "Renamed" })` → clone respects the custom title
- [ ] OAuth-authed account (existing users) continues to work for `list_documents`, `create_document` (defaults to not-public), `read_document`, `insert_text`, `append_text`, `replace_text`, `format_text`, `insert_image`
- [ ] `clone_document` under OAuth defaults to not-public and returns a URL the OAuth user owns

🤖 Generated with [Claude Code](https://claude.com/claude-code)