### PR TITLE
feat(cliproxy): publish redplanethq/cliproxy image seeded via env vars

### DIFF
--- a/.github/workflows/build-cliproxy-image.yml
+++ b/.github/workflows/build-cliproxy-image.yml
@@ -1,0 +1,61 @@
+name: Build CLIProxy Image
+
+# Publishes redplanethq/cliproxy — a thin wrapper around eceasy/cli-proxy-api
+# that seeds OAuth JSONs from CLIPROXY_AUTH_<name>_B64 env vars, so you can
+# deploy to Railway/Fly/etc. without running the interactive --*-login flow
+# inside the container.
+#
+# Triggers:
+#   - Tag `cliproxy-<version>` (e.g. cliproxy-0.1.0) → :<version>
+#   - Push to main touching hosting/cliproxy/**       → :latest
+#   - Manual workflow_dispatch                        → :latest
+
+on:
+  push:
+    tags:
+      - "cliproxy-*"
+    branches:
+      - main
+    paths:
+      - "hosting/cliproxy/**"
+      - ".github/workflows/build-cliproxy-image.yml"
+  workflow_dispatch:
+
+jobs:
+  build-cliproxy:
+    runs-on: [self-hosted, linux, x64, aws, spot]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      # Strip the `cliproxy-` prefix (cliproxy-0.1.0 → 0.1.0). For non-tag
+      # events (main push / workflow_dispatch) we publish `latest` only.
+      - name: Compute image tags
+        id: meta
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME#cliproxy-}"
+            echo "tags=redplanethq/cliproxy:${version},redplanethq/cliproxy:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=redplanethq/cliproxy:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and Push CLIProxy Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./hosting/cliproxy
+          file: ./hosting/cliproxy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=redplanethq/cliproxy:buildcache
+          cache-to: type=registry,ref=redplanethq/cliproxy:buildcache,mode=max

