### PR TITLE
fix(billing): handle async-payment topups + auto-init missing UserUsage

### DIFF
--- a/apps/webapp/app/routes/api.webhooks.stripe.tsx
+++ b/apps/webapp/app/routes/api.webhooks.stripe.tsx
@@ -16,6 +16,7 @@ import { logger } from "~/services/logger.service";
 import type { PlanType } from "@prisma/client";
 import { unscheduleAllForWorkspace } from "~/services/oauth/scheduler";
 import { sendPaymentFailedEmail } from "~/services/email.server";
+import { completeTopup, findTopupForSession } from "~/services/topup.server";
 
 // Initialize Stripe
 const stripe = BILLING_CONFIG.stripe.secretKey
@@ -330,9 +331,13 @@ async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
 }
 
 /**
- * Handle checkout.session.completed — currently only used for one-time
- * credit top-ups. Subscription checkouts are handled by
- * customer.subscription.created.
+ * Handle checkout.session.completed and checkout.session.async_payment_succeeded.
+ *
+ * Sync card payments fire `completed` with `payment_status: "paid"` — we
+ * grant credits immediately. Async methods (ACH, some wallets) fire
+ * `completed` with `payment_status: "unpaid"` first; `completeTopup` no-ops
+ * on that and we credit later when `async_payment_succeeded` fires.
+ * Subscription checkouts are handled by `customer.subscription.created`.
  */
 async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) {
   if (session.mode !== "payment") {
@@ -341,74 +346,17 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
   if (session.metadata?.type !== "topup") {
     return;
   }
-  if (session.payment_status !== "paid") {
-    logger.info("Skipping unpaid topup checkout session", {
-      sessionId: session.id,
-      payment_status: session.payment_status,
-    });
-    return;
-  }
 
-  const topupId = session.metadata.topupId as string | undefined;
-  const paymentIntentId =
-    typeof session.payment_intent === "string"
-      ? session.payment_intent
-      : session.payment_intent?.id;
-
-  const topup = topupId
-    ? await prisma.creditTopup.findUnique({ where: { id: topupId } })
-    : await prisma.creditTopup.findUnique({
-        where: { stripeCheckoutSessionId: session.id },
-      });
-
+  const topup = await findTopupForSession(session);
   if (!topup) {
     logger.error("Topup row not found for checkout session", {
       sessionId: session.id,
-      topupId,
+      topupId: session.metadata?.topupId,
     });
     return;
   }
 
-  // Idempotency: if already completed, skip. Webhooks retry on failure.
-  if (topup.status === "completed") {
-    logger.info("Topup already completed, skipping", { topupId: topup.id });
-    return;
-  }
-
-  const userUsage = await prisma.userUsage.findUnique({
-    where: { userId: topup.userId },
-  });
-  if (!userUsage) {
-    logger.error("UserUsage missing for topup", {
-      topupId: topup.id,
-      userId: topup.userId,
-    });
-    return;
-  }
-
-  await prisma.$transaction([
-    prisma.creditTopup.update({
-      where: { id: topup.id },
-      data: {
-        status: "completed",
-        completedAt: new Date(),
-        stripePaymentIntentId: paymentIntentId,
-        stripeCheckoutSessionId: session.id,
-      },
-    }),
-    prisma.userUsage.update({
-      where: { id: userUsage.id },
-      data: {
-        availableCredits: { increment: topup.credits },
-      },
-    }),
-  ]);
-
-  logger.info("Topup completed and credits granted", {
-    topupId: topup.id,
-    userId: topup.userId,
-    credits: topup.credits,
-  });
+  await completeTopup(topup.id, session);
 }
 
 /**
@@ -533,6 +481,7 @@ export async function action({ request }: ActionFunctionArgs) {
         break;
 
       case "checkout.session.completed":
+      case "checkout.session.async_payment_succeeded":
         await handleCheckoutSessionCompleted(
           event.data.object as Stripe.Checkout.Session,
         );

--- a/apps/webapp/app/services/topup.server.ts
+++ b/apps/webapp/app/services/topup.server.ts
@@ -90,23 +90,42 @@ export async function completeTopup(
       ? session.payment_intent
       : session.payment_intent?.id;
 
-  await prisma.$transaction([
-    prisma.creditTopup.update({
-      where: { id: topup.id },
+  // Race guard: two concurrent handlers (e.g. `completed` + `async_payment_
+  // succeeded` arriving close together, or Stripe re-delivery after a
+  // timeout) can both read status="pending" above. The `updateMany` with a
+  // status guard is atomic — only the winner sees `count === 1` and
+  // increments availableCredits. The loser sees count===0 and no-ops. The
+  // earlier `topup.status === "completed"` check is the fast path for
+  // already-settled rows; this is the correctness guarantee.
+  const claimed = await prisma.$transaction(async (tx) => {
+    const claim = await tx.creditTopup.updateMany({
+      where: { id: topup.id, status: "pending" },
       data: {
         status: "completed",
         completedAt: new Date(),
         stripePaymentIntentId: paymentIntentId,
         stripeCheckoutSessionId: session.id,
       },
-    }),
-    prisma.userUsage.update({
-      where: { id: userUsage.id },
+    });
+    if (claim.count === 0) {
+      return false;
+    }
+    await tx.userUsage.update({
+      where: { id: userUsage!.id },
       data: {
         availableCredits: { increment: topup.credits },
       },
-    }),
-  ]);
+    });
+    return true;
+  });
+
+  if (!claimed) {
+    logger.info(
+      "[topup] concurrent handler already completed — no credits granted this time",
+      { topupId: topup.id, sessionId: session.id },
+    );
+    return { status: "already_completed" };
+  }
 
   logger.info("[topup] completed and credits granted", {
     topupId: topup.id,

--- a/apps/webapp/app/services/topup.server.ts
+++ b/apps/webapp/app/services/topup.server.ts
@@ -1,0 +1,142 @@
+/**
+ * Credit Top-up Service
+ *
+ * One-time credit top-ups can settle via two webhooks that must land the
+ * same way:
+ *   1. `checkout.session.completed` — sync card payments.
+ *   2. `checkout.session.async_payment_succeeded` — ACH / wallets that
+ *      settle asynchronously. The initial `completed` event carries
+ *      `payment_status: "unpaid"`, so we skip it, and Stripe fires this
+ *      follow-up event once the money actually clears.
+ *
+ * `completeTopup` is the single write path — idempotent, safe to call
+ * multiple times, no-ops on already-completed rows.
+ */
+
+import type Stripe from "stripe";
+import { prisma } from "~/db.server";
+import { ensureBillingInitialized } from "~/services/billing.server";
+import { logger } from "~/services/logger.service";
+
+export type CompleteTopupResult =
+  | { status: "completed"; credits: number }
+  | { status: "already_completed" }
+  | { status: "unpaid"; paymentStatus: string | null }
+  | { status: "topup_not_found" }
+  | { status: "usage_missing_and_uninitializable" };
+
+/**
+ * Complete a topup by ID. Idempotent — returns `already_completed`
+ * without touching balances if the row is already done.
+ *
+ * When the session's `payment_status` isn't `paid`, we return `unpaid` so
+ * the webhook can no-op and wait for `async_payment_succeeded`.
+ *
+ * When `UserUsage` doesn't exist for the user, we auto-provision via
+ * `ensureBillingInitialized` — previously the webhook would silently
+ * return here, leaving the topup stuck in `pending` forever.
+ */
+export async function completeTopup(
+  topupId: string,
+  session: Stripe.Checkout.Session,
+): Promise<CompleteTopupResult> {
+  const topup = await prisma.creditTopup.findUnique({
+    where: { id: topupId },
+  });
+  if (!topup) {
+    logger.error("[topup] not found", { topupId, sessionId: session.id });
+    return { status: "topup_not_found" };
+  }
+
+  if (topup.status === "completed") {
+    return { status: "already_completed" };
+  }
+
+  if (session.payment_status !== "paid") {
+    logger.info(
+      "[topup] session not yet paid — will settle on async_payment_succeeded",
+      {
+        topupId,
+        sessionId: session.id,
+        payment_status: session.payment_status,
+      },
+    );
+    return { status: "unpaid", paymentStatus: session.payment_status ?? null };
+  }
+
+  let userUsage = await prisma.userUsage.findUnique({
+    where: { userId: topup.userId },
+  });
+  if (!userUsage) {
+    await ensureBillingInitialized(topup.workspaceId, topup.userId);
+    userUsage = await prisma.userUsage.findUnique({
+      where: { userId: topup.userId },
+    });
+  }
+  if (!userUsage) {
+    logger.error(
+      "[topup] UserUsage still missing after init — aborting credit grant",
+      {
+        topupId,
+        userId: topup.userId,
+        workspaceId: topup.workspaceId,
+      },
+    );
+    return { status: "usage_missing_and_uninitializable" };
+  }
+
+  const paymentIntentId =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id;
+
+  await prisma.$transaction([
+    prisma.creditTopup.update({
+      where: { id: topup.id },
+      data: {
+        status: "completed",
+        completedAt: new Date(),
+        stripePaymentIntentId: paymentIntentId,
+        stripeCheckoutSessionId: session.id,
+      },
+    }),
+    prisma.userUsage.update({
+      where: { id: userUsage.id },
+      data: {
+        availableCredits: { increment: topup.credits },
+      },
+    }),
+  ]);
+
+  logger.info("[topup] completed and credits granted", {
+    topupId: topup.id,
+    userId: topup.userId,
+    workspaceId: topup.workspaceId,
+    credits: topup.credits,
+  });
+
+  return { status: "completed", credits: topup.credits };
+}
+
+/**
+ * Look up the topup for a checkout session, preferring the `topupId`
+ * metadata (set by `createTopupCheckoutSession`) and falling back to the
+ * session id (covers the small window where the session-id update raced
+ * the webhook).
+ */
+export async function findTopupForSession(
+  session: Stripe.Checkout.Session,
+): Promise<{ id: string } | null> {
+  const topupId = session.metadata?.topupId as string | undefined;
+  if (topupId) {
+    const row = await prisma.creditTopup.findUnique({
+      where: { id: topupId },
+      select: { id: true },
+    });
+    if (row) return row;
+  }
+  return prisma.creditTopup.findUnique({
+    where: { stripeCheckoutSessionId: session.id },
+    select: { id: true },
+  });
+}


### PR DESCRIPTION
## Summary
Two failure modes were letting credit topups sit in \`pending\` even after Stripe confirmed the payment:

1. **Async payment methods (ACH, some wallets)** — Stripe fires \`checkout.session.completed\` with \`payment_status: \"unpaid\"\` first, then later \`checkout.session.async_payment_succeeded\` with \`payment_status: \"paid\"\`. The old handler bailed on the first event and didn't listen for the follow-up.
2. **Missing UserUsage row** — the handler returned 200 without granting credits, and Stripe wouldn't retry.

## Changes
- Extracts \`completeTopup\` + \`findTopupForSession\` into \`apps/webapp/app/services/topup.server.ts\`. The write path is idempotent — safe to call for the same topup any number of times.
- Webhook routes both \`checkout.session.completed\` and \`checkout.session.async_payment_succeeded\` through the same helper.
- \`completeTopup\` calls \`ensureBillingInitialized\` when \`UserUsage\` is missing before granting credits.

## Deploy step
Update the Stripe webhook endpoint in the dashboard to also subscribe to \`checkout.session.async_payment_succeeded\` — the code change alone doesn't do anything until Stripe is delivering that event.

The two topups currently stuck in \`pending\` need a manual DB fix (they were created before this ships):
\`\`\`sql
BEGIN;
UPDATE \"UserUsage\" SET \"availableCredits\" = \"availableCredits\" + <credits> WHERE \"userId\" = '<userId>';
UPDATE \"CreditTopup\" SET status = 'completed', \"completedAt\" = NOW() WHERE id = '<topupId>';
COMMIT;
\`\`\`

## Test plan
- [ ] Send a test \`checkout.session.completed\` event via Stripe CLI with \`payment_status: paid\` → topup completes, credits granted.
- [ ] Send a \`payment_status: unpaid\` event → topup stays pending, log shows \"session not yet paid\".
- [ ] Send a follow-up \`checkout.session.async_payment_succeeded\` → same topup completes, credits granted, idempotent on retry.
- [ ] Delete a user's UserUsage row and replay a completed event → row is re-initialized and credits granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)