### PR TITLE
fix(cli): use `where` on Windows in commandExists helper

### DIFF
--- a/packages/cli/src/utils/setup/docker.ts
+++ b/packages/cli/src/utils/setup/docker.ts
@@ -26,7 +26,7 @@ function safeDirName(name: string): string {
 
 async function commandExists(cmd: string): Promise<boolean> {
 	try {
-		await exec(`command -v ${cmd}`);
+		await exec(`${process.platform === 'win32' ? 'where' : 'command -v'} ${cmd}`);
 		return true;
 	} catch {
 		return false;

--- a/packages/cli/src/utils/setup/local.ts
+++ b/packages/cli/src/utils/setup/local.ts
@@ -21,7 +21,7 @@ const exec = promisify(execCb);
 
 async function commandExists(cmd: string): Promise<boolean> {
 	try {
-		await exec(`command -v ${cmd}`);
+		await exec(`${process.platform === 'win32' ? 'where' : 'command -v'} ${cmd}`);
 		return true;
 	} catch {
 		return false;

--- a/packages/cli/src/utils/setup/railway.ts
+++ b/packages/cli/src/utils/setup/railway.ts
@@ -15,7 +15,7 @@ const exec = promisify(execCb);
 
 async function commandExists(cmd: string): Promise<boolean> {
 	try {
-		await exec(`command -v ${cmd}`);
+		await exec(`${process.platform === 'win32' ? 'where' : 'command -v'} ${cmd}`);
 		return true;
 	} catch {
 		return false;


### PR DESCRIPTION
## Summary

On Windows, `command -v <cmd>` is a POSIX-only shell builtin that does not exist in `cmd.exe`. When Node's `child_process.exec()` runs this string on Windows, the shell immediately throws an error — causing `commandExists()` to return `false` even when the target binary (e.g. `docker`) is fully installed and on `PATH`. This makes `corebrain setup` (local, docker, and railway) completely unusable on Windows, even with a working Docker Desktop install.

This PR replaces the hardcoded `command -v` with a cross-platform check: `where` on `win32`, `command -v` on all other platforms — using `process.platform`, a value that is always available at runtime with no new imports or dependencies.

Fixes #904 — `corebrain setup` fails on Windows: "docker not found on PATH" when Docker is installed

## What changed

**`packages/cli/src/utils/setup/local.ts`**
- Problem: `commandExists` used `` await exec(`command -v ${cmd}`) `` — fails silently on Windows, causing `setupLocalWebapp` to throw `docker not found on PATH` even when Docker is installed.
- Change: Replaced template literal with `` `${process.platform === 'win32' ? 'where' : 'command -v'} ${cmd}` `` — one line, zero new imports.

**`packages/cli/src/utils/setup/docker.ts`**
- Problem: Same `command -v` pattern copied from local.ts, affects both `docker` and `tailscale` checks in `setupDockerGateway`.
- Change: Same single-line cross-platform fix.

**`packages/cli/src/utils/setup/railway.ts`**
- Problem: Same `command -v` pattern, affects `railway`, `brew`, and `npm` detection in `setupRailwayGateway` and `offerRailwayInstall`.
- Change: Same single-line cross-platform fix.

## Acceptance criteria

- [ ] `corebrain setup` no longer throws "docker not found on PATH" on Windows when Docker Desktop is installed and `docker` is on `PATH`
- [ ] `corebrain gateway setup --docker` correctly detects `docker` and `tailscale` on Windows
- [ ] `corebrain gateway setup --railway` correctly detects `railway`, `brew`, and `npm` on Windows
- [ ] All three setup paths continue to work unchanged on macOS and Linux

## How to test

1. On a Windows machine with Docker Desktop installed, run `corebrain setup`
2. Expected: the CLI proceeds past the `docker` check without throwing
3. On macOS/Linux, run the same commands — verify no regression
4. Edge case: rename `docker` temporarily out of PATH on Windows — verify `commandExists` correctly returns `false` and the error message still displays
5. Edge case: run on Linux — verify `command -v` is still used (not `where`)

## Notes

- No schema changes
- No new dependencies added — `process.platform` is a Node.js built-in
- No new imports in any file
- No server/API changes
- No breaking changes to existing consumers — `commandExists` is a private module-level function, not exported
- The `where` command has been available on Windows since XP and is present in all modern `cmd.exe` environments
- `process.platform` returns `'win32'` for both 32-bit and 64-bit Windows