### PR TITLE
feat(memory): tighter voice classifier, Identity-only persona, voice-aspect search on all queries

### DIFF
--- a/apps/webapp/app/components/conversation/conversation-item.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-item.client.tsx
@@ -1,5 +1,5 @@
 import { EditorContent, useEditor } from "@tiptap/react";
-import { useEffect, memo, useState } from "react";
+import { useEffect, memo, useMemo, useState } from "react";
 import { cn } from "~/lib/utils";
 import { extensionsForConversation } from "./editor-extensions";
 import { type ChatAddToolApproveResponseFunction, type UIMessage } from "ai";
@@ -41,11 +41,17 @@ const ConversationItemComponent = ({
   integrationFrontendMap = {},
   className,
 }: AIConversationItemProps) => {
-  const isUser = message.role === "user" || false;
-  const combinedText = message.parts
-    .filter((part: any) => part.type === "text" && part.text)
-    .map((p: any) => p.text)
-    .join("");
+  const isUser = message?.role === "user" || false;
+  const combinedText = useMemo(
+    () =>
+      message
+        ? message.parts
+            .filter((part: any) => part.type === "text" && part.text)
+            .map((p: any) => p.text)
+            .join("")
+        : "",
+    [message],
+  );
   const [showAllTools, setShowAllTools] = useState(false);
   const formattedTime = createdAt
     ? new Date(createdAt).toLocaleTimeString([], {
@@ -60,27 +66,51 @@ const ConversationItemComponent = ({
     content: combinedText ? combinedText : "",
   });
 
+  // Push new content only when the extracted text actually changes. During a
+  // sub-agent's tool-call storm, `message` identity flips on every stream
+  // chunk while combinedText is unchanged — depending on `message` here would
+  // reflow the editor hundreds of times a second and lock up the main thread.
   useEffect(() => {
     if (combinedText) {
       editor?.commands.setContent(combinedText);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [message]);
+  }, [combinedText]);
+
+  // Every derived value below walks the (potentially deep) parts tree once.
+  // Memoize on `message` so unrelated state changes (showAllTools toggle,
+  // isChatBusy flip) don't re-run the walks. During streaming the message
+  // reference does churn per tick, but throttling `useChat` upstream keeps
+  // the cost bounded.
+  const mergedParts = useMemo(
+    () => (message ? mergeAgentParts(message.parts) : []),
+    [message],
+  );
+
+  const groupedParts = useMemo(
+    () => groupToolParts(mergedParts),
+    [mergedParts],
+  );
+
+  // Pending approvals from merged parts (so nested tools inside take_action are visible)
+  const pendingApprovals = useMemo(
+    () => (isUser ? [] : findPendingApprovals(mergedParts)),
+    [isUser, mergedParts],
+  );
+
+  // Use mergedParts so data-tool-agent nested tools are included in the flat list
+  const allToolsFlat = useMemo(
+    () => findAllToolsDeep(mergedParts),
+    [mergedParts],
+  );
+  const firstPendingApprovalIdx = useMemo(
+    () => findFirstPendingApprovalIndex(allToolsFlat),
+    [allToolsFlat],
+  );
 
   if (!message) {
     return null;
   }
-
-  const mergedParts = mergeAgentParts(message.parts);
-
-  const groupedParts = groupToolParts(mergedParts);
-
-  // Pending approvals from merged parts (so nested tools inside take_action are visible)
-  const pendingApprovals = isUser ? [] : findPendingApprovals(mergedParts);
-
-  // Use mergedParts so data-tool-agent nested tools are included in the flat list
-  const allToolsFlat = findAllToolsDeep(mergedParts);
-  const firstPendingApprovalIdx = findFirstPendingApprovalIndex(mergedParts);
 
   // Pass approval responses straight through — cascade-reject is handled inside ToolApprovalPanel.
   const handleToolApproval = (params: { id: string; approved: boolean }) => {

--- a/apps/webapp/app/components/conversation/conversation-utils.ts
+++ b/apps/webapp/app/components/conversation/conversation-utils.ts
@@ -284,13 +284,13 @@ export const findAllToolsDeep = (
 // ── findFirstPendingApprovalIndex ─────────────────────────────────────────────
 
 /**
- * Finds the index of the first tool with "approval-requested" state in flattened list.
- * Returns -1 if none found.
+ * Finds the index of the first tool with "approval-requested" state in a
+ * flattened tool list. Callers pass a precomputed list (from findAllToolsDeep)
+ * to avoid a second deep walk during streaming.
  */
 export const findFirstPendingApprovalIndex = (
-  parts: ExtendedPart[],
+  allTools: ConversationToolPart[],
 ): number => {
-  const allTools = findAllToolsDeep(parts);
   return allTools.findIndex((part) => part.state === "approval-requested");
 };
 

--- a/apps/webapp/app/components/conversation/conversation-view.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-view.client.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher } from "@remix-run/react";
 import { useLocalCommonState } from "~/hooks/use-local-state";
 import { useChat, type UIMessage } from "@ai-sdk/react";
@@ -192,6 +192,11 @@ export function ConversationView({
   } = useChat({
     id: conversationId,
     resume: true,
+    // Sub-agents (e.g. take_action) can emit hundreds of tool-call chunks
+    // per second. Without throttling, each chunk triggers a full re-render
+    // + deep parts-tree walk on the active assistant message and freezes
+    // the main thread. 100ms coalesces updates to ~10fps of streaming.
+    experimental_throttle: 100,
     onFinish: () => {
       toolArgOverridesRef.current = {};
       pendingApprovalRequestsRef.current = [];
@@ -345,16 +350,22 @@ export function ConversationView({
     prevMessageCountRef.current = newCount;
   }, [messages.length]);
 
-  const lastAssistant = [...messages]
-    .reverse()
-    .find((m) => m.role === "assistant") as UIMessage | undefined;
+  const lastAssistant = useMemo(
+    () =>
+      [...messages].reverse().find((m) => m.role === "assistant") as
+        | UIMessage
+        | undefined,
+    [messages],
+  );
 
   // Accumulated plain-text rendering of the latest assistant message
   // — feeds the streaming TTS hook so each completed sentence can be
   // spoken as the model emits it.
-  const lastAssistantText = lastAssistant
-    ? extractAssistantText(lastAssistant.parts as any[])
-    : "";
+  const lastAssistantText = useMemo(
+    () =>
+      lastAssistant ? extractAssistantText(lastAssistant.parts as any[]) : "",
+    [lastAssistant],
+  );
   const isChatStreaming = status === "streaming" || status === "submitted";
   const tts = useStreamingTTS({
     enabled: voiceMode,
@@ -380,16 +391,27 @@ export function ConversationView({
     [tts],
   );
 
-  const needsApproval = lastAssistant?.parts
-    ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
-    : false;
+  // The two walks below run per render of ConversationView. Memoize on
+  // lastAssistant so unrelated state changes (voiceMode, tts internals,
+  // spacer height) don't re-walk the parts tree.
+  const needsApproval = useMemo(
+    () =>
+      lastAssistant?.parts
+        ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
+        : false,
+    [lastAssistant],
+  );
 
   // Deep-scan the last assistant message for all suspended tool calls.
   // Keep the ref at the max seen set (stable during approval processing);
   // reset on chat finish (onFinish above).
-  const currentApprovalRequests = lastAssistant
-    ? collectApprovalRequests(mergeAgentParts(lastAssistant.parts))
-    : [];
+  const currentApprovalRequests = useMemo(
+    () =>
+      lastAssistant
+        ? collectApprovalRequests(mergeAgentParts(lastAssistant.parts))
+        : [],
+    [lastAssistant],
+  );
   if (
     currentApprovalRequests.length > pendingApprovalRequestsRef.current.length
   ) {

--- a/apps/webapp/app/components/conversation/tool-item.tsx
+++ b/apps/webapp/app/components/conversation/tool-item.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "~/lib/utils";
 import { type ChatAddToolApproveResponseFunction } from "ai";
 import {
@@ -33,17 +33,7 @@ import type { IconType } from "../icon-utils";
 import { Task } from "../icons/task";
 import { SuggestIntegrationsCards } from "./suggest-integrations-cards";
 
-export const Tool = ({
-  part,
-  addToolApprovalResponse,
-  isDisabled = false,
-  allToolsFlat = [],
-  firstPendingApprovalIdx = -1,
-  isNested = false,
-  integrationAccountMap = {},
-  integrationFrontendMap = {},
-  setToolArgOverride,
-}: {
+interface ToolProps {
   part: ConversationToolPart;
   addToolApprovalResponse: ChatAddToolApproveResponseFunction;
   isDisabled?: boolean;
@@ -56,7 +46,19 @@ export const Tool = ({
     toolCallId: string,
     args: Record<string, unknown>,
   ) => void;
-}) => {
+}
+
+const ToolInner = ({
+  part,
+  addToolApprovalResponse,
+  isDisabled = false,
+  allToolsFlat = [],
+  firstPendingApprovalIdx = -1,
+  isNested = false,
+  integrationAccountMap = {},
+  integrationFrontendMap = {},
+  setToolArgOverride,
+}: ToolProps) => {
   const toolName = part.type.replace("tool-", "");
   const needsApproval = part.state === "approval-requested";
 
@@ -76,12 +78,21 @@ export const Tool = ({
     (part as unknown as { args?: Record<string, unknown> }).args ??
     {};
 
-  // Get all nested parts from output
-  const allNestedParts = getNestedPartsFromOutput(part.output);
+  // Get all nested parts from output. `part.output` identity is stable across
+  // stream ticks that don't change this specific tool, so useMemo keeps the
+  // walk cheap when a sibling tool advances.
+  const allNestedParts = useMemo(
+    () => getNestedPartsFromOutput(part.output),
+    [part.output],
+  );
 
   // Filter to get only tool parts
-  const liveNestedToolParts = allNestedParts.filter(
-    (item): item is ConversationToolPart => item.type.includes("tool-"),
+  const liveNestedToolParts = useMemo(
+    () =>
+      allNestedParts.filter((item): item is ConversationToolPart =>
+        item.type.includes("tool-"),
+      ),
+    [allNestedParts],
   );
 
   // Cache toolCalls seen in nested parts. The resumed stream (after approval)
@@ -93,7 +104,7 @@ export const Tool = ({
     cachedNestedPartsRef.current = liveNestedToolParts;
   }
 
-  const nestedToolParts: ConversationToolPart[] = (() => {
+  const nestedToolParts: ConversationToolPart[] = useMemo(() => {
     if (liveNestedToolParts.length > 0) return liveNestedToolParts;
     const cached = cachedNestedPartsRef.current;
     if (cached.length === 0) return [];
@@ -123,13 +134,15 @@ export const Tool = ({
         output: match.result,
       };
     });
-  })();
+  }, [liveNestedToolParts, part.output]);
 
   const hasNestedTools = nestedToolParts.length > 0;
 
   // Check if any nested tool (at any depth) needs approval (to auto-open)
-  const hasNestedApproval =
-    hasNestedTools && hasNeedsApprovalDeep(nestedToolParts);
+  const hasNestedApproval = useMemo(
+    () => hasNestedTools && hasNeedsApprovalDeep(nestedToolParts),
+    [hasNestedTools, nestedToolParts],
+  );
 
   const [isOpen, setIsOpen] = useState(!needsApproval && hasNestedApproval);
 
@@ -599,8 +612,49 @@ export const Tool = ({
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className={cn("w-full", isNested && "pl-3")}>
-        {hasNestedTools ? renderNestedContent() : renderLeafContent()}
+        {/* Only construct the child JSX when actually visible. Otherwise a
+         *  sub-agent with hundreds of nested tools would stringify every
+         *  input/output on every stream tick even though it's hidden. */}
+        {isOpen &&
+          (hasNestedTools ? renderNestedContent() : renderLeafContent())}
       </CollapsibleContent>
     </Collapsible>
   );
 };
+
+/**
+ * Memoize so a stream tick that only advances one tool in a sub-agent's
+ * take_action doesn't re-render every sibling. Once a tool reaches a
+ * terminal state, its data won't change again, so we can safely skip the
+ * re-render even if the parent handed us a fresh part object reference and
+ * a fresh allToolsFlat array — isToolDisabled only returns true for pending
+ * approvals, so terminal tools are unaffected by sibling churn.
+ */
+const arePropsEqual = (prev: ToolProps, next: ToolProps): boolean => {
+  const p = prev.part;
+  const n = next.part;
+  if (p.toolCallId !== n.toolCallId || p.state !== n.state) return false;
+  const terminal =
+    n.state === "output-available" ||
+    n.state === "output-error" ||
+    n.state === "output-denied" ||
+    n.state === "approval-responded";
+  // Terminal fast-path: skip regardless of upstream reference churn — the
+  // observable data on a completed tool is fixed for life. This is what
+  // actually breaks the O(N²) storm when a sub-agent has many tools.
+  if (terminal) return true;
+  // Non-terminal (still streaming): fall back to shallow prop equality.
+  return (
+    p === n &&
+    prev.isDisabled === next.isDisabled &&
+    prev.firstPendingApprovalIdx === next.firstPendingApprovalIdx &&
+    prev.isNested === next.isNested &&
+    prev.addToolApprovalResponse === next.addToolApprovalResponse &&
+    prev.setToolArgOverride === next.setToolArgOverride &&
+    prev.integrationAccountMap === next.integrationAccountMap &&
+    prev.integrationFrontendMap === next.integrationFrontendMap &&
+    prev.allToolsFlat === next.allToolsFlat
+  );
+};
+
+export const Tool = memo(ToolInner, arePropsEqual);

--- a/apps/webapp/app/components/editor/conversation-popover.tsx
+++ b/apps/webapp/app/components/editor/conversation-popover.tsx
@@ -107,6 +107,9 @@ export function ConversationPopover({
   } = useChat({
     id: conversationId ?? "conversation-popover",
     messages: historyMessages,
+    // Throttle stream-driven state updates so a chatty sub-agent can't stall
+    // the popover's main thread — matches ConversationView.
+    experimental_throttle: 100,
     onFinish: () => {
       toolArgOverridesRef.current = {};
     },
@@ -218,13 +221,19 @@ export function ConversationPopover({
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [visibleMessages]);
 
-  const lastAssistant = [...messages]
-    .reverse()
-    .find((message) => message.role === "assistant");
+  const lastAssistant = useMemo(
+    () =>
+      [...messages].reverse().find((message) => message.role === "assistant"),
+    [messages],
+  );
 
-  const needsApproval = lastAssistant?.parts
-    ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
-    : false;
+  const needsApproval = useMemo(
+    () =>
+      lastAssistant?.parts
+        ? hasNeedsApprovalDeep(lastAssistant.parts as ConversationToolPart[])
+        : false,
+    [lastAssistant],
+  );
 
   const handleToolApprovalResponse = useCallback(
     (params: { id: string; approved: boolean }) => {

--- a/apps/webapp/app/jobs/spaces/aspect-persona-generation.ts
+++ b/apps/webapp/app/jobs/spaces/aspect-persona-generation.ts
@@ -58,8 +58,10 @@ const MIN_STATEMENTS_PER_SECTION = 1;
 const MAX_STATEMENTS_PER_CHUNK = 30;
 const MAX_EPISODES_PER_CHUNK = 20;
 
-// Aspects to skip entirely from persona generation
-// Event: Transient calendar/schedule data - agents can query graph directly for specific dates
+// Persona now surfaces IDENTITY only. Everything else (preferences, directives,
+// goals, beliefs, etc.) lives in the graph and is retrievable via memory search
+// at runtime — the persona is intentionally kept small so it stays useful when
+// preloaded on every task.
 const SKIPPED_ASPECTS: StatementAspect[] = [
   "Event",
   "Relationship",
@@ -70,6 +72,8 @@ const SKIPPED_ASPECTS: StatementAspect[] = [
   "Decision",
   "Problem",
   "Task",
+  "Preference",
+  "Directive",
 ];
 
 // ─── Markdown section helpers ───────────────────────────────────────
@@ -1225,11 +1229,7 @@ function combineIntoPersonaDocument(
   sections: PersonaSectionResult[],
   userContext: UserContext,
 ): string {
-  const sectionOrder: StatementAspect[] = [
-    "Identity",
-    "Preference",
-    "Directive",
-  ];
+  const sectionOrder: StatementAspect[] = ["Identity"];
 
   const sectionsByAspect = new Map(sections.map((s) => [s.aspect, s]));
 

--- a/apps/webapp/app/services/prompts/__tests__/classify-voice.cases.json
+++ b/apps/webapp/app/services/prompts/__tests__/classify-voice.cases.json
@@ -1,0 +1,765 @@
+[
+  {
+    "id": "goal_de371848",
+    "fact": "Plan to redeploy the town (town push) when ready to make the manifest/instruction changes live.",
+    "oldAspect": "Goal",
+    "expected": "Task",
+    "reason": "one-time plan"
+  },
+  {
+    "id": "goal_489292cf",
+    "fact": "Harshith Mullapudi intends to use the Google Docs integration from the core integrations codebase (google-docs).",
+    "oldAspect": "Goal",
+    "expected": "Task",
+    "reason": "'intends to use X' — one-time"
+  },
+  {
+    "id": "goal_faaf9644",
+    "fact": "Harshith Mullapudi intends to use the startup town from the repository path towns/ (specifically towns/ai-startup-town).",
+    "oldAspect": "Goal",
+    "expected": "Task",
+    "reason": "'intends to use X' — one-time"
+  },
+  {
+    "id": "goal_249a312d",
+    "fact": "1. Harshith Mullapudi wants the personalized town project to preserve clear visual differences between towns and buildings across users so designs don't converge over time.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_bdc28d09",
+    "fact": "Harshith Mullapudi is considering migrating the project to Next.js because it will be server-backed.",
+    "oldAspect": "Goal",
+    "expected": "Task",
+    "reason": "one-time evaluation"
+  },
+  {
+    "id": "goal_d4cdf07f",
+    "fact": "Harshith Mullapudi wants the game developed iteratively over time while keeping it strictly 2D with a Nintendo Pokémon–like top-down, tile-based RPG aesthetic.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_1a86cf1f",
+    "fact": "Harshith Mullapudi wants the gateway-skill installation UX to let the end user “not worry about all this” by selecting a gateway during an Install action (UI asks “which gateway?”) and then installing the skill onto that chosen gateway.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_5a01e138",
+    "fact": "Wants the final scorecard UI to be responsive on small screens (wrap/flow instead of being cut off).",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "'wants X to <verb>' — feature spec"
+  },
+  {
+    "id": "goal_15625fe3",
+    "fact": "Wants the Home app redesigned to function as a manifesto of what the product is doing, using the current '/' landing page content as the Home page text.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject: 'wants [product-component]'"
+  },
+  {
+    "id": "goal_81b56c22",
+    "fact": "I want to build a community and a public “intelligence layer” product positioned like a butler/Jarvis/chief of staff, with a publicly owned roadmap (community-owned product direction).",
+    "oldAspect": "Goal",
+    "expected": "Goal",
+    "reason": "'I want to X' + personal-pursuit verb"
+  },
+  {
+    "id": "goal_8d0effe3",
+    "fact": "Wants a home/overview widget that shows all currently running coding sessions and to make it available as a default widget users can add.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject: 'wants [product-component]'"
+  },
+  {
+    "id": "goal_fe466aec",
+    "fact": "Harshith is considering positioning CORE as an “opinionated framework of working” and is evaluating whether that phrasing appropriately conveys the product’s feel/positioning.",
+    "oldAspect": "Goal",
+    "expected": "Task",
+    "reason": "one-time evaluation"
+  },
+  {
+    "id": "goal_183d6a1e",
+    "fact": "Harshith Mullapudi wants a mobile implementation that avoids a plain WebView embed and instead uses a native-feeling Tentap (Tiptap-in-WebView) editor.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_46f652ae",
+    "fact": "Harshith Mullapudi intends an initial app scope of two pages—Scratchpad and Voice—and is evaluating whether a separate Tasks surface is needed.",
+    "oldAspect": "Goal",
+    "expected": "Task",
+    "reason": "one-time evaluation"
+  },
+  {
+    "id": "goal_f34e9597",
+    "fact": "Harshith Mullapudi wants the Corebrain TUI redesigned to align with the Mac app’s tasks UX (a substantial redesign described as “stunning changes”).",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_6a0aa040",
+    "fact": "Harshith Mullapudi's launch success targets for CORE: reach the Hacker News front page for 4+ hours, achieve 500+ HN points, have all four planned Reddit posts reach “Hot” in their respective subreddits, hit GitHub Trending within 24 hours of launch, reach 3k–5k GitHub stars on day one, and reach 8k–10k GitHub stars by end of week.",
+    "oldAspect": "Goal",
+    "expected": "Goal",
+    "reason": "explicit launch success metrics"
+  },
+  {
+    "id": "goal_63a0ba1a",
+    "fact": "Harshith Mullapudi has an aspirational target of roughly 10k GitHub stars (an increase of ~8.5k stars).",
+    "oldAspect": "Goal",
+    "expected": "Goal",
+    "reason": "'aspirational target' phrasing"
+  },
+  {
+    "id": "goal_2c4c5240",
+    "fact": "Deliverable goal: produce an updated plan (not implementation) that is file+line accurate for three fixes, returning a concise plan that includes touched files, key components, acceptance criteria, and open questions.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "'Deliverable goal:' phrasing"
+  },
+  {
+    "id": "goal_d6253d45",
+    "fact": "3. April focus is to launch and iterate on positioning until something clearly clicks.",
+    "oldAspect": "Goal",
+    "expected": "Goal",
+    "reason": "time-boxed personal focus"
+  },
+  {
+    "id": "goal_4f8bc995",
+    "fact": "Wants the system to support default Azure model/deployment selection (deriving defaults from the selected model/template when possible) while still allowing end users to override those defaults.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject: 'wants [product-component]'"
+  },
+  {
+    "id": "goal_a76bdfb2",
+    "fact": "Harshith Mullapudi wants a Channel CRUD API in the Remix app scoped to the current workspace (session-derived workspaceId) that lists and creates channels, supports PATCH updates for name/config/isDefault/isActive, and treats DELETE as a soft-delete by deactivating a channel rather than hard deletion.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_055b93be",
+    "fact": "Harshith Mullapudi wants the final widget build artifact to be a single file named `index.js`, stored/registered in the “integration definition” table and dynamically downloaded/loaded by the UI at runtime.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_1d90c8dd",
+    "fact": "Harshith Mullapudi wants the widget render API/context to receive: (1) `placement` (the surface/where it is rendered), (2) `accounts` representing all connected integration accounts but containing only each account's `id`, and (3) a PAT (personal access token) for tool/API access.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_e8912408",
+    "fact": "Harshith Mullapudi wants the system to support creating two orders simultaneously (e.g., one on Amazon and one on Swiggy) rather than being limited to only one session/task running at a time.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject spec"
+  },
+  {
+    "id": "goal_fe88215f",
+    "fact": "Wants system prompts reviewed to ensure they are high-quality and that users can clearly perceive differences between personalities during interaction.",
+    "oldAspect": "Goal",
+    "expected": "Directive",
+    "reason": "system-subject: 'wants [product-component]'"
+  },
+  {
+    "id": "habit_d1803420",
+    "fact": "Harshith Mullapudi uses YNAB (You Need A Budget).",
+    "oldAspect": "Habit",
+    "expected": "Habit",
+    "reason": "personal-finance recurring behavior"
+  },
+  {
+    "id": "habit_b104115f",
+    "fact": "Harshith Mullapudi records product/SDK guidance about Claude model capabilities and migration considerations (task budgets, vision resolution and token/cost implications, prompting and memory behavior, and interim-update behavior) for later reference.",
+    "oldAspect": "Habit",
+    "expected": "Directive",
+    "reason": "SDK-scoped methodology"
+  },
+  {
+    "id": "habit_e27d6382",
+    "fact": "Harshith Mullapudi journals about meals and restaurant experiences.",
+    "oldAspect": "Habit",
+    "expected": "Habit",
+    "reason": "personal journaling ritual"
+  },
+  {
+    "id": "habit_ee56f345",
+    "fact": "Harshith Mullapudi maintains a daily “today’s scratchpad” with sections like “Brief,” “Carried over,” “Suggested today,” and “Heads up,” and uses it to track and surface tasks and notices.",
+    "oldAspect": "Habit",
+    "expected": "Habit",
+    "reason": "life-cadence keyword"
+  },
+  {
+    "id": "habit_7284fb3b",
+    "fact": "Uses a “Subagent-Driven Development” workflow defined as a DOT/Graphviz process that starts by reading an implementation plan, extracting all tasks with full text, noting relevant context, and creating a TodoWrite task list.",
+    "oldAspect": "Habit",
+    "expected": "Directive",
+    "reason": "DOT/Graphviz workflow doc"
+  },
+  {
+    "id": "habit_80a343a2",
+    "fact": "Harshith Mullapudi asks clarifying questions and challenges whether proposed approaches are the best way to solve problems.",
+    "oldAspect": "Habit",
+    "expected": "Habit",
+    "reason": "recurring communication behavior"
+  },
+  {
+    "id": "habit_9ed42e75",
+    "fact": "Treats 3+ failed fixes as a potential “wrong architecture” situation rather than merely a failed hypothesis, and responds by stopping to question fundamentals and discussing with a human partner before attempting more fixes.",
+    "oldAspect": "Habit",
+    "expected": "Directive",
+    "reason": "meta-methodology rule"
+  },
+  {
+    "id": "habit_268f3989",
+    "fact": "Harshith Mullapudi has an automated WhatsApp “daily morning sync for harshith” reminder workflow with specific filtering rules and deliverables.",
+    "oldAspect": "Habit",
+    "expected": "Habit",
+    "reason": "life-cadence keyword"
+  },
+  {
+    "id": "habit_46762845",
+    "fact": "I rely on tauri-apps/tauri-action to handle macOS notarization automatically when the required environment variables are set.",
+    "oldAspect": "Habit",
+    "expected": "Preference",
+    "reason": "SDK/tool-choice preference"
+  },
+  {
+    "id": "habit_fa234471",
+    "fact": "I handle personal finance and security triage by quickly verifying alerts and locking down issues.",
+    "oldAspect": "Habit",
+    "expected": "Directive",
+    "reason": "triage workflow methodology"
+  },
+  {
+    "id": "ctrl_dir_b0ec71e5",
+    "fact": "Anything that looks wrong should always be flagged in one sentence describing what was noticed and its impact.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_f105e40c",
+    "fact": "Do not repeatedly point to documentation (e.g., avoid “Refs:” links); reference docs only when the conversation explicitly goes into documentation or technical/setup details.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_d5e33700",
+    "fact": "Questions must not be persisted into the task description; derive/bubble them up from the chat thread instead.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_87353b74",
+    "fact": "Use `figma.createAutoLayout()` for containers with structurally related children rather than relying on absolute `x/y` positioning (\"Rule 12a\").",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_2447b951",
+    "fact": "Harshith Mullapudi requires that gateway-dependent commands must not operate when no native native gateway is installed/present.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_108d0528",
+    "fact": "Store credentials securely using the existing credential storage patterns (IntegrationAccount credentials/config).",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_279b1658",
+    "fact": "Do not use placeholders or ambiguous task surfacing.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_de6f8899",
+    "fact": "When working on integrations, missing permissions must be stated and the system must not advance by assumption.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_8788ff47",
+    "fact": "Only actionable, non-noise emails should be surfaced and must include source/context.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_43285c14",
+    "fact": "Any project/iteration filtering requires explicit field/value confirmation and must not proceed if ambiguous.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_3ac92ae0",
+    "fact": "Actions/status changes/IDs must always be explicit in messaging.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_7bcd2900",
+    "fact": "Onboarding outputs must always show connection status, progress, and a preference/memory graph, and must allow Harshith Mullapudi to provide correction/feedback.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_dfadc4d4",
+    "fact": "Users must not be able to access /home until onboardingComplete === true.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_893b4a28",
+    "fact": "Do not bundle Playwright Chromium into the CoreBrain gateway binary; ensure Chromium is installed during post-install/setup.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_81a69ea4",
+    "fact": "Do not introduce a separate “tasks” system or separate task storage for CORE’s coding orchestration, because task orchestration is already handled by CORE’s existing coding-session machinery.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_ecdc21d5",
+    "fact": "Do not use queue workers (BullMQ/Trigger.dev or similar); focus on an HTTP-only chat streaming path for this implementation.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_9b361ee2",
+    "fact": "Use quick, read-only inspection scripts to discover file structure (e.g., listing pages/top-level nodes, components, and variable collections) before making changes.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_e3f8189f",
+    "fact": "Use a one-time-per-project routing-rules injection flow; skip the routing-rules step entirely if HAS_ROUTING is yes or ROUTING_DECLINED is true.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_eee87d04",
+    "fact": "Never process, notify, or store Harshith Mullapudi’s data without per-case opt-in.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_26acfea0",
+    "fact": "Harshith Mullapudi requires an explicit system-prompt guardrail: the system must always ask Harshith for explicit approval before calling any generate function because generation consumes aura.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_f44c384a",
+    "fact": "Use output_config: {format: {...}} instead of the deprecated output_format parameter on messages.create().",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_b5b7a434",
+    "fact": "Only one item/channel may be marked as the single default at a time — not everything should be default.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_b049f211",
+    "fact": "Treat “plan my day” as a task only (a pure task), not a reusable skill/policy.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_23aab1a0",
+    "fact": "Do not push changes, open a pull request, or merge unless explicitly asked.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_dir_d14a1d10",
+    "fact": "Treat a task as “recurring” only if it has a schedule defined and taskOccurrences > 1; show “runs” in the UI only in that case.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: standing rule should stay Directive"
+  },
+  {
+    "id": "ctrl_pref_310ed43c",
+    "fact": "Prefers using WhatsApp for quick back-and-forth/ambient checks and approvals as a communication channel.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_a5dc567d",
+    "fact": "Harshith Mullapudi prefers a larger HOME interior with more items (the current interior felt too small).",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_eb9dd72e",
+    "fact": "Harshith Mullapudi prefers using a fixed structure (e.g., for NPC prompt templates).",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_b53584fe",
+    "fact": "I prefer the Home app’s default window size to be larger.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_9bff5082",
+    "fact": "For GitHub scanning, prefer repo-wide scans over filtered issue searches.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_4bf0a3eb",
+    "fact": "Harshith Mullapudi prefers a design shaped like a central rectangle with two circular side elements (pods/earpieces).",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_8b8a59b9",
+    "fact": "Prefer reusing existing OAuth and integration account routes rather than introducing new routes; an onboarding property-picker UI is an optional future enhancement.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_032e836e",
+    "fact": "For the analyst persona, I prefer a “CIA analyst” style name.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_23651d4a",
+    "fact": "Prefer renaming UI buttons to town-related, theme-consistent names.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_f8af6c9d",
+    "fact": "When reviewing visual output, I prefer using reference screenshots and having the assistant look at them to compare results.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_ec96b31c",
+    "fact": "Prefer high-level diagrams and architecture evaluations when requested.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_1df35204",
+    "fact": "Prefers using the Geist font, specifically setting Geist Variable as the default site-wide font.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_f3751f08",
+    "fact": "Prefer making only the exact requested string replacements and do not change other related mentions (e.g., Slack headers/section titles) unless explicitly instructed.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_c0794e90",
+    "fact": "For the butler persona, I prefer using “Alfred” for recognizability and clarity.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_d5ec579c",
+    "fact": "Prefers using a Tab+Tab gesture when the input is empty (for entering new-task mode).",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_bd74e96b",
+    "fact": "Harshith Mullapudi prefers using Option 1 if possible, but finds a WebView approach acceptable if required.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_b0f85a06",
+    "fact": "Finds the TARS persona to be the only one working well/preferred among the available personas.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_1b8288f4",
+    "fact": "Prefer detecting and operating on structured TipTap/ProseMirror node types (e.g., plan, output, workingContext via node.type.name) instead of parsing HTML and string-matching <h2> headings.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_896a0a8d",
+    "fact": "Prefer relationship retrieval to use vector search instead of brittle string CONTAINS matching.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref_25543a00",
+    "fact": "For the handleExploratory implementation, Harshith Mullapudi prefers using documents (querying PostgreSQL Document records via prisma.document) rather than fetching and grouping raw Neo4j episodes.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_bel_68f70df5",
+    "fact": "Harshith Mullapudi believes expanding comments and keeping conversations “still doable with butler” is feasible.",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_bel_fbe0b2e3",
+    "fact": "Harshith believes an LLM can notice cross-profile patterns across thousands of founders that humans cannot hold in working memory.",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_bel_81b8086e",
+    "fact": "I believe every AI-using knowledge worker will eventually have a personal operating system (an operating layer, not a chat app) that knows them, watches their work, learns from every conversation, and acts across every tool they use.",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_bel_74f95c36",
+    "fact": "I believe building is not the performance of building, and I reject tech-for-tech’s-sake; work becomes real when it ships and solves a real problem for a real person.",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_bel_6a268716",
+    "fact": "Harshith Mullapudi believes that building the same packages is bad.",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_bel_6618b11a",
+    "fact": "Harshith Mullapudi thinks the current STORE interior “ticket” concept is bad because it reads like “store outside” (the signage/feel suggests an exterior or non-store context rather than an interior store experience).",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_bel_319a9557",
+    "fact": "Harshith believes storing a node 'position' may be unnecessary for updates if a TipTap JSON document contains a page identifier and a task item identifier, since the system can search the JSON and update the matching node by ID.",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_bel_ac40a6a2",
+    "fact": "Harshith Mullapudi believes stripping with regex is incorrect.",
+    "oldAspect": "Belief",
+    "expected": "Belief",
+    "reason": "control: conviction should stay Belief"
+  },
+  {
+    "id": "ctrl_task_f7bf879e",
+    "fact": "Add a Help icon that opens a Help view containing two tabs: Privacy and Terms.",
+    "oldAspect": "Task",
+    "expected": "Task",
+    "reason": "control: one-time action should stay Task"
+  },
+  {
+    "id": "ctrl_task_e0c12327",
+    "fact": "Ship a CLI gateway plus login commands.",
+    "oldAspect": "Task",
+    "expected": "Task",
+    "reason": "control: one-time action should stay Task"
+  },
+  {
+    "id": "ctrl_task_8099f5dd",
+    "fact": "Remove labels because they are no longer needed.",
+    "oldAspect": "Task",
+    "expected": "Task",
+    "reason": "control: one-time action should stay Task"
+  },
+  {
+    "id": "ctrl_task_2e02b25c",
+    "fact": "Add a streaming tool-part UI and validate it via a calendar query.",
+    "oldAspect": "Task",
+    "expected": "Task",
+    "reason": "control: one-time action should stay Task"
+  },
+  {
+    "id": "ctrl_task_b236e6f2",
+    "fact": "Replace the separate “Concepts” tab with a “Concepts” section on the Welcome page.",
+    "oldAspect": "Task",
+    "expected": "Task",
+    "reason": "control: one-time action should stay Task"
+  },
+  {
+    "id": "ctrl_dir2_c94819",
+    "fact": "PLAN MODE EXCEPTION — ALWAYS RUN: telemetry must always be run because it writes locally to `~/.gstack/analytics/` (a user config directory, not project files), and skipping it loses session duration and outcome data.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_db9543",
+    "fact": "When an agent session gets stuck mid-task, CORE should read the error and session state, consult memory and the task description, try to apply a fix and resume, or otherwise ping the team on Slack with a tightly scoped unblock question.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_246d10",
+    "fact": "If issues are found during the plan self-check, fix them inline without re-review.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_eda2be",
+    "fact": "When evaluating founders’ startup claims, every answer must take a clear position and explicitly state what evidence would change that position (rigor without hedging or fake certainty).",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_137833",
+    "fact": "When making edits, keep existing items/content unchanged but remove emojis from any changes (preserve content while stripping emoji).",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_c2ae6c",
+    "fact": "When assigning memory labels, avoid instructions that bias toward only broad labels; assign labels across all relevant dimensions (project, domain, feature, activity) to improve retrieval usefulness.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_643ce2",
+    "fact": "The assistant must not offer the Visual Companion upfront; offer it just-in-time only when a question genuinely needs visual clarification.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_a1d62c",
+    "fact": "If an agent does not exist yet, creating the agent is step zero for every example.",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_96cf76",
+    "fact": "If RECENT_PATTERN shows a repeating skill sequence (e.g., review→ship→review), suggest the likely next skill as “Based on your recent pattern, you probably want /[next skill].”",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_dir2_2cb3f6",
+    "fact": "When implementing a new integration, model it after an existing integration in the codebase (inspect authentication, account connection flow, and request client, and mirror those patterns).",
+    "oldAspect": "Directive",
+    "expected": "Directive",
+    "reason": "control: rule-shaped fact should stay Directive"
+  },
+  {
+    "id": "ctrl_pref2_7a7b96",
+    "fact": "Harshith Mullapudi prefers the terminal background color to match the design token/class `bg-background-2` across both dark and light themes.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref2_83c3cf",
+    "fact": "Harshith prefers a closing call-to-action that explicitly solicits critical feedback (ask readers what hard things CORE will fail at) to surface blind spots and improve the product.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref2_e7258f",
+    "fact": "Harshith Mullapudi prefers implementing gateway availability detection via a polling-based health check mechanism.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref2_2a8fe4",
+    "fact": "Harshith Mullapudi prefers TipTap task/checklist items to display checkbox, task text, task ID, and status control inline (in that sequence) and for the bullet/dot to be removed.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref2_ebddeb",
+    "fact": "Harshith Mullapudi prefers to stop repeated pings/notifications.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  },
+  {
+    "id": "ctrl_pref2_6ee737",
+    "fact": "Prefers writing in a personal founder voice rather than a purely corporate brand voice.",
+    "oldAspect": "Preference",
+    "expected": "Preference",
+    "reason": "control: taste preference should stay Preference"
+  }
+]

--- a/apps/webapp/app/services/prompts/__tests__/classify-voice.eval.test.ts
+++ b/apps/webapp/app/services/prompts/__tests__/classify-voice.eval.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Live eval for the voice classifier prompt — 100+ held-out cases.
+ *
+ * NOT a mocked unit test. Calls the real Anthropic API with the current exported
+ * `classifyVoicePrompt` and asserts on the model's output. Cases live in
+ * `classify-voice.cases.json` and are pulled from real production CSV rows that
+ * do NOT lexically overlap with the prompt (so passes aren't just copy-from-example).
+ *
+ * Runs only when `ANTHROPIC_API_KEY` is set. Skipped otherwise.
+ *
+ * Usage:
+ *   cd apps/webapp
+ *   ANTHROPIC_API_KEY=sk-ant-... pnpm vitest run \
+ *     app/services/prompts/__tests__/classify-voice.eval.test.ts
+ *
+ * Optional env:
+ *   EVAL_MODEL — override the model (default claude-sonnet-4-6)
+ *   EVAL_BATCH_SIZE — max facts per API call (default 30)
+ *
+ * Regenerating cases:
+ *   The JSON file is produced offline by mining the production CSV. To refresh
+ *   after prompt edits, re-run the case-generation script (see git log for the
+ *   Python snippet that produced classify-voice.cases.json).
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+import { beforeAll, describe, test, expect } from "vitest";
+import { classifyVoicePrompt, ClassifyVoiceSchema } from "../classify-voice";
+import CASES_RAW from "./classify-voice.cases.json";
+
+type ExpectedLabel =
+  | "Directive"
+  | "Preference"
+  | "Belief"
+  | "Habit"
+  | "Goal"
+  | "Task"
+  | "null";
+
+interface Case {
+  id: string;
+  fact: string;
+  oldAspect: string;
+  expected: ExpectedLabel;
+  reason: string;
+}
+
+const CASES: Case[] = CASES_RAW as Case[];
+
+const HAS_KEY = Boolean(process.env.ANTHROPIC_API_KEY);
+
+describe.skipIf(!HAS_KEY)("classify-voice held-out eval (live API)", () => {
+  const RESULTS = new Map<string, string | null | undefined>();
+
+  beforeAll(async () => {
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+    const model = process.env.EVAL_MODEL ?? "claude-sonnet-4-6";
+    const BATCH = Number(process.env.EVAL_BATCH_SIZE ?? "30");
+
+    const inputSchema = z.toJSONSchema(ClassifyVoiceSchema);
+    const allFacts = CASES.map((c) => ({ fact: c.fact }));
+
+    console.log(
+      `[eval] model=${model} cases=${CASES.length} batchSize=${BATCH}`,
+    );
+    const t0 = Date.now();
+
+    // Batch to stay under context / max_tokens comfortably
+    for (let i = 0; i < allFacts.length; i += BATCH) {
+      const chunk = allFacts.slice(i, i + BATCH);
+      const messages = classifyVoicePrompt(chunk);
+      const system = messages.find((m) => m.role === "system")!.content as string;
+      const userMsg = messages.find((m) => m.role === "user")!.content as string;
+
+      const res = await client.messages.create({
+        model,
+        max_tokens: 8192,
+        system,
+        messages: [{ role: "user", content: userMsg }],
+        tools: [
+          {
+            name: "classify_voice",
+            description: "Classify each voice fact into an aspect (or null).",
+            input_schema: inputSchema as any,
+          },
+        ],
+        tool_choice: { type: "tool", name: "classify_voice" },
+      });
+
+      const toolUse = res.content.find((b: any) => b.type === "tool_use") as any;
+      if (!toolUse) {
+        throw new Error(
+          `Batch ${i}: no tool_use block: ${JSON.stringify(res.content)}`,
+        );
+      }
+      const parsed = ClassifyVoiceSchema.parse(toolUse.input);
+      for (const o of parsed.aspects) {
+        RESULTS.set(o.fact, o.aspect);
+      }
+    }
+
+    const dur = Date.now() - t0;
+
+    // Print summary
+    let pass = 0;
+    const confusion: Record<string, Record<string, number>> = {};
+    const byBucket: Record<string, { pass: number; fail: number }> = {};
+
+    for (const c of CASES) {
+      const got = RESULTS.get(c.fact);
+      const gotStr =
+        got === undefined ? "<MISSING>" : got === null ? "null" : got;
+      const ok = gotStr === c.expected;
+      if (ok) pass++;
+
+      const bucket = `${c.oldAspect}→${c.expected}`;
+      (byBucket[bucket] ??= { pass: 0, fail: 0 })[ok ? "pass" : "fail"]++;
+
+      (confusion[c.expected] ??= {})[gotStr] =
+        (confusion[c.expected]?.[gotStr] ?? 0) + 1;
+    }
+
+    console.log(
+      `\n[eval] pass=${pass}/${CASES.length} (${((100 * pass) / CASES.length).toFixed(1)}%) dur=${dur}ms\n`,
+    );
+
+    // Per-bucket accuracy
+    console.log("Per-bucket accuracy:");
+    for (const [bucket, s] of Object.entries(byBucket).sort()) {
+      const total = s.pass + s.fail;
+      const pct = ((100 * s.pass) / total).toFixed(0);
+      console.log(
+        `  ${bucket.padEnd(30)} ${s.pass}/${total}  (${pct}%)`,
+      );
+    }
+
+    // Confusion matrix
+    console.log("\nConfusion (rows=expected, cols=got):");
+    for (const [exp, gots] of Object.entries(confusion).sort()) {
+      const parts = Object.entries(gots)
+        .sort((a, b) => b[1] - a[1])
+        .map(([g, n]) => `${g}:${n}`)
+        .join(", ");
+      console.log(`  ${exp.padEnd(12)} → ${parts}`);
+    }
+
+    // Failing cases (grouped)
+    const failing = CASES.filter((c) => {
+      const got = RESULTS.get(c.fact);
+      const gotStr =
+        got === undefined ? "<MISSING>" : got === null ? "null" : got;
+      return gotStr !== c.expected;
+    });
+    if (failing.length > 0) {
+      console.log(`\nFailing cases (${failing.length}):`);
+      for (const c of failing) {
+        const got = RESULTS.get(c.fact);
+        const gotStr =
+          got === undefined ? "<MISSING>" : got === null ? "null" : got;
+        console.log(
+          `  [${c.id}] ${c.oldAspect}→${c.expected}, got=${gotStr}`,
+        );
+        console.log(`     reason: ${c.reason}`);
+        console.log(`     fact: ${c.fact.slice(0, 130)}${c.fact.length > 130 ? "…" : ""}`);
+      }
+    }
+  }, /* timeout */ 300_000);
+
+  for (const c of CASES) {
+    test(`${c.id}: ${c.oldAspect}→${c.expected} — ${c.reason}`, () => {
+      const got = RESULTS.get(c.fact);
+      const gotStr =
+        got === undefined ? "<MISSING>" : got === null ? "null" : got;
+      expect(gotStr, `fact: ${c.fact.slice(0, 120)}…`).toBe(c.expected);
+    });
+  }
+});

--- a/apps/webapp/app/services/prompts/classify-voice.ts
+++ b/apps/webapp/app/services/prompts/classify-voice.ts
@@ -73,24 +73,30 @@ Anti-examples (one-time spec edits that sound like Preferences but are Tasks):
 NOT: system architecture, data storage, or caching strategy → Directive. NOT: product positioning or strategic stance → Belief or Directive. NOT: one-time design/copy/spec edits → Task. NOT: standing instructions for work output format → Directive. NOT: value judgments about how the world works → Belief.
 
 **Habit** — What the USER (as a person) actually DOES REPEATEDLY in real life. Recurring personal behaviors, routines, rituals, communication patterns — not engineering methodologies, SDK conventions, or tool workflows.
+
+TEST 1 (RUN THIS FIRST, BEFORE READING KEEP-EXAMPLES): Would this recurring pattern still exist if the user switched jobs tomorrow, stopped using this SDK, or the tool was deleted? If the pattern is scoped to "when using X SDK," "for Y configuration," "when scripting Z tool," or "my methodology for debugging/validating/launching," it is a Preference or Directive — STOP, do not classify as Habit.
+
+TEST 2: Does this describe a recurring rhythm in the user's LIFE (morning routine, weekly ritual, meal habit, exercise pattern, finance behavior, communication cadence with people) — OR a repeated pattern in how the user WORKS with a specific tool, SDK, codebase, or output format? If it's the latter → Preference (personal taste for how output/code should look) or Directive (standing rule for a system/workflow). Only the former is a Habit.
+
 - "Takes fish oil supplements daily at breakfast" → Habit
 - "Reviews PRs every morning before standup" → Habit
 - "I primarily use credit cards for spending, about 80% of transactions" → Habit
 - "Maintains a daily scratchpad for tasks and notes" → Habit
 - "Asks clarifying questions before starting work; challenges proposed approaches" → Habit
 
-TEST: would this recurring pattern exist if the user switched jobs or stopped using a specific SDK/tool? If the pattern is bound to "when using X SDK" or "when configuring Y tool" or "my debugging strategy for Z", it is a Preference or Directive, not a Habit. Habits are about the PERSON; methodologies are about HOW THEY WORK.
+Anti-examples (these SOUND like habits — they use "when," "uses a," "workflow," "maintains," or present-tense verbs — but fail TEST 1 or TEST 2):
+- "When using the @anthropic-ai/sdk TypeScript client, I handle errors via typed exception classes" → Preference (SDK-bound coding convention; dies if the SDK changes)
+- "For Extended Thinking configuration, I use adaptive thinking for Opus 4.7/4.6 and Sonnet 4.6" → Directive (SDK configuration methodology, not a life rhythm)
+- "When using use_figma, I work incrementally in small steps and stop on any error" → Directive (tool-scoped workflow — fails TEST 1)
+- "Uses a four-phase Systematic Debugging methodology: Phase 1 Root Cause, Phase 2 Pattern..." → Directive (engineering methodology the user documented, not a behavior observed in daily life)
+- "Validation workflow: call get_metadata to verify structure, call get_screenshot to verify visual correctness..." → Directive (tool-call procedure, not a personal ritual)
+- "I use bulleted lists in ~33-44% of technical/workflow outputs" → Preference (output-format preference)
+- "I use a minimal Tauri Rust entrypoint: tauri::Builder::default().run(...)" → Preference (code convention)
+- "Before launch, I run a repo health pre-flight checklist: CI green, no stale PRs..." → Directive (SOP for a specific project event)
+- "He already has agent handoffs automated via scripts, but context still leaks" → null (problem report / current-state observation)
+- "I position CORE as a coordination/orchestration layer" → Belief (positioning stance, not repeated behavior)
 
-Anti-examples (these SOUND like habits because they describe a repeated pattern, but are SDK/tool methodologies, conceptual stances, or problem reports):
-- "When using the @anthropic-ai/sdk TypeScript client, I handle errors via typed exception classes" → Preference or Directive (coding methodology, not a personal habit)
-- "For Extended Thinking configuration, I use adaptive thinking for Opus 4.7/4.6" → Directive (SDK configuration pattern)
-- "I verify prompt-cache effectiveness by inspecting Claude API response usage fields" → Directive (how to verify a system behavior)
-- "When using use_figma, I work incrementally in small steps and stop on any error" → Preference or Directive (tool workflow pattern)
-- "He already has agent handoffs automated via scripts, but context still leaks between agents" → null (problem report / system observation, not a habit)
-- "He is thinking in terms of memory primitives and session compaction" → Belief or null (conceptual stance, not a demonstrated recurring behavior)
-- "I position CORE as a coordination/orchestration layer" → Belief (positioning / strategic principle)
-
-NOT: SDK or coding methodologies → Preference/Directive. NOT: tool workflows or configuration patterns → Preference/Directive. NOT: conceptual stances or worldviews → Belief. NOT: problem reports or system observations → null. NOT: something the user WANTS to start but isn't doing yet → Goal.
+NOT: SDK/coding/config methodologies (any "when using X", "for Y configuration") → Preference/Directive. NOT: tool workflows or validation checklists → Directive. NOT: engineering methodologies the user authored (phase diagrams, DOT graphs, red-flag lists) → Directive. NOT: output-format or code-style patterns → Preference. NOT: conceptual stances or worldviews → Belief. NOT: problem reports, current-state observations, or "still has to" complaints → null or Task. NOT: something the user WANTS to start but isn't doing yet → Goal. NOT: a single past action described in past tense → Task.
 
 **Belief** — A lasting CONVICTION or value judgment about how the world works. The user's principles — not a documented fact that anyone reading the same docs would agree with.
 - "Open-source builds more trust than closed products" → Belief
@@ -111,21 +117,31 @@ Anti-examples (these SOUND like principles because they use declarative language
 
 NOT: documented technical facts about external APIs/SDKs/models → null. NOT: procedural workarounds or constraints → null. NOT: standing operating rules ("if intermittent, don't fix") → Directive. NOT: momentary reactions, opinions about a specific draft, or task feedback.
 
-**Goal** — Something the USER personally is working toward over time. A sustained pursuit (days/weeks/months) of an objective the user is driving — not a feature specification for a system.
+**Goal** — Something the USER (a named person, "I", or "he/she") personally is working toward over time. The SUBJECT of the sentence must be a person, not a product/feature/component. A sustained personal pursuit (days/weeks/months) — launch pushes, positioning, community-building, founder objectives, personal growth — not a specification for what a system should do.
 - "I want to run a marathon by December" → Goal
 - "Launch the personal-OS MVP this quarter" → Goal
 - "I want to personally onboard Guillaume" → Goal
 - "Ship the home-screen redesign before Q4" → Goal
 
-TEST: ask "who is pursuing this?" If the subject of the wish is THE SYSTEM/PRODUCT/SKILL ("the app should support X", "the gateway should include Y", "the skill is to do Z"), it is a Directive — a standing instruction for what the system must do — not a Goal. Goal is what the USER is personally pursuing.
+TEST 1 (subject swap): rewrite the sentence starting with "the [feature/page/building/widget/UI/CLI/API/skill/agent] should …". If it still reads naturally, the true subject is the product → Directive. Goal requires a human subject who is personally pursuing something.
 
-Anti-examples (these SOUND like Goals because they use "wants"/"should"/"goal for", but the subject is the system, not the user's personal pursuit):
+TEST 2 (spec swap): would this still be true if we replaced "the app" / "CORE" / "the game" with "this specific feature I'm building right now"? If yes → Directive (it's a feature spec, not a life-scale pursuit).
+
+TEST 3 (word "goal" is not enough): the literal string "goal for X" or "my goal is" does NOT make something a Goal if X is a tool, skill, widget, or deliverable. Ask what the pursuit is over time.
+
+Anti-examples (these SOUND like Goals because they use "wants"/"goal for"/"product goal", but the subject is a system/feature/component):
 - "Wants the app to support OpenAI in addition to Anthropic" → Directive (feature requirement)
-- "OpenCode should have the same functionality as claude-code and codex (full feature parity)" → Directive (system mandate)
+- "OpenCode should have the same functionality as claude-code and codex" → Directive (system mandate)
 - "Wants CORE's open-source deployment to include the gateway component" → Directive (product requirement)
-- "Goal for the claude-code-plugin skill is to ask OpenAI Codex questions about a repository codebase" → Directive (tool behavior spec)
+- "Goal for the claude-code-plugin skill is to ask OpenAI Codex questions about a repository codebase…" → Directive (tool behavior spec)
+- "Wants the game's 'home' interior scene to include … a wall-mounted scratchpad, a computer/terminal …, and a sofa …" → Directive (feature spec)
+- "Wants the Office building to provide a work-focused interface for tasks …" → Directive (surface spec)
+- "Goal: build a Linear integration widget … that shows issues assigned to Harshith in the current cycle" → Directive (widget spec, subject is the widget)
+- "Wants the Home page to present modules … as interactive items that show a different-colored button on hover …" → Directive (UI behavior spec)
+- "Harshith wants a permission-mode feature with two modes ('Default' vs 'Full access') implemented as a separate reusable component …" → Directive (component spec)
+- "Wants CLI features for easy local self-hosting of CORE via Docker: two commands — install-local and config-local …" → Directive (CLI spec)
 
-NOT: feature requirements or product specifications, even if phrased as "I want the app to X" → Directive. NOT: one-time follow-ups or action items → Task. NOT: pending evaluation work ("considering migrating to X") → Task.
+NOT: feature requirements or product specifications, even if phrased as "I want the app to X" or "Goal for X is …" → Directive. NOT: one-time follow-ups, evaluations, or "considering/intends to use X" → Task. NOT: positioning judgments without a pursuit dimension → Belief. Rule of thumb: if the subject of the sentence is a product, feature, page, building, widget, UI element, API, CLI, skill, or workflow, it is NOT a Goal.
 
 **Task** — A specific, FUTURE, uncompleted commitment the user intends to do. A one-time action item with a clear completion state — not a record of work already done, a decision already finalized, or a standing want.
 - "Need to send the proposal to the client by Friday" → Task

--- a/apps/webapp/app/services/search-v2/handlers.ts
+++ b/apps/webapp/app/services/search-v2/handlers.ts
@@ -1381,8 +1381,11 @@ export async function handleTemporalFacets(
 }
 
 /**
- * Search voice aspects from the Aspects Store when query involves voice aspect types
- * Voice aspects: Directive, Preference, Habit, Belief, Goal
+ * Search voice aspects (Directive, Preference, Habit, Belief, Goal, Task) from
+ * the Aspects Store using the query embedding. Runs on ANY episode-returning
+ * query — voice aspects are complementary to episodes and useful even when the
+ * router didn't tag a voice-aspect type. If the router DID name voice aspects,
+ * filter to those; otherwise return the top matches across all voice aspects.
  */
 async function searchVoiceAspectsForQuery(
   ctx: HandlerContext,
@@ -1390,18 +1393,9 @@ async function searchVoiceAspectsForQuery(
   const query = ctx.options.query;
   if (!query) return [];
 
-  // Check if any requested aspects overlap with voice aspects
-  const voiceAspectSet = new Set(VOICE_ASPECTS as readonly string[]);
-  const requestedVoiceAspects = ctx.routerOutput.aspects.filter((a) =>
-    voiceAspectSet.has(a),
-  );
-
-  if (requestedVoiceAspects.length === 0) return [];
-
   const queryEmbedding = await getEmbedding(query);
   if (!queryEmbedding || queryEmbedding.length === 0) return [];
 
-  // Search for each requested voice aspect type
   const results = await searchVoiceAspects({
     queryVector: queryEmbedding,
     userId: ctx.userId,
@@ -1410,13 +1404,23 @@ async function searchVoiceAspectsForQuery(
     threshold: 0.5,
   });
 
-  // Filter to only requested voice aspects
-  const filtered = results.filter((r) =>
-    requestedVoiceAspects.includes(r.aspect as StatementAspect),
+  // If the router picked voice aspects, honour that filter. Otherwise keep all.
+  const voiceAspectSet = new Set(VOICE_ASPECTS as readonly string[]);
+  const requestedVoiceAspects = ctx.routerOutput.aspects.filter((a) =>
+    voiceAspectSet.has(a),
   );
+  const filtered =
+    requestedVoiceAspects.length > 0
+      ? results.filter((r) =>
+          requestedVoiceAspects.includes(r.aspect as StatementAspect),
+        )
+      : results;
 
   logger.info(
-    `[VoiceAspects] Found ${filtered.length} voice aspects for aspects: [${requestedVoiceAspects.join(", ")}]`,
+    `[VoiceAspects] Found ${filtered.length}/${results.length} voice aspects` +
+      (requestedVoiceAspects.length > 0
+        ? ` (filtered to [${requestedVoiceAspects.join(", ")}])`
+        : ""),
   );
 
   return filtered.map((r) => ({
@@ -1456,16 +1460,16 @@ export async function routeToHandler(
         );
       }
 
-      // Broad mode - return episodes with entity
-      const augmentedEpisodes = await augmentEpisodesWithBroadRecallBackstop(
-        result.episodes,
-        ctx,
-      );
+      // Broad mode - return episodes with entity + voice aspects in parallel
+      const [augmentedEpisodes, voiceAspects] = await Promise.all([
+        augmentEpisodesWithBroadRecallBackstop(result.episodes, ctx),
+        searchVoiceAspectsForQuery(ctx),
+      ]);
       const rerankedEpisodes = await applyEpisodeReranking(
         augmentedEpisodes,
         ctx,
       );
-      return await normalizeToRecallResult(
+      const broadResult = await normalizeToRecallResult(
         {
           episodes: rerankedEpisodes,
           entities: result.entities,
@@ -1473,6 +1477,10 @@ export async function routeToHandler(
         },
         ctx,
       );
+      if (voiceAspects.length > 0) {
+        broadResult.voiceAspects = voiceAspects;
+      }
+      return broadResult;
     }
 
     case "aspect_query": {
@@ -1498,7 +1506,10 @@ export async function routeToHandler(
     }
 
     case "temporal": {
-      const episodes = await handleTemporal(ctx);
+      const [episodes, voiceAspects] = await Promise.all([
+        handleTemporal(ctx),
+        searchVoiceAspectsForQuery(ctx),
+      ]);
       // Only rerank when there's a topic focus — pure date-range queries have no semantic
       // content to score against, so sort by recency instead to avoid filtering valid results
       const hasTopic =
@@ -1517,7 +1528,14 @@ export async function routeToHandler(
                 new Date(a.createdAt).getTime(),
             )
             .slice(0, ctx.options.maxEpisodes || 10);
-      return await normalizeToRecallResult({ episodes: rerankedEpisodes }, ctx);
+      const temporalResult = await normalizeToRecallResult(
+        { episodes: rerankedEpisodes },
+        ctx,
+      );
+      if (voiceAspects.length > 0) {
+        temporalResult.voiceAspects = voiceAspects;
+      }
+      return temporalResult;
     }
 
     case "temporal_facets": {
@@ -1532,9 +1550,14 @@ export async function routeToHandler(
     }
 
     case "exploratory": {
-      const episodes = await handleExploratory(ctx);
-      const augmentedEpisodes =
-        await augmentEpisodesWithBroadRecallBackstop(episodes, ctx);
+      const [episodes, voiceAspects] = await Promise.all([
+        handleExploratory(ctx),
+        searchVoiceAspectsForQuery(ctx),
+      ]);
+      const augmentedEpisodes = await augmentEpisodesWithBroadRecallBackstop(
+        episodes,
+        ctx,
+      );
       const rerankedEpisodes = await applyEpisodeReranking(
         augmentedEpisodes,
         ctx,
@@ -1542,7 +1565,14 @@ export async function routeToHandler(
           threshold: 0.2,
         },
       );
-      return await normalizeToRecallResult({ episodes: rerankedEpisodes }, ctx);
+      const exploratoryResult = await normalizeToRecallResult(
+        { episodes: rerankedEpisodes },
+        ctx,
+      );
+      if (voiceAspects.length > 0) {
+        exploratoryResult.voiceAspects = voiceAspects;
+      }
+      return exploratoryResult;
     }
 
     case "relationship": {


### PR DESCRIPTION
## Summary

Three coupled improvements to CORE's memory pipeline, driven by an audit of a 2,995-row voice-aspect CSV export.

### 1. Tighter voice classifier prompt

Audit findings:

| Aspect | Rows | Correctly labeled |
|---|---:|---:|
| Goal | 161 | ~19% (109 / 161 were product feature-specs mislabeled as Goal) |
| Habit | 72 | ~21% (28 / 72 were engineering methodologies mislabeled as Habit) |

Rewrote the `Goal` and `Habit` sections in `classify-voice.ts` with:
- **Goal** — three sequential tests (subject-swap, spec-swap, "the word goal is not enough"), plus 6 new anti-examples pulled verbatim from mislabeled CSV rows. Rule of thumb: if the sentence's subject is a product/feature/page/building/widget/UI/CLI/skill/workflow, it is NOT a Goal.
- **Habit** — TEST 1 promoted to run *before* the keep-examples ("would this pattern still exist if the user switched jobs or the tool was deleted?"). Adds TEST 2 (life rhythm vs. work-with-tool). Adds 5 new anti-examples for SDK methodologies, authored engineering methodologies, and code conventions.

### 2. 109-case held-out eval

`apps/webapp/app/services/prompts/__tests__/classify-voice.eval.test.ts` + `classify-voice.cases.json`:
- Real API calls with `classifyVoicePrompt` — not mocked.
- Cases pulled from production CSV; every fact verified NOT to appear as a ≥30-char substring in the prompt (no copy-from-example passes possible).
- Distribution: 15 Goal → Directive (fix target), 4 Goal → Goal, 6 Goal → Task, 4 Habit → Directive (fix target), 1 Habit → Preference, 5 Habit → Habit, and 74 regression controls (35 Directive, 26 Preference, 8 Belief, 5 Task).
- Prints per-bucket accuracy, confusion matrix, and per-failure detail so prompt iteration is driven by the actual failures.
- Skips when `ANTHROPIC_API_KEY` is unset — safe for CI.

Run: `ANTHROPIC_API_KEY=… pnpm vitest run app/services/prompts/__tests__/classify-voice.eval.test.ts`

### 3. Persona: Identity only

`aspect-persona-generation.ts`:
- `sectionOrder` collapsed to `["Identity"]`.
- Added `"Preference"` and `"Directive"` to `SKIPPED_ASPECTS` so those sections don't get generated.

The persona is now a small durable header. Preferences, directives, goals, habits, beliefs are retrievable via memory search at runtime — where they belong.

### 4. Voice-aspect search on every episode-returning query

`search-v2/handlers.ts`:
- `searchVoiceAspectsForQuery` no longer early-returns when the router didn't pick a voice-aspect type. If aspects were picked, filter to those; otherwise return top-10 across all voice aspects.
- Wired into `entity_lookup` (broad), `temporal`, and `exploratory` via `Promise.all` alongside the existing episode fetch. `aspect_query` already had it.
- Same latency shape — extra call runs in parallel with the graph fetch.

Before this, only `aspect_query` returned voice aspects, and only when the router named a voice-aspect type. Queries like "who is Sarah?", "what happened last week with CORE?", "search implementation in CORE" got no voice aspects at all.

## Test plan

- [ ] `pnpm tsc --noEmit -p tsconfig.json` — clean (verified locally, only unrelated node_modules noise).
- [ ] `ANTHROPIC_API_KEY=… pnpm vitest run app/services/prompts/__tests__/classify-voice.eval.test.ts` — expect ≥95/109 pass with zero regressions in the 74 control cases.
- [ ] Trigger a persona regeneration on a workspace with many Preferences/Directives; verify the resulting persona only contains the Identity section and is materially smaller.
- [ ] Run a spread of search queries via search-v2 (entity_lookup, temporal, exploratory) and verify `voiceAspects` is populated in the RecallResult.

## Notes

- Prompt fixes only affect future classifications. The existing ~109 mislabeled Goals and ~28 mislabeled Habits stay wrong in the DB until you run a backfill.
- Depends on the earlier `fix/chat-subagent-render-freeze` commit (32fb9a1c) since this branch was cut from that HEAD, not main. If that PR isn't merged first, the diff will include both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)