### PR TITLE
fix(titles): forward workspaceId when session compaction generates a title

### DIFF
--- a/apps/webapp/app/jobs/session/session-compaction.logic.ts
+++ b/apps/webapp/app/jobs/session/session-compaction.logic.ts
@@ -231,7 +231,7 @@ async function getTitleForCompactedSession(
       const titleResult = await processTitleGeneration({
         queueId: ingestionRecords[0].id,
         userId: episodes[0]?.userId || "",
-        workspaceId: "", // Not critical for title generation
+        workspaceId,
       });
 
       if (titleResult.success && titleResult.title) {


### PR DESCRIPTION
## Summary

`session-compaction.logic.ts::getTitleForCompactedSession` was calling `processTitleGeneration` with `workspaceId: ""` and a comment claiming "Not critical for title generation." It's critical — without a real workspaceId, `makeModelCall`'s resolver skips the workspace BYOK lookup and falls through to `env.OPENAI_API_KEY`, which is empty for subscription-proxy self-hosts. Mastra then throws `Could not find API key process.env.OPENAI_API_KEY for model id openai/gpt-5-mini-2025-08-07` and no title ever gets written.

`workspaceId` was already a parameter of the enclosing function (threaded from the compaction payload). Just forwarding it.

Every other caller of `processTitleGeneration` already passes the real workspaceId — only this one path was broken.

## Test plan

- [ ] Boot a self-hosted container against a CLIProxyAPI subscription proxy (env `OPENAI_API_KEY=""`, workspace OpenAI BYOK set with base URL `http://host.docker.internal:8317/v1`).
- [ ] Trigger session compaction on a session whose ingestion queue has no pre-set title — confirm the outbound title-generation request lands on the proxy and returns a title, no `Could not find API key process.env.OPENAI_API_KEY` in worker logs.
- [ ] Verify the resulting `Document.title` is updated (not left as `Untitled Document`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)