### PR TITLE
feat(integrations): populate IntegrationCallLog.source for API-triggered actions

### DIFF
--- a/apps/webapp/app/routes/api.v1.integration_account.$integrationAccountId.action.tsx
+++ b/apps/webapp/app/routes/api.v1.integration_account.$integrationAccountId.action.tsx
@@ -21,6 +21,7 @@ const SearchParamsSchema = z.object({
 const ActionBodySchema = z.object({
   action: z.string().min(1, "Action name is required"),
   parameters: z.record(z.string(), z.any()).optional().default({}),
+  source: z.string().max(128).optional(),
 });
 
 /**
@@ -70,12 +71,19 @@ const { action } = createHybridActionApiRoute(
   async ({ params, body, authentication }) => {
     const { integrationAccountId } = params;
     const { action: actionName, parameters } = body;
+    
+    const source =
+      body.source ??
+      (authentication.type === "OAUTH2" && authentication.oauth2
+        ? `oauth:${authentication.oauth2.clientId}`
+        : undefined);
 
     const result = await executeIntegrationAction(
       integrationAccountId,
       actionName,
       parameters,
       authentication.userId,
+      source,
     );
 
     return json({ result });

--- a/apps/webapp/app/utils/mcp/integration-operations.ts
+++ b/apps/webapp/app/utils/mcp/integration-operations.ts
@@ -324,8 +324,32 @@ export async function executeIntegrationAction(
         } finally {
           await client.close();
         }
+        await prisma.integrationCallLog
+          .create({
+            data: {
+              integrationAccountId: accountId,
+              toolName: action,
+              source: source || null,
+              error: null,
+            },
+          })
+          .catch((logError: any) => {
+            logger.error(`Failed to log custom MCP call: ${logError}`);
+          });
       } catch (error) {
         logger.error(`Custom MCP call error for ${account.id}: ${error}`);
+        await prisma.integrationCallLog
+          .create({
+            data: {
+              integrationAccountId: accountId,
+              toolName: action,
+              source: source || null,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          })
+          .catch((logError: any) => {
+            logger.error(`Failed to log custom MCP call error: ${logError}`);
+          });
         throw error;
       }
     } else {


### PR DESCRIPTION
## Summary

Populates `IntegrationCallLog.source` for integration actions triggered over the API, and closes an audit gap for custom MCP calls.

- `POST /api/v1/integration_account/:id/action` now accepts an optional `source` (max 128 chars). When omitted, OAuth-app callers default to `oauth:<clientId>`; PAT/session callers stay `null` (unchanged).
- `executeIntegrationAction` threads `source` into every `IntegrationCallLog` row.
- Custom MCP executions now write a call-log row on success and failure - first-party integrations already did; this makes auditing uniform across both integration flavors.

## Why

The `IntegrationCallLog.source` column already exists but was never populated over HTTP, so every API-triggered call logged as `source: null` — you couldn't tell which app performed an action. This is the foundational piece for auditing agent/NPC actions requested in [RedPlanetHQ/town#48](https://github.com/RedPlanetHQ/town/issues/48#issuecomment-4955317090), where Town's NPCs send `source: "town:npc:<id>"` so an owner can trace exactly which character used which integration.

## Scope / compatibility

Purely additive. `source` is optional; existing callers are unaffected. No schema migration - the column already exists.