### PR TITLE
feat(billing): charge chat turns by real input/output tokens

### DIFF
--- a/apps/webapp/app/config/billing.server.ts
+++ b/apps/webapp/app/config/billing.server.ts
@@ -54,11 +54,30 @@ export const BILLING_CONFIG = {
     },
   },
 
-  // Credit costs per operation
+  // Credit costs per operation. `chatMessage` is the pre-flight minimum
+  // (used by `hasCredits` to refuse turns for empty wallets); the real
+  // charge for a chat turn is computed from actual input/output tokens via
+  // `creditsForTokens` in ~/jobs/credit_utils.
   creditCosts: {
     addEpisode: parseInt(process.env.CREDIT_COST_EPISODE || "1", 10),
     search: parseInt(process.env.CREDIT_COST_SEARCH || "1", 10),
     chatMessage: parseInt(process.env.CREDIT_COST_CHAT || "1", 10),
+  },
+
+  // Token → credit conversion for chat/agent turns.
+  // Defaults price 1 credit per 1K input tokens and 5 credits per 1K
+  // output tokens, matching the typical 5× premium providers charge for
+  // completion vs. prompt tokens.
+  tokenCosts: {
+    inputTokensPerCredit: parseInt(
+      process.env.CREDIT_INPUT_TOKENS_PER_CREDIT || "1000",
+      10,
+    ),
+    outputTokensPerCredit: parseInt(
+      process.env.CREDIT_OUTPUT_TOKENS_PER_CREDIT || "200",
+      10,
+    ),
+    minChatCredits: parseInt(process.env.CREDIT_MIN_CHAT || "1", 10),
   },
 
   // Billing cycle settings

--- a/apps/webapp/app/jobs/credit_utils.ts
+++ b/apps/webapp/app/jobs/credit_utils.ts
@@ -1,4 +1,4 @@
-import { isBillingEnabled } from "~/config/billing.server";
+import { BILLING_CONFIG, isBillingEnabled } from "~/config/billing.server";
 import { prisma } from "~/db.server";
 
 import { type CreditOperation } from "~/trigger/utils/utils";