--- a/hosting/cliproxy/DEPLOY.md
+++ b/hosting/cliproxy/DEPLOY.md
@@ -1,0 +1,117 @@
+# Deploying `redplanethq/cliproxy` (OAuth, headless)
+
+This directory publishes a wrapper image around
+[`eceasy/cli-proxy-api`](https://github.com/router-for-me/CLIProxyAPI) that lets
+you seed OAuth tokens through env vars, so the container boots
+pre-authenticated on Railway / Fly / a plain VPS — no interactive
+`--*-login` step inside the container, no SSH tunnels.
+
+Everything here uses the **OAuth subscription** path (Claude Max / ChatGPT
+Plus / Codex / Gemini). No API keys involved.
+
+> ⚠ Same ToS caveat as `docker-compose.yaml`: subscription plans are licensed
+> for interactive use. Personal self-host is fine; serving other users can get
+> your OAuth tokens revoked.
+
+## 1. Log in locally, once per subscription
+
+Boot the upstream image locally (this repo's `docker-compose.yaml` already
+wires up the OAuth callback ports on `127.0.0.1`) and run each login:
+
+```bash
+docker compose -f hosting/cliproxy/docker-compose.yaml up -d
+
+docker compose exec cli-proxy-api \
+  /CLIProxyAPI/CLIProxyAPI -no-browser --claude-login
+# repeat for --codex-login, --gemini-login, --qwen-login, --iflow-login
+```
+
+Each login writes one JSON file to `/root/.cli-proxy-api/` inside the
+container, named `<provider>-<email>.json`. That file holds the OAuth
+`access_token` + `refresh_token`; cliproxy rotates the access token
+automatically as long as the refresh token stays valid.
+
+## 2. Base64 each auth JSON
+
+Pull the files out and encode them:
+
+```bash
+docker exec cli-proxy-api sh -c 'cat /root/.cli-proxy-api/claude-you@example.com.json' \
+  | base64 | tr -d '\n'
+```
+
+Do this once per subscription you want to expose in the deployment.
+
+## 3. Set env vars on your host
+
+Convention: `CLIPROXY_AUTH_<name>_B64` → decoded to
+`/root/.cli-proxy-api/<name>.json` at container startup. The `<name>` is a
+label you pick; it just needs to be a valid env var suffix and unique per
+account.
+
+Example Railway / Fly / docker env vars:
+
+```
+CLIPROXY_AUTH_claude_B64=eyJpZF90b2tlbiI6...
+CLIPROXY_AUTH_codex_B64=eyJhY2Nlc3Nfd...
+CLIPROXY_AUTH_gemini_B64=...
+```
+
+## 4. Deploy the image
+
+The workflow at `.github/workflows/build-cliproxy-image.yml` publishes:
+
+- `redplanethq/cliproxy:latest` — on every push to `main` that touches
+  `hosting/cliproxy/**`
+- `redplanethq/cliproxy:<version>` — when you push a
+  `cliproxy-<version>` git tag (e.g. `cliproxy-0.1.0` → `:0.1.0`)
+
+### Railway
+
+- New service → **Deploy from Docker image** → `redplanethq/cliproxy:latest`
+- **Port**: `8317` (Railway assigns a public HTTPS URL)
+- **Volume** (recommended): mount at `/root/.cli-proxy-api` so refreshed
+  access tokens survive restarts. The entrypoint only seeds files that don't
+  already exist, so the volume is the source of truth after first boot.
+- **Env vars**: `CLIPROXY_AUTH_*_B64` plus rotate the `api-keys` value in
+  `config.yaml` before shipping (see below).
+
+### Anywhere else
+
+Same shape — mount a volume at `/root/.cli-proxy-api`, set the env vars,
+expose port `8317`.
+
+## 5. Wire into CORE
+
+Workspace Settings → Models → BYOK for the OpenAI provider:
+
+- **Base URL**: `https://<your-host>/v1`
+- **API key**: the value from `api-keys:` in `config.yaml`
+
+Then set the workspace model with the `openai/` prefix to route through the
+proxy, e.g. `openai/claude-sonnet-4-6`.
+
+## Seed semantics — read this once
+
+The entrypoint's rule: **env vars are a first-boot seed, not the source of
+truth.** For each `CLIPROXY_AUTH_<name>_B64`:
+
+- If `/root/.cli-proxy-api/<name>.json` already exists → skip (respect the
+  refreshed copy on the volume)
+- If it doesn't exist → decode the base64 and write it
+
+This matters because cliproxy rotates the access token on every refresh and
+writes the new value to disk. Without a volume, that refreshed state is lost
+on restart and you fall back to the (still-valid) seed. With a volume, the
+seed is used exactly once — on the first boot after you add a new
+subscription.
+
+If you ever need to force-reseed (e.g. after re-doing an OAuth login on your
+laptop and pushing a new base64), delete the file on the volume first, then
+restart.
+
+## Rebuilding after upstream changes
+
+The Dockerfile pins `eceasy/cli-proxy-api:latest`. Kick the workflow via
+**Actions → Build CLIProxy Image → Run workflow** to pull the newest upstream
+and republish `redplanethq/cliproxy:latest`.

--- a/hosting/cliproxy/Dockerfile
+++ b/hosting/cliproxy/Dockerfile
@@ -1,0 +1,16 @@
+# redplanethq/cliproxy — thin wrapper around eceasy/cli-proxy-api that lets you
+# seed OAuth tokens via env vars, so the container can boot straight into a
+# pre-authenticated state on Railway / Fly / any host without an interactive
+# --*-login step.
+#
+# The entrypoint decodes CLIPROXY_AUTH_<name>_B64 env vars into
+# /root/.cli-proxy-api/<name>.json, then execs the upstream binary. See
+# entrypoint.sh for the full contract.
+
+FROM eceasy/cli-proxy-api:latest
+
+COPY config.yaml /CLIProxyAPI/config.yaml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/hosting/cliproxy/docker-compose.yaml
+++ b/hosting/cliproxy/docker-compose.yaml
@@ -2,6 +2,13 @@
 # Grok subscription behind a single OpenAI-compatible endpoint, then plug it
 # into CORE as a workspace BYOK provider.
 #
+# This compose file is for LOCAL use — running the proxy on your laptop and
+# doing the OAuth login flow interactively. For hosted deployments (Railway,
+# Fly, VPS) where you want to seed OAuth tokens via env vars instead of
+# logging in inside the container, see ./DEPLOY.md — that path uses the
+# redplanethq/cliproxy wrapper image (built by
+# .github/workflows/build-cliproxy-image.yml).
+#
 # ⚠  Terms of Service — subscription plans (Pro / Max / Plus / Codex) are
 #    licensed for interactive use. Using them as a headless backend for a
 #    hosted service is a gray area; providers can rate-limit or revoke

--- a/hosting/cliproxy/entrypoint.sh
+++ b/hosting/cliproxy/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Seed CLIProxyAPI's auth-dir from env vars, then launch the server.
+#
+# Convention:
+#   CLIPROXY_AUTH_<name>_B64=<base64-encoded auth JSON>
+#     → decoded to /root/.cli-proxy-api/<name>.json
+#
+# Example (locally): pull the JSONs the login flow wrote, base64 them, and
+# paste into your host's env vars:
+#   base64 -i ~/.cli-proxy-api/claude-you@example.com.json
+#   → CLIPROXY_AUTH_claude_B64=<that string>
+#
+# CLIProxyAPI walks the whole auth-dir and loads every *.json file, so the
+# suffix you pick (`claude`, `codex_work`, `gemini_personal`) is just a label
+# — pick whatever you'll recognize later.
+#
+# Seed-only, never overwrite: if the file already exists on disk (i.e. the
+# volume kept a refreshed copy from a previous run), we leave it alone. Access
+# tokens rotate on every refresh, so blindly rewriting the env-var version
+# would clobber good state. Env vars are a first-boot seed, not the source
+# of truth.
+
+set -e
+
+AUTH_DIR="${CLIPROXY_AUTH_DIR:-/root/.cli-proxy-api}"
+mkdir -p "$AUTH_DIR"
+chmod 700 "$AUTH_DIR"
+
+for var in $(env | awk -F= '/^CLIPROXY_AUTH_.*_B64=/ {print $1}'); do
+    name=$(echo "$var" | sed -e 's/^CLIPROXY_AUTH_//' -e 's/_B64$//')
+    target="$AUTH_DIR/$name.json"
+
+    if [ -s "$target" ]; then
+        echo "[entrypoint] $target already present, skipping seed from \$$var"
+        continue
+    fi
+
+    value=$(eval "printf '%s' \"\$$var\"")
+    if [ -z "$value" ]; then
+        continue
+    fi
+
+    if ! printf '%s' "$value" | base64 -d > "$target" 2>/dev/null; then
+        echo "[entrypoint] ERROR: \$$var is not valid base64" >&2
+        rm -f "$target"
+        exit 1
+    fi
+
+    chmod 600 "$target"
+    echo "[entrypoint] seeded $target from \$$var"
+done
+
+exec /CLIProxyAPI/CLIProxyAPI --config /CLIProxyAPI/config.yaml "$@"


### PR DESCRIPTION
## Summary

- Adds `hosting/cliproxy/Dockerfile` + `entrypoint.sh` that wrap `eceasy/cli-proxy-api` and seed OAuth JSONs from `CLIPROXY_AUTH_<name>_B64` env vars into `/root/.cli-proxy-api/<name>.json` at container startup — no interactive `--*-login` inside the container.
- Adds `.github/workflows/build-cliproxy-image.yml` publishing multi-arch (amd64+arm64) images to `redplanethq/cliproxy` — `:latest` on main pushes touching `hosting/cliproxy/**`, `:<version>` on `cliproxy-<version>` tags.
- Adds `hosting/cliproxy/DEPLOY.md` documenting the local-login → base64 → Railway/Fly/VPS flow.

## How it works

1. Log in locally, once per subscription: `docker compose exec cli-proxy-api /CLIProxyAPI/CLIProxyAPI -no-browser --claude-login` (repeats for `--codex-login`, `--gemini-login`, etc.).
2. Pull each JSON out of `/root/.cli-proxy-api/`, `base64` it, paste into your host's env vars as `CLIPROXY_AUTH_<label>_B64`.
3. Deploy `redplanethq/cliproxy:latest` with a volume mounted at `/root/.cli-proxy-api` — the entrypoint seeds files only if they don't already exist, so refreshed access tokens on the volume are preserved across restarts.

Pure OAuth path (subscription-based). No API keys involved.

## Test plan

- [x] Shell syntax check on `entrypoint.sh` (`sh -n`)
- [x] Dry-run entrypoint with two stub JSONs → confirmed both seeded on first run and skipped on second run
- [ ] Manual: trigger the workflow via `workflow_dispatch`, verify `redplanethq/cliproxy:latest` lands on Docker Hub for both amd64 and arm64
- [ ] Manual: deploy to Railway with real base64'd Claude auth, confirm `/v1` endpoint answers with the subscription's model list
- [ ] Manual: restart the container and confirm auth files on the volume are NOT overwritten by the env-var seed

## Notes

- Requires existing `DOCKER_USERNAME` / `DOCKER_PASSWORD` GitHub secrets (same as `build-docker-image.yml`).
- ToS caveat carried over from `docker-compose.yaml`: subscription plans are licensed for interactive use — personal self-host is fine, serving other users is where OAuth revocations start.
- Local `docker-compose.yaml` unchanged in behavior; only the header comment now points at `DEPLOY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)