### PR TITLE
fix(search): forward workspaceId through rerank LLM validation

### DIFF
--- a/apps/webapp/app/services/search.server.ts
+++ b/apps/webapp/app/services/search.server.ts
@@ -279,6 +279,7 @@ export class SearchService {
         episodesWithProvenance,
         rerankConfig,
         opts,
+        workspaceId,
       );
 
       // Filter by threshold if using a reranking model

--- a/apps/webapp/app/services/search/rerank.ts
+++ b/apps/webapp/app/services/search/rerank.ts
@@ -311,6 +311,7 @@ export async function applyMultiFactorReranking(
   episodes: EpisodeWithProvenance[],
   limit: number,
   options?: SearchOptions,
+  workspaceId?: string,
 ): Promise<(EpisodeWithProvenance & { rerankScore: number })[]> {
   // Stage 1: Optional LLM validation for borderline confidence
   let finalEpisodes = episodes;
@@ -320,6 +321,7 @@ export async function applyMultiFactorReranking(
     query,
     episodes,
     maxEpisodesForLLM,
+    workspaceId,
   );
 
   if (finalEpisodes.length === 0) {
@@ -378,6 +380,7 @@ export async function applyEpisodeReranking(
   episodes: EpisodeWithProvenance[],
   config: RerankConfig,
   options?: SearchOptions,
+  workspaceId?: string,
 ): Promise<(EpisodeWithProvenance & { rerankScore: number })[]> {
   const limit = config.limit || 20;
 
@@ -405,7 +408,7 @@ export async function applyEpisodeReranking(
         { error },
       );
       // Fallback to original multi-stage algorithm
-      return applyMultiFactorReranking(query, episodes, limit, options);
+      return applyMultiFactorReranking(query, episodes, limit, options, workspaceId);
     }
   }
 
@@ -423,7 +426,7 @@ export async function applyEpisodeReranking(
         { error },
       );
       // Fallback to original multi-stage algorithm
-      return applyMultiFactorReranking(query, episodes, limit, options);
+      return applyMultiFactorReranking(query, episodes, limit, options, workspaceId);
     }
   }
 
@@ -431,7 +434,7 @@ export async function applyEpisodeReranking(
   logger.info(
     "RERANK_PROVIDER=none, using original multi-stage ranking algorithm",
   );
-  return applyMultiFactorReranking(query, episodes, limit, options);
+  return applyMultiFactorReranking(query, episodes, limit, options, workspaceId);
 }
 
 /**
@@ -442,6 +445,7 @@ async function validateEpisodesWithLLM(
   query: string,
   episodes: EpisodeWithProvenance[],
   maxEpisodes: number = 20,
+  workspaceId?: string,
 ): Promise<EpisodeWithProvenance[]> {
   const prompt = `Given user query, validate which episodes are truly relevant.
 
@@ -504,7 +508,7 @@ If NO episodes are relevant to the query, return:
       "low",
       "search-rerank",
       undefined,
-      undefined,
+      workspaceId,
       "search",
     );
 
@@ -544,6 +548,7 @@ async function validateEpisodesWithLLMInBatches(
   query: string,
   episodes: EpisodeWithProvenance[],
   maxEpisodes: number = 20,
+  workspaceId?: string,
 ): Promise<EpisodeWithProvenance[]> {
   const BATCH_SIZE = 10;
 
@@ -569,7 +574,7 @@ async function validateEpisodesWithLLMInBatches(
   // Process all batches in parallel
   const batchResults = await Promise.all(
     batches.map((batch, batchIndex) =>
-      validateEpisodesWithLLM(query, batch, batch.length).then((result) => {
+      validateEpisodesWithLLM(query, batch, batch.length, workspaceId).then((result) => {
         logger.info(
           `Batch ${batchIndex + 1}/${batches.length} completed: ${result.length}/${batch.length} episodes validated`,
         );


### PR DESCRIPTION
## Summary

Follow-up audit after PR #946: found one more place where a real `workspaceId` was available at the outer call site but got dropped by an inner helper on the way to `makeModelCall`.

`services/search/rerank.ts::validateEpisodesWithLLM` calls `makeModelCall(..., undefined, "search")` — position 8 (workspaceId) is hardcoded `undefined`. When `RERANK_PROVIDER=none`, `applyMultiFactorReranking` runs LLM validation on borderline-confidence search hits; without the workspaceId the resolver skips workspace BYOK lookup and falls back to `env.OPENAI_API_KEY`, which is empty for subscription-proxy self-hosts. Mastra then throws `Could not find API key process.env.OPENAI_API_KEY for model id openai/<model>` and reranking silently degrades to returning the input list unfiltered.

`workspaceId` is already in scope at `services/search.server.ts::search` where `applyEpisodeReranking` is called. Threaded through 4 hops:

```
applyEpisodeReranking(query, episodes, config, options, workspaceId)
  → applyMultiFactorReranking(query, episodes, limit, options, workspaceId)
    → validateEpisodesWithLLMInBatches(query, episodes, maxEpisodes, workspaceId)
      → validateEpisodesWithLLM(query, episodes, maxEpisodes, workspaceId)
        → makeModelCall(..., workspaceId, "search")
```

## Audit results

Complete sweep of `makeModelCall` / `makeStructuredModelCall` callsites for the same class of bug (workspaceId available in scope, silently dropped):

| Callsite | Status |
|---|---|
| `session-compaction.logic.ts:234` | fixed in PR #946 |
| `search/rerank.ts:497` (via `validateEpisodesWithLLM`) | **this PR** |
| All other callsites (`title-generation`, `graph-resolution`, `label-assignment`, `aspect-resolution`, `contact-summary`, `agent/memory`, `knowledgeGraph` normalization + extract/reflect/classify, `search-v2/router`, `create-title`, `recurrence`, `description-update`, `integration-operations`, `batch.server`, `onboarding.suggestions`) | already forward `workspaceId` correctly |

Separately noted (out of scope for this fix, worth its own thread): `resolveModelString(useCase, complexity)` is called from ~14 places (`web-explorer`, `skill-tools`, `decision`, `deep-search`, `skills.generate`, `onboarding.server`, `personality.server`, `summarize.server`, `aspect-persona-generation`, `persona-llm-placement`, `batch.server`, `batch/providers/openai`) without a workspaceId. The resulting `createAgent(modelString)` (no apiKey option) always uses env keys and can't leverage workspace BYOK. Not a silent-drop bug — it's a design gap where BYOK simply isn't wired into those paths.

## Test plan

- [ ] Boot a self-hosted container against a CLIProxyAPI subscription proxy (`OPENAI_API_KEY=""`, workspace openai BYOK with base URL). Run a memory search query that surfaces borderline-confidence results.
- [ ] Confirm the outbound rerank-validation request lands on the proxy (not `api.openai.com`) and no `Could not find API key process.env.OPENAI_API_KEY` in worker logs.
- [ ] Verify search results are filtered by LLM validation (not just passed through raw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)