### PR TITLE
scheduled task reply threading

### DIFF
--- a/apps/webapp/app/services/agent/__tests__/channel-conversation.test.ts
+++ b/apps/webapp/app/services/agent/__tests__/channel-conversation.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/logger.service", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+vi.mock("~/db.server", () => ({
+  prisma: {
+    conversationHistory: { findFirst: vi.fn() },
+    conversation: { findFirst: vi.fn() },
+  },
+}));
+vi.mock("../conversation.server", () => ({
+  createConversation: vi.fn(),
+}));
+vi.mock("~/models/user.server", () => ({
+  getUserTimezone: vi.fn().mockResolvedValue("UTC"),
+}));
+vi.mock("~/services/channels/whatsapp/utils", () => ({
+  formatDailyWhatsAppTitle: vi.fn().mockReturnValue("title"),
+}));
+
+import { prisma } from "~/db.server";
+import { getOrCreateChannelConversation } from "../message-processor";
+
+describe("getOrCreateChannelConversation — Slack thread routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes a thread reply to the task conversation via slackTs", async () => {
+    (prisma.conversationHistory.findFirst as any).mockResolvedValue({
+      conversationId: "taskConv1",
+    });
+
+    const id = await getOrCreateChannelConversation(
+      "user1",
+      "ws1",
+      "different recipe please",
+      "slack",
+      { threadTs: "1700000000.000100" },
+    );
+
+    expect(id).toBe("taskConv1");
+    expect(prisma.conversationHistory.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          context: { path: ["slackTs"], equals: "1700000000.000100" },
+          conversation: { userId: "user1", deleted: null },
+        }),
+      }),
+    );
+    // Did NOT fall through to daily-bucket lookup
+    expect(prisma.conversation.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("falls through to existing behavior when no slackTs match", async () => {
+    (prisma.conversationHistory.findFirst as any).mockResolvedValue(null);
+    (prisma.conversation.findFirst as any).mockResolvedValue({ id: "dailyConv1" });
+
+    const id = await getOrCreateChannelConversation(
+      "user1",
+      "ws1",
+      "hello",
+      "slack",
+      { threadTs: "1700000000.999999" },
+    );
+
+    expect(id).toBe("dailyConv1");
+  });
+});

