### PR TITLE
feat(usage): store model on streaming token rollup rows

### DIFF
--- a/apps/webapp/app/routes/api.v1.conversation._index.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation._index.tsx
@@ -387,6 +387,7 @@ const { loader, action } = createHybridActionApiRoute(
       userId: authentication.userId,
       workspaceId: workspaceId || "",
       isBYOK,
+      model: modelString,
     };
 
     const messageHistoryProcessor: Processor<"message-history"> = {

--- a/apps/webapp/app/routes/api.v1.voice.turn.tsx
+++ b/apps/webapp/app/routes/api.v1.voice.turn.tsx
@@ -163,6 +163,7 @@ const { loader, action } = createHybridActionApiRoute(
           userId,
           workspaceId,
           isBYOK,
+          model: modelString,
         });
         return messages;
       },


### PR DESCRIPTION
## Summary

- Both streaming routes (`api.v1.conversation._index.tsx`, `api.v1.voice.turn.tsx`) already resolved `modelString` before agent setup but weren't plumbing it into `saveConversationResult` — so streaming turns were landing in `DailyTokenUsage` with `model=""`, collapsing every model into one bucket.
- Now the model identifier reaches the recorder, matching the non-streaming path (`no-stream-process.ts`) and the per-call `makeModelCall` path.

## Test plan

- [x] `pnpm --filter webapp typecheck` — clean on touched files
- [x] `pnpm --filter webapp vitest run app/services/__tests__/tokenUsage.test.ts` — 15/15 green
- [ ] Send a streaming chat message → confirm a `DailyTokenUsage` row appears with the real model (e.g. `claude-sonnet-4-6`), not `""`
- [ ] Do the same via `/api/v1/voice/turn` → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)