### PR TITLE
fix(chat): stop sub-agent tool-call storms from freezing the chat UI

### DIFF
--- a/apps/webapp/app/components/conversation/conversation-item.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-item.client.tsx
@@ -1,5 +1,5 @@
 import { EditorContent, useEditor } from "@tiptap/react";
-import { useEffect, memo, useState } from "react";
+import { useEffect, memo, useMemo, useState } from "react";
 import { cn } from "~/lib/utils";
 import { extensionsForConversation } from "./editor-extensions";
 import { type ChatAddToolApproveResponseFunction, type UIMessage } from "ai";
@@ -41,11 +41,17 @@ const ConversationItemComponent = ({
   integrationFrontendMap = {},
   className,
 }: AIConversationItemProps) => {
-  const isUser = message.role === "user" || false;
-  const combinedText = message.parts
-    .filter((part: any) => part.type === "text" && part.text)
-    .map((p: any) => p.text)
-    .join("");
+  const isUser = message?.role === "user" || false;
+  const combinedText = useMemo(
+    () =>
+      message
+        ? message.parts
+            .filter((part: any) => part.type === "text" && part.text)
+            .map((p: any) => p.text)
+            .join("")
+        : "",
+    [message],
+  );
   const [showAllTools, setShowAllTools] = useState(false);
   const formattedTime = createdAt
     ? new Date(createdAt).toLocaleTimeString([], {
@@ -60,27 +66,51 @@ const ConversationItemComponent = ({
     content: combinedText ? combinedText : "",
   });
 
+  // Push new content only when the extracted text actually changes. During a
+  // sub-agent's tool-call storm, `message` identity flips on every stream
+  // chunk while combinedText is unchanged — depending on `message` here would
+  // reflow the editor hundreds of times a second and lock up the main thread.
   useEffect(() => {
     if (combinedText) {
       editor?.commands.setContent(combinedText);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [message]);
+  }, [combinedText]);
+
+  // Every derived value below walks the (potentially deep) parts tree once.
+  // Memoize on `message` so unrelated state changes (showAllTools toggle,
+  // isChatBusy flip) don't re-run the walks. During streaming the message
+  // reference does churn per tick, but throttling `useChat` upstream keeps
+  // the cost bounded.
+  const mergedParts = useMemo(
+    () => (message ? mergeAgentParts(message.parts) : []),
+    [message],
+  );
+
+  const groupedParts = useMemo(
+    () => groupToolParts(mergedParts),
+    [mergedParts],
+  );
+
+  // Pending approvals from merged parts (so nested tools inside take_action are visible)
+  const pendingApprovals = useMemo(
+    () => (isUser ? [] : findPendingApprovals(mergedParts)),
+    [isUser, mergedParts],
+  );
+
+  // Use mergedParts so data-tool-agent nested tools are included in the flat list
+  const allToolsFlat = useMemo(
+    () => findAllToolsDeep(mergedParts),
+    [mergedParts],
+  );
+  const firstPendingApprovalIdx = useMemo(
+    () => findFirstPendingApprovalIndex(allToolsFlat),
+    [allToolsFlat],
+  );
 
   if (!message) {
     return null;
   }
-
-  const mergedParts = mergeAgentParts(message.parts);
-
-  const groupedParts = groupToolParts(mergedParts);
-
-  // Pending approvals from merged parts (so nested tools inside take_action are visible)
-  const pendingApprovals = isUser ? [] : findPendingApprovals(mergedParts);
-
-  // Use mergedParts so data-tool-agent nested tools are included in the flat list
-  const allToolsFlat = findAllToolsDeep(mergedParts);
-  const firstPendingApprovalIdx = findFirstPendingApprovalIndex(mergedParts);
 
   // Pass approval responses straight through — cascade-reject is handled inside ToolApprovalPanel.
   const handleToolApproval = (params: { id: string; approved: boolean }) => {

--- a/apps/webapp/app/components/conversation/conversation-utils.ts
+++ b/apps/webapp/app/components/conversation/conversation-utils.ts
@@ -284,13 +284,13 @@ export const findAllToolsDeep = (
 // ── findFirstPendingApprovalIndex ─────────────────────────────────────────────
 
 /**
- * Finds the index of the first tool with "approval-requested" state in flattened list.
- * Returns -1 if none found.
+ * Finds the index of the first tool with "approval-requested" state in a
+ * flattened tool list. Callers pass a precomputed list (from findAllToolsDeep)
+ * to avoid a second deep walk during streaming.
  */
 export const findFirstPendingApprovalIndex = (
-  parts: ExtendedPart[],
+  allTools: ConversationToolPart[],
 ): number => {
-  const allTools = findAllToolsDeep(parts);
   return allTools.findIndex((part) => part.state === "approval-requested");
 };
 

--- a/apps/webapp/app/components/conversation/conversation-view.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-view.client.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher } from "@remix-run/react";
 import { useLocalCommonState } from "~/hooks/use-local-state";
 import { useChat, type UIMessage } from "@ai-sdk/react";
@@ -192,6 +192,11 @@ export function ConversationView({
   } = useChat({
     id: conversationId,
     resume: true,
+    // Sub-agents (e.g. take_action) can emit hundreds of tool-call chunks
+    // per second. Without throttling, each chunk triggers a full re-render
+    // + deep parts-tree walk on the active assistant message and freezes
+    // the main thread. 100ms coalesces updates to ~10fps of streaming.
+    experimental_throttle: 100,
     onFinish: () => {
       toolArgOverridesRef.current = {};
       pendingApprovalRequestsRef.current = [];
@@ -345,16 +350,22 @@ export function ConversationView({
     prevMessageCountRef.current = newCount;
   }, [messages.length]);
 
-  const lastAssistant = [...messages]
-    .reverse()
-    .find((m) => m.role === "assistant") as UIMessage | undefined;
+  const lastAssistant = useMemo(
+    () =>
+      [...messages].reverse().find((m) => m.role === "assistant") as
+        | UIMessage
+        | undefined,
+    [messages],
+  );
 
   // Accumulated plain-text rendering of the latest assistant message
   // — feeds the streaming TTS hook so each completed sentence can be
   // spoken as the model emits it.
-  const lastAssistantText = lastAssistant
-    ? extractAssistantText(lastAssistant.parts as any[])
-    : "";
+  const lastAssistantText = useMemo(
+    () =>
+      lastAssistant ? extractAssistantText(lastAssistant.parts as any[]) : "",
+    [lastAssistant],
+  );
   const isChatStreaming = status === "streaming" || status === "submitted";
   const tts = useStreamingTTS({
     enabled: voiceMode,
@@ -380,16 +391,27 @@ export function ConversationView({
     [tts],
   );
 
-  const needsApproval = lastAssistant?.parts
-    ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
-    : false;
+  // The two walks below run per render of ConversationView. Memoize on
+  // lastAssistant so unrelated state changes (voiceMode, tts internals,
+  // spacer height) don't re-walk the parts tree.
+  const needsApproval = useMemo(
+    () =>
+      lastAssistant?.parts
+        ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
+        : false,
+    [lastAssistant],
+  );
 
   // Deep-scan the last assistant message for all suspended tool calls.
   // Keep the ref at the max seen set (stable during approval processing);
   // reset on chat finish (onFinish above).
-  const currentApprovalRequests = lastAssistant
-    ? collectApprovalRequests(mergeAgentParts(lastAssistant.parts))
-    : [];
+  const currentApprovalRequests = useMemo(
+    () =>
+      lastAssistant
+        ? collectApprovalRequests(mergeAgentParts(lastAssistant.parts))
+        : [],
+    [lastAssistant],
+  );
   if (
     currentApprovalRequests.length > pendingApprovalRequestsRef.current.length
   ) {

--- a/apps/webapp/app/components/conversation/tool-item.tsx
+++ b/apps/webapp/app/components/conversation/tool-item.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "~/lib/utils";
 import { type ChatAddToolApproveResponseFunction } from "ai";
 import {
@@ -33,17 +33,7 @@ import type { IconType } from "../icon-utils";
 import { Task } from "../icons/task";
 import { SuggestIntegrationsCards } from "./suggest-integrations-cards";
 
-export const Tool = ({
-  part,
-  addToolApprovalResponse,
-  isDisabled = false,
-  allToolsFlat = [],
-  firstPendingApprovalIdx = -1,
-  isNested = false,
-  integrationAccountMap = {},
-  integrationFrontendMap = {},
-  setToolArgOverride,
-}: {
+interface ToolProps {
   part: ConversationToolPart;
   addToolApprovalResponse: ChatAddToolApproveResponseFunction;
   isDisabled?: boolean;
@@ -56,7 +46,19 @@ export const Tool = ({
     toolCallId: string,
     args: Record<string, unknown>,
   ) => void;
-}) => {
+}
+
+const ToolInner = ({
+  part,
+  addToolApprovalResponse,
+  isDisabled = false,
+  allToolsFlat = [],
+  firstPendingApprovalIdx = -1,
+  isNested = false,
+  integrationAccountMap = {},
+  integrationFrontendMap = {},
+  setToolArgOverride,
+}: ToolProps) => {
   const toolName = part.type.replace("tool-", "");
   const needsApproval = part.state === "approval-requested";
 
@@ -76,12 +78,21 @@ export const Tool = ({
     (part as unknown as { args?: Record<string, unknown> }).args ??
     {};
 
-  // Get all nested parts from output
-  const allNestedParts = getNestedPartsFromOutput(part.output);
+  // Get all nested parts from output. `part.output` identity is stable across
+  // stream ticks that don't change this specific tool, so useMemo keeps the
+  // walk cheap when a sibling tool advances.
+  const allNestedParts = useMemo(
+    () => getNestedPartsFromOutput(part.output),
+    [part.output],
+  );
 
   // Filter to get only tool parts
-  const liveNestedToolParts = allNestedParts.filter(
-    (item): item is ConversationToolPart => item.type.includes("tool-"),
+  const liveNestedToolParts = useMemo(
+    () =>
+      allNestedParts.filter((item): item is ConversationToolPart =>
+        item.type.includes("tool-"),
+      ),
+    [allNestedParts],
   );
 
   // Cache toolCalls seen in nested parts. The resumed stream (after approval)
@@ -93,7 +104,7 @@ export const Tool = ({
     cachedNestedPartsRef.current = liveNestedToolParts;
   }
 
-  const nestedToolParts: ConversationToolPart[] = (() => {
+  const nestedToolParts: ConversationToolPart[] = useMemo(() => {
     if (liveNestedToolParts.length > 0) return liveNestedToolParts;
     const cached = cachedNestedPartsRef.current;
     if (cached.length === 0) return [];
@@ -123,13 +134,15 @@ export const Tool = ({
         output: match.result,
       };
     });
-  })();
+  }, [liveNestedToolParts, part.output]);
 
   const hasNestedTools = nestedToolParts.length > 0;
 
   // Check if any nested tool (at any depth) needs approval (to auto-open)
-  const hasNestedApproval =
-    hasNestedTools && hasNeedsApprovalDeep(nestedToolParts);
+  const hasNestedApproval = useMemo(
+    () => hasNestedTools && hasNeedsApprovalDeep(nestedToolParts),
+    [hasNestedTools, nestedToolParts],
+  );
 
   const [isOpen, setIsOpen] = useState(!needsApproval && hasNestedApproval);
 
@@ -599,8 +612,49 @@ export const Tool = ({
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className={cn("w-full", isNested && "pl-3")}>
-        {hasNestedTools ? renderNestedContent() : renderLeafContent()}
+        {/* Only construct the child JSX when actually visible. Otherwise a
+         *  sub-agent with hundreds of nested tools would stringify every
+         *  input/output on every stream tick even though it's hidden. */}
+        {isOpen &&
+          (hasNestedTools ? renderNestedContent() : renderLeafContent())}
       </CollapsibleContent>
     </Collapsible>
   );
 };
+
+/**
+ * Memoize so a stream tick that only advances one tool in a sub-agent's
+ * take_action doesn't re-render every sibling. Once a tool reaches a
+ * terminal state, its data won't change again, so we can safely skip the
+ * re-render even if the parent handed us a fresh part object reference and
+ * a fresh allToolsFlat array — isToolDisabled only returns true for pending
+ * approvals, so terminal tools are unaffected by sibling churn.
+ */
+const arePropsEqual = (prev: ToolProps, next: ToolProps): boolean => {
+  const p = prev.part;
+  const n = next.part;
+  if (p.toolCallId !== n.toolCallId || p.state !== n.state) return false;
+  const terminal =
+    n.state === "output-available" ||
+    n.state === "output-error" ||
+    n.state === "output-denied" ||
+    n.state === "approval-responded";
+  // Terminal fast-path: skip regardless of upstream reference churn — the
+  // observable data on a completed tool is fixed for life. This is what
+  // actually breaks the O(N²) storm when a sub-agent has many tools.
+  if (terminal) return true;
+  // Non-terminal (still streaming): fall back to shallow prop equality.
+  return (
+    p === n &&
+    prev.isDisabled === next.isDisabled &&
+    prev.firstPendingApprovalIdx === next.firstPendingApprovalIdx &&
+    prev.isNested === next.isNested &&
+    prev.addToolApprovalResponse === next.addToolApprovalResponse &&
+    prev.setToolArgOverride === next.setToolArgOverride &&
+    prev.integrationAccountMap === next.integrationAccountMap &&
+    prev.integrationFrontendMap === next.integrationFrontendMap &&
+    prev.allToolsFlat === next.allToolsFlat
+  );
+};
+
+export const Tool = memo(ToolInner, arePropsEqual);

--- a/apps/webapp/app/components/editor/conversation-popover.tsx
+++ b/apps/webapp/app/components/editor/conversation-popover.tsx
@@ -107,6 +107,9 @@ export function ConversationPopover({
   } = useChat({
     id: conversationId ?? "conversation-popover",
     messages: historyMessages,
+    // Throttle stream-driven state updates so a chatty sub-agent can't stall
+    // the popover's main thread — matches ConversationView.
+    experimental_throttle: 100,
     onFinish: () => {
       toolArgOverridesRef.current = {};
     },
@@ -218,13 +221,19 @@ export function ConversationPopover({
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [visibleMessages]);
 
-  const lastAssistant = [...messages]
-    .reverse()
-    .find((message) => message.role === "assistant");
+  const lastAssistant = useMemo(
+    () =>
+      [...messages].reverse().find((message) => message.role === "assistant"),
+    [messages],
+  );
 
-  const needsApproval = lastAssistant?.parts
-    ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
-    : false;
+  const needsApproval = useMemo(
+    () =>
+      lastAssistant?.parts
+        ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
+        : false,
+    [lastAssistant],
+  );
 
   const handleToolApprovalResponse = useCallback(
     (params: { id: string; approved: boolean }) => {


### PR DESCRIPTION
## Summary
- A sub-agent (e.g. `take_action`) can emit hundreds of tool-call chunks per second. Without throttling, every chunk re-rendered the active assistant message, and every render walked the parts tree 5× (`findFirstPendingApprovalIndex` called `findAllToolsDeep` internally). Every nested `<Tool>` also constructed its `JSON.stringify` output JSX even when its collapsible was closed. That's O(N²) of JSX per streamed tick — enough to freeze the tab. The stalled client also lets the resumable-stream Redis buffer back up on the server side, which is the likely path to the intermittent backend OOMs.
- `useChat` now sets `experimental_throttle: 100` (coalesces to ~10fps), tree walks are memoized, `<Tool>` is wrapped in `React.memo` with a terminal-state fast-path so completed nested tools stop re-rendering when a sibling advances, and `CollapsibleContent` children render only when `isOpen` — no more per-tick `JSON.stringify` on hundreds of hidden nodes.

## Test plan
- [ ] Load a conversation that already has a completed sub-agent (`agent-take_action`) with many nested tool calls — everything renders correctly and Chevron expansion still shows input/output JSON.
- [ ] Start a fresh chat that triggers `take_action` with many tool calls (e.g. a bulk integration action). Confirm the page stays interactive during streaming (scroll, click, type in composer) — should no longer freeze.
- [ ] While streaming, expand and collapse a nested tool row — the input/output panels render on open and disappear on close (no lingering DOM).
- [ ] Approve/decline a suspended tool. Approval flow and cascade rejection still work; the approval panel receives the correct `approvalId`/`toolCallId`.
- [ ] Verify voice mode: `lastAssistantText` still updates the streaming TTS incrementally.
- [ ] `ConversationPopover` (butler popover) opens on a conversation with many parts and remains responsive during a sub-agent turn.
- [ ] Run `pnpm typecheck` from `apps/webapp`. Only the pre-existing errors (`slash-command.tsx`, `home.memory.people.*`, `home.tsx`, `onboarding.name.tsx`, `settings.workspace._index.tsx`, task/contact tests) remain — no new errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)