--- a/apps/webapp/app/services/agent/message-processor.ts
+++ b/apps/webapp/app/services/agent/message-processor.ts
@@ -67,6 +67,21 @@ export async function getOrCreateChannelConversation(
   channelMetadata?: Record<string, string>,
   userType?: UserTypeEnum,
 ): Promise<string> {
+  // Slack thread-reply → route back to the task conversation that posted
+  // the message (matched by the stored slackTs on its ConversationHistory row).
+  const threadTs = channelMetadata?.threadTs;
+  if (threadTs) {
+    const match = await prisma.conversationHistory.findFirst({
+      where: {
+        context: { path: ["slackTs"], equals: threadTs },
+        conversation: { userId, deleted: null },
+      },
+      orderBy: { createdAt: "desc" },
+      select: { conversationId: true },
+    });
+    if (match) return match.conversationId;
+  }
+
   const sessionId = channelMetadata?.sessionId;
 
   if (sessionId) {

--- a/apps/webapp/app/services/agent/tools/__tests__/message-tools.test.ts
+++ b/apps/webapp/app/services/agent/tools/__tests__/message-tools.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/logger.service", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+vi.mock("~/db.server", () => ({
+  prisma: {
+    channel: { findFirst: vi.fn() },
+    conversation: { findFirst: vi.fn() },
+    conversationHistory: { create: vi.fn() },
+    voiceInboxMessage: { create: vi.fn() },
+  },
+}));
+vi.mock("~/services/channel.server", () => ({
+  getWorkspaceChannelContext: vi.fn(),
+}));
+vi.mock("~/services/agent/message-processor", () => ({
+  getOrCreateChannelConversation: vi.fn(),
+}));
+vi.mock("~/services/conversation.server", () => ({
+  upsertConversationHistory: vi.fn(),
+}));
+
+const sendReplyMock = vi.fn();
+vi.mock("~/services/channels", () => ({
+  getChannel: vi.fn(() => ({ sendReply: sendReplyMock })),
+}));
+
+import { prisma } from "~/db.server";
+import { getMessageTools } from "../message-tools";
+
+describe("send_message task threading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mirrors into the task conversation with slackTs when Slack returns a ts", async () => {
+    (prisma.channel.findFirst as any).mockResolvedValue({
+      id: "ch1",
+      type: "slack",
+      config: { user_id: "U123" },
+    });
+    (prisma.conversation.findFirst as any).mockResolvedValue({ id: "taskConv1" });
+    (prisma.conversationHistory.create as any).mockResolvedValue({ id: "hist1" });
+    (prisma.voiceInboxMessage.create as any).mockResolvedValue({ id: "inbox1" });
+    sendReplyMock.mockResolvedValue({ ts: "1700000000.000100" });
+
+    const tools = getMessageTools({
+      workspaceId: "ws1",
+      userId: "user1",
+      userEmail: "u@example.com",
+      triggerChannelId: "ch1",
+      currentTaskId: "task1",
+    });
+
+    await (tools.send_message as any).execute({ message: "your keto recipe" });
+
+    // Looked up the task conversation by asyncJobId=taskId
+    expect(prisma.conversation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          asyncJobId: "task1",
+          userId: "user1",
+          deleted: null,
+        }),
+      }),
+    );
+
+    // Wrote a history row into the task conversation carrying slackTs
+    expect(prisma.conversationHistory.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          conversationId: "taskConv1",
+          context: { slackTs: "1700000000.000100" },
+        }),
+      }),
+    );
+  });
+
+  it("falls back to daily-bucket mirror when there is no currentTaskId", async () => {
+    (prisma.channel.findFirst as any).mockResolvedValue({
+      id: "ch1",
+      type: "slack",
+      config: { user_id: "U123" },
+    });
+    (prisma.voiceInboxMessage.create as any).mockResolvedValue({ id: "inbox1" });
+    sendReplyMock.mockResolvedValue({ ts: "1700000000.000200" });
+
+    const { getOrCreateChannelConversation } = await import(
+      "~/services/agent/message-processor"
+    );
+    (getOrCreateChannelConversation as any).mockResolvedValue("dailyConv1");
+
+    const tools = getMessageTools({
+      workspaceId: "ws1",
+      userId: "user1",
+      userEmail: "u@example.com",
+      triggerChannelId: "ch1",
+      // no currentTaskId
+    });
+
+    await (tools.send_message as any).execute({ message: "hi" });
+
+    expect(getOrCreateChannelConversation).toHaveBeenCalled();
+    expect(prisma.conversationHistory.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/services/agent/tools/message-tools.ts
+++ b/apps/webapp/app/services/agent/tools/message-tools.ts
@@ -161,30 +161,66 @@ export function getMessageTools(
             preview: message.slice(0, 100),
           });
 
-          await handler.sendReply(replyTo, message, metadata);
+          const sendResult = await handler.sendReply(replyTo, message, metadata);
+
+          const slackTs =
+            channelType === "slack" &&
+            sendResult &&
+            typeof sendResult === "object"
+              ? (sendResult as { ts?: string }).ts
+              : undefined;
 
           // ---------------------------------------------------------------
-          // Mirror to channel conversation for reply context
+          // Mirror to conversation for reply context.
+          // If this send belongs to a task, mirror into the TASK's
+          // conversation (asyncJobId=taskId) and stamp slackTs so a Slack
+          // thread-reply routes back here. Otherwise, daily-bucket mirror.
           // ---------------------------------------------------------------
           try {
-            const channelConversationId =
-              await getOrCreateChannelConversation(
-                userId,
-                workspaceId,
-                message,
-                channelType,
-                undefined,
+            let taskConversationId: string | undefined;
+            if (currentTaskId) {
+              const taskConv = await prisma.conversation.findFirst({
+                where: {
+                  asyncJobId: currentTaskId,
+                  userId,
+                  deleted: null,
+                },
+                orderBy: { createdAt: "desc" },
+                select: { id: true },
+              });
+              taskConversationId = taskConv?.id;
+            }
+
+            if (taskConversationId) {
+              await prisma.conversationHistory.create({
+                data: {
+                  conversationId: taskConversationId,
+                  parts: [{ text: message, type: "text" }],
+                  message: "",
+                  userType: UserTypeEnum.Agent,
+                  ...(slackTs ? { context: { slackTs } } : {}),
+                },
+              });
+            } else {
+              const channelConversationId =
+                await getOrCreateChannelConversation(
+                  userId,
+                  workspaceId,
+                  message,
+                  channelType,
+                  undefined,
+                  UserTypeEnum.Agent,
+                );
+              await upsertConversationHistory(
+                crypto.randomUUID(),
+                [{ text: message, type: "text" }],
+                channelConversationId,
                 UserTypeEnum.Agent,
+                false,
               );
-            await upsertConversationHistory(
-              crypto.randomUUID(),
-              [{ text: message, type: "text" }],
-              channelConversationId,
-              UserTypeEnum.Agent,
-              false,
-            );
+            }
           } catch (mirrorError) {
-            logger.warn("[send_message] Failed to mirror to channel conversation", {
+            logger.warn("[send_message] Failed to mirror to conversation", {
               error: mirrorError,
             });
           }

--- a/apps/webapp/app/services/channels/slack/__tests__/outbound.test.ts
+++ b/apps/webapp/app/services/channels/slack/__tests__/outbound.test.ts
@@ -39,4 +39,54 @@ describe("slack outbound sendReply", () => {
 
     expect(result).toEqual({ ts: "1700000000.000100" });
   });
+
+  it("threads the DM reply under threadTs when the inbound was a thread reply", async () => {
+    (prisma.channel.findFirst as any).mockResolvedValue({
+      id: "ch1",
+      config: { bot_token: "xoxb-test" },
+    });
+
+    // conversations.open then chat.postMessage
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ ok: true, channel: { id: "D123" } }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ ok: true, ts: "1700000000.000200" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendReply("U123", "different recipe", {
+      workspaceId: "ws1",
+      threadTs: "1700000000.000100",
+    });
+
+    // The chat.postMessage call (second fetch) must carry thread_ts
+    const postCall = fetchMock.mock.calls[1];
+    const postBody = JSON.parse(postCall[1].body);
+    expect(postBody.thread_ts).toBe("1700000000.000100");
+  });
+
+  it("does NOT thread a plain DM reply when no threadTs is present", async () => {
+    (prisma.channel.findFirst as any).mockResolvedValue({
+      id: "ch1",
+      config: { bot_token: "xoxb-test" },
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ ok: true, channel: { id: "D123" } }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ ok: true, ts: "1700000000.000300" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendReply("U123", "hello", { workspaceId: "ws1" });
+
+    const postBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(postBody.thread_ts).toBeUndefined();
+  });
 });

--- a/apps/webapp/app/services/channels/slack/__tests__/outbound.test.ts
+++ b/apps/webapp/app/services/channels/slack/__tests__/outbound.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/logger.service", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+vi.mock("~/db.server", () => ({
+  prisma: {
+    channel: { findFirst: vi.fn() },
+  },
+}));
+
+import { prisma } from "~/db.server";
+import { sendReply } from "../outbound";
+
+describe("slack outbound sendReply", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("returns the posted message ts for a DM", async () => {
+    (prisma.channel.findFirst as any).mockResolvedValue({
+      id: "ch1",
+      config: { bot_token: "xoxb-test" },
+    });
+
+    // conversations.open then chat.postMessage
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: async () => ({ ok: true, channel: { id: "D123" } }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ ok: true, ts: "1700000000.000100" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await sendReply("U123", "hello", { workspaceId: "ws1" });
+
+    expect(result).toEqual({ ts: "1700000000.000100" });
+  });
+});