@@ -184,4 +184,30 @@ export async function reconcileCredits(
  */
 export function estimateCreditsFromTokens(tokenCount: number): number {
   return Math.max(1, Math.ceil(tokenCount / 10));
+}
+
+/**
+ * Convert real LLM token usage into credits for a chat/agent turn.
+ *
+ * Uses `BILLING_CONFIG.tokenCosts` divisors: 1 credit per N input tokens
+ * plus 1 credit per M output tokens (defaults 1000 and 200 respectively,
+ * i.e. output is billed 5× input). Floors at `minChatCredits` so trivial
+ * turns still show as at least one credit — this matches the prior flat
+ * per-turn behavior and avoids "free" replies when a model returns an
+ * empty message.
+ */
+export function creditsForTokens(
+  inputTokens: number,
+  outputTokens: number,
+  opts?: { min?: number },
+): number {
+  const { inputTokensPerCredit, outputTokensPerCredit, minChatCredits } =
+    BILLING_CONFIG.tokenCosts;
+  const inTok = Math.max(0, Math.floor(inputTokens || 0));
+  const outTok = Math.max(0, Math.floor(outputTokens || 0));
+  const raw =
+    Math.ceil(inTok / Math.max(1, inputTokensPerCredit)) +
+    Math.ceil(outTok / Math.max(1, outputTokensPerCredit));
+  const floor = opts?.min ?? minChatCredits;
+  return Math.max(floor, raw);
 }

--- a/apps/webapp/app/jobs/credit_utils.ts
+++ b/apps/webapp/app/jobs/credit_utils.ts
@@ -189,12 +189,14 @@ export function estimateCreditsFromTokens(tokenCount: number): number {
 /**
  * Convert real LLM token usage into credits for a chat/agent turn.
  *
- * Uses `BILLING_CONFIG.tokenCosts` divisors: 1 credit per N input tokens
- * plus 1 credit per M output tokens (defaults 1000 and 200 respectively,
- * i.e. output is billed 5× input). Floors at `minChatCredits` so trivial
- * turns still show as at least one credit — this matches the prior flat
- * per-turn behavior and avoids "free" replies when a model returns an
- * empty message.
+ * Uses `BILLING_CONFIG.tokenCosts` divisors: 1 credit per
+ * `inputTokensPerCredit` input tokens + 1 credit per `outputTokensPerCredit`
+ * output tokens. Defaults price 1 credit / 1K input tokens and 5 credits /
+ * 1K output tokens (i.e. `outputTokensPerCredit` = 200 → smaller divisor →
+ * more credits per token → output billed 5× input, matching typical
+ * provider pricing). Floors at `minChatCredits` so trivial turns still
+ * show as at least one credit, matching the prior flat per-turn behavior
+ * and avoiding "free" replies when a model returns an empty message.
  */
 export function creditsForTokens(
   inputTokens: number,

--- a/apps/webapp/app/jobs/ingest/graph-resolution.logic.ts
+++ b/apps/webapp/app/jobs/ingest/graph-resolution.logic.ts
@@ -39,7 +39,6 @@ import {
 import { makeModelCall } from "~/lib/model.server";
 import { prisma } from "~/db.server";
 import { IngestionStatus } from "@core/database";
-import { deductCredits } from "~/trigger/utils/utils";
 import { isWorkspaceBYOK } from "~/services/byok.server";
 
 import {
@@ -478,38 +477,33 @@ export async function processGraphResolution(
         // Don't throw - the graph resolution work is still valid
       }
 
-      // Credit reconciliation: only reconcile when all chunks are done
-      // Skip for BYOK workspaces (no credits were reserved or need deducting)
+      // Commit the upfront reservation as the final ingest bill on the
+      // last chunk. Ingest is billed purely on the input-token estimate
+      // from `addToQueue` — no reconciliation against statement count.
+      // reconcileCredits with actual === reserved skips the availableCredits
+      // update (already decremented at reserve time) and just rolls the
+      // amount into usedCredits + episodeCreditsUsed for analytics.
+      // Skip for BYOK workspaces (no credits were reserved).
       const byok = await isWorkspaceBYOK(payload.workspaceId);
-
       if (!byok) {
-        const reservedCredits = finalOutput?.reservedCredits || currentOutput?.reservedCredits || 0;
+        const reservedCredits =
+          finalOutput?.reservedCredits || currentOutput?.reservedCredits || 0;
         const totalChunks = payload.episodeDetails?.totalChunks || 1;
         const completedChunks = finalOutput?.episodes?.length || 1;
         const allChunksDone = completedChunks >= totalChunks;
 
-        if (reservedCredits > 0) {
-          if (allChunksDone) {
-            // All chunks done: reconcile reserved vs total statements across all chunks
-            const totalStatementsUsed = finalOutput?.statementsCreated || statementsCount;
-            await reconcileCredits(
-              payload.workspaceId,
-              payload.userId,
-              "addEpisode",
-              reservedCredits,
-              totalStatementsUsed,
-            );
-          }
-          // Non-last chunks: credits already reserved, no action needed
-        } else {
-          // Fallback: no reservation found (legacy path), deduct full amount
-          await deductCredits(
+        if (reservedCredits > 0 && allChunksDone) {
+          await reconcileCredits(
             payload.workspaceId,
             payload.userId,
             "addEpisode",
-            statementsCount,
+            reservedCredits,
+            reservedCredits,
           );
         }
+        // Non-last chunks: leave the reservation in place; the final chunk
+        // will commit for the whole session. No reservation at all means
+        // upstream skipped reserveCredits — nothing to commit.
       }
       // Token rollup happens per-call inside makeModelCall now; no aggregated
       // recording here (would double-count with the per-call writes).

--- a/apps/webapp/app/routes/api.v1.conversation._index.tsx
+++ b/apps/webapp/app/routes/api.v1.conversation._index.tsx
@@ -28,6 +28,7 @@ import {
   createResumableUIResponse,
   drainAgentResult,
 } from "~/services/agent/mastra-stream.server";
+import { pickAgentResultTokens } from "~/services/tokenUsage.server";
 import { processFileAttachments } from "~/services/agent/file-resolver.server";
 import {
   registerStream,
@@ -422,6 +423,13 @@ const { loader, action } = createHybridActionApiRoute(
       model: modelString,
     };
 
+    // Mutable handle to the current Mastra run — set right after each
+    // `agent.stream` / `approveToolCall` / `declineToolCall` below. The
+    // output processor closes over this so it can pull real token totals
+    // off the stream instead of falling back to the char/4 estimate. Both
+    // credit deduction AND DailyTokenUsage rollup depend on these numbers.
+    const currentRun: { result: any } = { result: null };
+
     const messageHistoryProcessor: Processor<"message-history"> = {
       id: "message-history",
       async processInput({ messages }) {
@@ -430,10 +438,31 @@ const { loader, action } = createHybridActionApiRoute(
       async processOutputResult({ messages }) {
         const convertedMessages = convertMessages(messages).to("AIV6.UI");
 
+        // Pull real input/output tokens off the current stream/resume result.
+        // `totalUsage` sums across every step of a tool loop; `usage` is only
+        // the last step. Prefer totalUsage — for tool-heavy turns `usage`
+        // undercounts by 5–10×. Both fields are promises on Mastra streams,
+        // so await them defensively.
+        let realInputTokens: number | undefined;
+        let realOutputTokens: number | undefined;
+        try {
+          const src = currentRun.result;
+          const usage = src ? await (src.totalUsage ?? src.usage) : undefined;
+          if (usage) {
+            const picked = pickAgentResultTokens({ totalUsage: usage });
+            realInputTokens = picked.inputTokens;
+            realOutputTokens = picked.outputTokens;
+          }
+        } catch {
+          // Fall through — saveConversationResult has a char/4 fallback.
+        }
+
         await saveConversationResult({
           parts: convertedMessages[convertedMessages.length - 1]
             ? convertedMessages[convertedMessages.length - 1].parts
             : [],
+          inputTokens: realInputTokens,
+          outputTokens: realOutputTokens,
           ...saveParams,
         });
 
@@ -563,6 +592,10 @@ const { loader, action } = createHybridActionApiRoute(
             });
           }
 
+          // Point the closed-over ref at the run whose outputProcessor is
+          // about to fire, so token totals land on this iteration's save.
+          currentRun.result = resumeResult;
+
           // Drain intermediate streams so each Mastra run finishes (and its
           // outputProcessors fire) before the next tool decision is processed.
           if (!isLast) {
@@ -621,6 +654,8 @@ const { loader, action } = createHybridActionApiRoute(
         modelSettings: { temperature: 0.5 },
         abortSignal: abortController.signal,
       });
+      // Same ref the outputProcessor reads for real token usage.
+      currentRun.result = stream;
     } catch (error) {
       // Stream failed to start (e.g., context-length overflow, provider
       // error). Nothing has been sent to the client yet, so we can mark the

--- a/apps/webapp/app/routes/api.v1.voice.turn.tsx
+++ b/apps/webapp/app/routes/api.v1.voice.turn.tsx
@@ -37,6 +37,7 @@ import {
   saveConversationResult,
   createResumableUIResponse,
 } from "~/services/agent/mastra-stream.server";
+import { pickAgentResultTokens } from "~/services/tokenUsage.server";
 import {
   registerStream,
   unregisterStream,
@@ -147,6 +148,14 @@ const { loader, action } = createHybridActionApiRoute(
       (gw as any).__registerMastra(mastra);
     }
 
+    // Mutable handle to the current Mastra run — set right after
+    // `agent.stream` below. The output processor closes over this so it can
+    // pull real token totals off the stream instead of falling back to a
+    // char/4 estimate. Both credit deduction AND DailyTokenUsage rollup
+    // depend on these numbers. No approval loop on the voice path, so this
+    // is only assigned once.
+    const currentRun: { result: any } = { result: null };
+
     const messageHistoryProcessor: Processor<"message-history"> = {
       id: "message-history",
       async processInput({ messages }) {
@@ -155,6 +164,24 @@ const { loader, action } = createHybridActionApiRoute(
       async processOutputResult({ messages }) {
         const convertedMessages = convertMessages(messages).to("AIV6.UI");
         const last = convertedMessages[convertedMessages.length - 1];
+
+        // Prefer totalUsage (sums every step of a tool loop) over usage
+        // (last step only). Await defensively — Mastra exposes these as
+        // promises on streams.
+        let realInputTokens: number | undefined;
+        let realOutputTokens: number | undefined;
+        try {
+          const src = currentRun.result;
+          const usage = src ? await (src.totalUsage ?? src.usage) : undefined;
+          if (usage) {
+            const picked = pickAgentResultTokens({ totalUsage: usage });
+            realInputTokens = picked.inputTokens;
+            realOutputTokens = picked.outputTokens;
+          }
+        } catch {
+          // Fall through — saveConversationResult has a char/4 fallback.
+        }
+
         await saveConversationResult({
           parts: last ? last.parts : [],
           conversationId,
@@ -164,6 +191,8 @@ const { loader, action } = createHybridActionApiRoute(
           workspaceId,
           isBYOK,
           model: modelString,
+          inputTokens: realInputTokens,
+          outputTokens: realOutputTokens,
         });
         return messages;
       },
@@ -187,6 +216,8 @@ const { loader, action } = createHybridActionApiRoute(
         modelSettings: { temperature: 0.5 },
         abortSignal: abortController.signal,
       });
+      // Same ref the outputProcessor reads for real token usage.
+      currentRun.result = stream;
     } catch (error) {
       logger.error("[voice-turn] agent.stream failed to start", {
         conversationId,

--- a/apps/webapp/app/services/agent/decision-agent-pipeline.ts
+++ b/apps/webapp/app/services/agent/decision-agent-pipeline.ts
@@ -23,7 +23,7 @@ import { prisma } from "~/db.server";
 import { type OrchestratorTools } from "~/services/agent/orchestrator-tools";
 import { getOrCreateAsyncConversation } from "~/services/agent/context/decision-context";
 import { createConversation } from "~/services/conversation.server";
-import { deductCredits, hasCredits } from "~/trigger/utils/utils";
+import { hasCredits } from "~/trigger/utils/utils";
 import { isWorkspaceBYOK } from "~/services/byok.server";
 
 // ============================================================================
@@ -245,23 +245,10 @@ export async function runCASEPipeline(
       }
     }
 
-    // Deduct credits (1 for think-only, 2 if butler also ran full execution)
-    // Skip credit deduction if workspace is using their own API key (BYOK).
-    // `isBYOK` was resolved during the pre-flight credit check above.
-    if (!isBYOK) {
-      try {
-        await deductCredits(
-          userData.workspaceId,
-          userData.userId,
-          "chatMessage",
-          1, // noStreamProcess already deducts 1, so just 1 more for the pipeline
-        );
-      } catch (error) {
-        logger.warn(`[pipeline] Failed to deduct credits for ${entityId}`, {
-          error,
-        });
-      }
-    }
+    // No extra credit charge here — the underlying `noStreamProcess` call
+    // already deducted token-based credits for the butler+think turn. The
+    // previous flat +1 double-charged every trigger run relative to a
+    // regular chat turn.
 
     logger.info(`[pipeline] Successfully processed ${entityId}`);
 

--- a/apps/webapp/app/services/agent/mastra-stream.server.ts
+++ b/apps/webapp/app/services/agent/mastra-stream.server.ts
@@ -13,6 +13,7 @@ import {
   clearActiveStreamId,
 } from "~/services/conversation.server";
 import { deductCredits } from "~/trigger/utils/utils";
+import { creditsForTokens } from "~/jobs/credit_utils";
 import {
   recordTokenUsage,
   type TokenUsageSource,
@@ -109,10 +110,6 @@ export async function saveConversationResult({
     }
   }
 
-  if (!isBYOK) {
-    await deductCredits(workspaceId, userId, "chatMessage", 1);
-  }
-
   // Roll up token usage into the daily bucket. If the caller passed real
   // usage from agentResult.usage, use it. Otherwise fall back to a rough
   // char/4 estimate over the assistant text — good enough for the daily
@@ -127,6 +124,16 @@ export async function saveConversationResult({
     inTok = Math.floor(userLen / 4);
     outTok = Math.floor(textLen / 4);
   }
+
+  // Charge from real token usage — the flat per-turn cost was replaced so a
+  // turn that spends 20K tokens on tool loops isn't priced the same as a
+  // one-sentence reply. Falls back to the char/4 estimate above when the
+  // agent didn't report `totalUsage` (self-hosted / older providers).
+  if (!isBYOK) {
+    const chatCredits = creditsForTokens(inTok, outTok);
+    await deductCredits(workspaceId, userId, "chatMessage", chatCredits);
+  }
+
   await recordTokenUsage({
     workspaceId,
     userId,

--- a/apps/webapp/app/services/agent/no-stream-process.ts
+++ b/apps/webapp/app/services/agent/no-stream-process.ts
@@ -21,6 +21,7 @@ import {
 } from "~/services/agent/types/decision-agent";
 import { type OrchestratorTools } from "~/services/agent/executors/base";
 import { deductCredits, hasCredits } from "~/trigger/utils/utils";
+import { creditsForTokens } from "~/jobs/credit_utils";
 import { isWorkspaceBYOK } from "~/services/byok.server";
 import {
   pickAgentResultTokens,
@@ -393,14 +394,20 @@ export async function noStreamProcess(
       );
     }
 
-    if (!isBYOK) {
-      await deductCredits(workspaceId, userId, "chatMessage", 1);
-    }
-
     // Roll up real LLM token usage. Trigger flows (reminders, task triggers)
     // set body.triggerContext — track those separately from user chat so the
     // daily rollup breaks out task_conversation vs conversation.
     const { inputTokens, outputTokens } = pickAgentResultTokens(agentResult);
+
+    // Charge from real token usage. Prior code deducted a flat 1 credit per
+    // turn regardless of how many tokens the agent burned across tool loops;
+    // now a heavy multi-step turn costs proportionally more. BYOK workspaces
+    // still bypass — they pay their own provider bills.
+    if (!isBYOK) {
+      const chatCredits = creditsForTokens(inputTokens, outputTokens);
+      await deductCredits(workspaceId, userId, "chatMessage", chatCredits);
+    }
+
     await recordTokenUsage({
       workspaceId,
       userId,


### PR DESCRIPTION
## Summary
- Chat/agent turns now bill by real token usage instead of a flat 1 credit per turn: **1 credit / 1K input tokens + 5 credits / 1K output tokens**, min 1 credit.
- Non-streaming path uses `pickAgentResultTokens(agentResult)` which sums `totalUsage` across every step of a tool loop (previously would have used `usage`, undercounting 5–10×).
- Streaming path plumbs `stream.totalUsage` through a closure ref into `saveConversationResult` — fixes both credit deduction AND `DailyTokenUsage` rollup for streaming turns, which were previously falling back to a char/4 estimate.
- Trigger pipeline (`runCASEPipeline`) no longer double-charges the extra `+1`; the underlying `noStreamProcess` now handles it.
- Ingest billing simplified: bills purely on the input-token reservation from `addToQueue`; dropped the reconcile-to-statement-count and the legacy `deductCredits` fallback in `graph-resolution.logic.ts`. Failure/nothing-to-remember refunds in `ingest-episode.logic.ts` unchanged.

New `BILLING_CONFIG.tokenCosts` block (env-tunable):
- `CREDIT_INPUT_TOKENS_PER_CREDIT` (default 1000)
- `CREDIT_OUTPUT_TOKENS_PER_CREDIT` (default 200)
- `CREDIT_MIN_CHAT` (default 1)

## Test plan
- [ ] Regression: send a short chat turn and confirm ≥1 credit deducted (min floor).
- [ ] Regression: send a long tool-loop turn on non-streaming path and confirm credits ≈ ceil(in/1000) + ceil(out/200).
- [ ] Streaming: send a chat turn in the web UI, verify `DailyTokenUsage` row inputTokens/outputTokens > 0 (not char/4).
- [ ] Streaming resume: approve a suspended tool call, verify tokens roll into that turn's row.
- [ ] Trigger fire (reminder or scheduled task): confirm only one turn's worth of credits deducted (no extra +1).
- [ ] Ingest an episode: confirm reserved amount is committed as final charge; failure path still refunds.
- [ ] BYOK workspace: confirm no credits deducted on any of the above paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)