--- a/apps/webapp/app/services/channels/slack/client.ts
+++ b/apps/webapp/app/services/channels/slack/client.ts
@@ -39,7 +39,7 @@ export async function sendSlackMessage(
   text: string,
   threadTs?: string,
   blocks?: unknown[],
-): Promise<void> {
+): Promise<{ ts?: string }> {
   const payload: Record<string, unknown> = { channel, text };
   if (threadTs) {
     payload.thread_ts = threadTs;
@@ -65,6 +65,8 @@ export async function sendSlackMessage(
     });
     throw new Error(`Slack chat.postMessage failed: ${msgData.error}`);
   }
+
+  return { ts: msgData.ts as string | undefined };
 }
 
 /**
@@ -132,7 +134,7 @@ export async function sendSlackDM(
   slackUserId: string,
   text: string,
   blocks?: unknown[],
-): Promise<void> {
+): Promise<{ ts?: string }> {
   const openRes = await fetch("https://slack.com/api/conversations.open", {
     method: "POST",
     headers: {
@@ -151,7 +153,7 @@ export async function sendSlackDM(
     throw new Error(`Slack conversations.open failed: ${openData.error}`);
   }
 
-  await sendSlackMessage(
+  return await sendSlackMessage(
     accessToken,
     openData.channel.id,
     text,

--- a/apps/webapp/app/services/channels/slack/client.ts
+++ b/apps/webapp/app/services/channels/slack/client.ts
@@ -134,6 +134,7 @@ export async function sendSlackDM(
   slackUserId: string,
   text: string,
   blocks?: unknown[],
+  threadTs?: string,
 ): Promise<{ ts?: string }> {
   const openRes = await fetch("https://slack.com/api/conversations.open", {
     method: "POST",
@@ -157,7 +158,7 @@ export async function sendSlackDM(
     accessToken,
     openData.channel.id,
     text,
-    undefined,
+    threadTs,
     blocks,
   );
 }

--- a/apps/webapp/app/services/channels/slack/outbound.ts
+++ b/apps/webapp/app/services/channels/slack/outbound.ts
@@ -191,6 +191,9 @@ export async function sendReply(
     return await sendSlackMessage(botToken, slackChannel, plainText, threadTs, blocks);
   }
 
-  // DM — `to` is the Slack user ID (set from inbound replyTo)
-  return await sendSlackDM(botToken, to, plainText, blocks);
+  // DM — `to` is the Slack user ID (set from inbound replyTo).
+  // Thread the reply under the original message when the inbound came in as a
+  // thread reply (threadTs present), so the exchange stays in one Slack thread.
+  const threadTs = metadata?.threadTs as string | undefined;
+  return await sendSlackDM(botToken, to, plainText, blocks, threadTs);
 }

--- a/apps/webapp/app/services/channels/slack/outbound.ts
+++ b/apps/webapp/app/services/channels/slack/outbound.ts
@@ -168,7 +168,7 @@ export async function sendReply(
   to: string,
   text: string,
   metadata?: ReplyMetadata,
-): Promise<void> {
+): Promise<{ ts?: string } | void> {
   const workspaceId = metadata?.workspaceId as string | undefined;
   const channelId = metadata?.channelId as string | undefined;
 
@@ -188,10 +188,9 @@ export async function sendReply(
   const slackChannel = metadata?.slackChannel as string | undefined;
   if (slackChannel) {
     const threadTs = metadata?.threadTs as string | undefined;
-    await sendSlackMessage(botToken, slackChannel, plainText, threadTs, blocks);
-    return;
+    return await sendSlackMessage(botToken, slackChannel, plainText, threadTs, blocks);
   }
 
   // DM — `to` is the Slack user ID (set from inbound replyTo)
-  await sendSlackDM(botToken, to, plainText, blocks);
+  return await sendSlackDM(botToken, to, plainText, blocks);
 }

--- a/apps/webapp/app/services/channels/types.ts
+++ b/apps/webapp/app/services/channels/types.ts
@@ -26,7 +26,11 @@ export interface ChannelHandler {
   slug: string;
   capabilities: ChannelCapabilities;
   parseInbound(request: Request): Promise<InboundParseResult>;
-  sendReply(to: string, text: string, metadata?: ReplyMetadata): Promise<void>;
+  sendReply(
+    to: string,
+    text: string,
+    metadata?: ReplyMetadata,
+  ): Promise<{ ts?: string } | void>;
   getFormat(): string;
   emptyResponse(): Response;
   /** Send a typing/processing indicator. Only called if capabilities.sendTypingIndicator is true. */


### PR DESCRIPTION
Problem

Scheduled tasks send their first message with full context because it's composed inside the task's own conversation (Conversation.asyncJobId = taskId). But replies lost that context — they were routed to a per-channel daily bucket with no back-link to the task, so the butler answered generically (generic diet, not keto). On top of that, the butler's reply posted as a new top-level Slack message instead of staying in the thread.

Fix

Slack-only, thread-only, no schema migration (reuses the existing ConversationHistory.context JSON column).

1. sendReply returns the posted Slack ts — sendSlackMessage/sendSlackDM/sendReply now surface chat.postMessage's ts. Backward compatible (existing callers ignore the return).
2. send_message mirrors into the task conversation — when a task sends on Slack, the outbound message is written into the task's own conversation with context: { slackTs: ts }. Non-task sends keep the daily-bucket behavior.
3. Inbound resolver routes thread-replies to the task — when a reply carries threadTs, getOrCreateChannelConversation looks up the history row where context.slackTs == threadTs (scoped to the user) and routes into that task conversation; otherwise falls through to prior behavior.
4. DM replies thread correctly — sendSlackDM now passes thread_ts, so the butler's reply lands inside the task's Slack thread instead of a new top-level DM.

Behavior

- Reply in the thread of a task's Slack message → butler keeps full task context (keto stays keto) and replies in-thread.
- A brand-new top-level DM (not a thread reply) → unchanged (daily bucket). Accepted strict-thread trade-off.
- Email and WhatsApp unchanged — deferred to a follow-up.

Testing

- 7 new unit tests pass (outbound ts + threading, task-conversation mirror + daily-bucket fallback, inbound thread routing + fallthrough).
- Broader agent+channels suite: 108/110. The 2 failures are in decision.test.ts and are pre-existing (reproduced on the branch base 67933c57, untouched by this diff).
- Touched files typecheck clean (baseline tsc has unrelated pre-existing errors).

Follow-ups (out of scope)

- Email (Message-ID/In-Reply-To) and WhatsApp reply threading.
- The parallel executor path executors/direct.ts::sendChannelMessage doesn't stamp slackTs — currently has no active dispatch caller; revisit if activated.
