### PR TITLE
feat(gateway): bundle cliproxy inside gateway with single-port nginx routing

### DIFF
--- a/docker/Dockerfile.gateway
+++ b/docker/Dockerfile.gateway
@@ -7,8 +7,14 @@
 # any Docker host. For laptop installs use `npm install -g @redplanethq/corebrain`
 # instead — this image exists to make the hosted-gateway deploy one command.
 #
+# Also bundles CLIProxyAPI (cliproxy) behind the same port — accessible at
+# /llmproxy/v1 — so you can use a single Railway service for both the gateway
+# and an OpenAI-compatible proxy for Claude Max / ChatGPT / Codex / Gemini
+# subscriptions. Configure CORE's BYOK base URL as:
+#   https://<gateway-host>/llmproxy/v1
+#
 # Build:
-#   docker build -f packages/cli/docker/Dockerfile -t corebrain-gateway .
+#   docker build -f docker/Dockerfile.gateway -t corebrain-gateway .
 # Run:
 #   docker run --rm -it \
 #     -p 7787:7787 \
@@ -20,13 +26,19 @@
 #     -e GITHUB_TOKEN=...                         # optional; for `git clone` of private repos \
 #     -e ANTHROPIC_API_KEY=...                    # optional; lets claude skip OAuth login \
 #     -e OPENAI_API_KEY=...                       # optional; lets codex skip OAuth login \
-#     -v corebrain-home:/home/corebrain                 # persist gateway id, agent login + session state, chromium cache \
+#     -e CLIPROXY_API_KEY=...                     # optional; auto-generated if absent \
+#     -e CLIPROXY_AUTH_CLAUDE_B64=...             # optional; base64 of claude auth JSON \
+#     -e CLIPROXY_OVERRIDE_CONFIG_B64=...         # optional; base64 of full config.yaml \
+#     -v corebrain-home:/home/corebrain                 # persist gateway state + cliproxy auth tokens \
 #     -v corebrain-workspace:/app                       # persist cloned repos and worktree state \
 #     corebrain-gateway
 #
-# On first run with no COREBRAIN_GATEWAY_SECURITY_KEY env var the gateway
-# generates one and prints it to stdout. Copy it from `docker logs` and paste
-# (along with the public URL) into the webapp's New Gateway dialog.
+# On first run with no COREBRAIN_GATEWAY_SECURITY_KEY the gateway generates one
+# and prints it to stdout. On first run with no CLIPROXY_API_KEY cliproxy
+# generates one the same way. Copy both from `docker logs`.
+
+# Extract the CLIProxyAPI binary from the upstream image.
+FROM eceasy/cli-proxy-api:latest AS cliproxy-upstream
 
 FROM --platform=linux/amd64 node:22-slim
 
@@ -40,6 +52,7 @@ RUN apt-get update \
         python3 \
         build-essential \
         openssh-client \
+        nginx \
     && rm -rf /var/lib/apt/lists/*
 
 # Coding agents — shipped so every gateway has claude + codex available out
@@ -61,6 +74,15 @@ ARG GATEWAY_GID=1001
 RUN groupadd --gid "${GATEWAY_GID}" corebrain \
     && useradd --uid "${GATEWAY_UID}" --gid "${GATEWAY_GID}" \
         --create-home --shell /bin/bash corebrain
+
+# CLIProxyAPI binary — copied from the upstream image so cliproxy runs inside
+# the same container and is reachable at /llmproxy/v1 through nginx.
+COPY --from=cliproxy-upstream /CLIProxyAPI/CLIProxyAPI /CLIProxyAPI/CLIProxyAPI
+
+# nginx routing — single port (7787) proxies /llmproxy/* to cliproxy (:8317)
+# and everything else to the gateway (:7788).
+COPY docker/nginx-gateway.conf /etc/nginx/conf.d/gateway.conf
+RUN rm -f /etc/nginx/sites-enabled/default
 
 # Browser — Brave (Chromium-based, so Playwright's `chromium.launchPersistentContext`
 # drives it via `executablePath`). We deliberately skip Playwright's bundled
@@ -101,8 +123,10 @@ ENV COREBRAIN_SLOT_FILES=false
 RUN mkdir -p /home/corebrain/.corebrain \
     && chown -R corebrain:corebrain /home/corebrain
 
-# Ensure the gateway's manifest port is the documented default. Users can
-# override with -p <host>:7787 or -e COREBRAIN_GATEWAY_HTTP_PORT=<port>.
+# nginx listens on 7787 (external). Gateway listens on 7788 (internal only).
+# COREBRAIN_GATEWAY_HTTP_PORT tells the gateway daemon which port to bind;
+# nginx is the public entry point and routes traffic to it.
+ENV COREBRAIN_GATEWAY_HTTP_PORT=7788
 EXPOSE 7787
 
 WORKDIR /app

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -58,6 +58,57 @@ if [ "$(id -u)" = "0" ]; then
     chown -R corebrain:corebrain /app /home/corebrain 2>/dev/null || true
   fi
 
+  # ── cliproxy setup ──────────────────────────────────────────────────────
+  # CLIProxyAPI runs as root (its auth-dir is /root/.cli-proxy-api by default;
+  # we redirect it to the corebrain-home volume so tokens survive restarts).
+  CLIPROXY_AUTH_DIR="/home/corebrain/.cli-proxy-api"
+  mkdir -p "$CLIPROXY_AUTH_DIR"
+  chmod 700 "$CLIPROXY_AUTH_DIR"
+
+  # Config: full override takes priority; otherwise generate from env vars.
+  if [ -n "${CLIPROXY_OVERRIDE_CONFIG_B64:-}" ]; then
+    printf '%s' "$CLIPROXY_OVERRIDE_CONFIG_B64" | base64 -d > /CLIProxyAPI/config.yaml
+    echo "[cliproxy] using config from CLIPROXY_OVERRIDE_CONFIG_B64"
+  else
+    # Resolve (or auto-generate) the API key.
+    _cliproxy_key="${CLIPROXY_API_KEY:-}"
+    if [ -z "$_cliproxy_key" ]; then
+      _cliproxy_key=$(head -c 32 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 32 || true)
+      echo "[cliproxy] generated API key: $_cliproxy_key"
+      echo "[cliproxy] set CLIPROXY_API_KEY=$_cliproxy_key to pin it across restarts"
+    fi
+    printf 'host: 0.0.0.0\nport: 8317\nauth-dir: %s\napi-keys:\n  - %s\n' \
+      "$CLIPROXY_AUTH_DIR" "$_cliproxy_key" > /CLIProxyAPI/config.yaml
+    unset _cliproxy_key
+  fi
+
+  # Seed per-provider auth JSONs from CLIPROXY_AUTH_<name>_B64 env vars.
+  # Seed-only: if the file already exists (volume has a refreshed token), skip.
+  for _var in $(env | awk -F= '/^CLIPROXY_AUTH_.*_B64=/{print $1}'); do
+    _name=$(printf '%s' "$_var" | sed -e 's/^CLIPROXY_AUTH_//' -e 's/_B64$//')
+    _target="$CLIPROXY_AUTH_DIR/$_name.json"
+    if [ -s "$_target" ]; then
+      echo "[cliproxy] $_target already present, skipping seed from \$$_var"
+      continue
+    fi
+    _val=$(eval "printf '%s' \"\$$_var\"")
+    if [ -z "$_val" ]; then continue; fi
+    if ! printf '%s' "$_val" | base64 -d > "$_target" 2>/dev/null; then
+      echo "[cliproxy] ERROR: \$$_var is not valid base64" >&2
+      rm -f "$_target"; continue
+    fi
+    chmod 600 "$_target"
+    echo "[cliproxy] seeded $_target from \$$_var"
+  done
+  unset _var _name _target _val
+
+  # Start cliproxy in the background. Logs flow to container stdout/stderr.
+  /CLIProxyAPI/CLIProxyAPI --config /CLIProxyAPI/config.yaml &
+
+  # Start nginx in the background. It proxies :7787 → gateway (:7788) or
+  # cliproxy (:8317) based on the /llmproxy prefix.
+  nginx -g 'daemon off;' &
+
   # Re-exec this script as corebrain. `runuser` (util-linux) is in the base
   # node:22-slim image and doesn't require PAM, unlike `su`.
   exec runuser -u corebrain -- "$0" "$@"

--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -1,0 +1,43 @@
+# nginx reverse proxy — single external port (7787) for gateway + cliproxy.
+#
+# Routing:
+#   /llmproxy/*  → cliproxy  (CLIProxyAPI on :8317, prefix stripped)
+#   /*           → gateway   (CoreBrain gateway on :7788)
+#
+# BYOK base URL to configure in CORE:  https://<gateway-host>/llmproxy/v1
+#
+# This file is included inside nginx's http{} block via conf.d/, so map
+# directives are valid here.
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 7787;
+
+    # CLIProxy — strip /llmproxy prefix, forward remainder to cliproxy.
+    # e.g. /llmproxy/v1/chat/completions → http://127.0.0.1:8317/v1/chat/completions
+    location /llmproxy/ {
+        proxy_pass         http://127.0.0.1:8317/;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        client_max_body_size 50m;
+    }
+
+    # Gateway — manifest, healthz, verify, api/*
+    location / {
+        proxy_pass         http://127.0.0.1:7788;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        client_max_body_size 50m;
+    }
+}

--- a/hosting/gateway/docker-compose.yaml
+++ b/hosting/gateway/docker-compose.yaml
@@ -68,7 +68,33 @@ services:
       # shell — flip to `true` if you want both tool groups exposed.
       # The same pattern works for BROWSER / CODING / EXEC.
       - COREBRAIN_SLOT_FILES=${COREBRAIN_SLOT_FILES:-false}
+
+      # ── CLIProxy (built-in LLM subscription proxy) ─────────────────
+      # The gateway bundles CLIProxyAPI and exposes it at /llmproxy/v1.
+      # Set CORE's BYOK base URL to: https://<gateway-host>/llmproxy/v1
+      #
+      # CLIPROXY_API_KEY: the bearer token CORE sends to /llmproxy/v1.
+      #   Leave unset on first boot — the container generates one and
+      #   prints it to logs. Pin it here once you have it.
+      - CLIPROXY_API_KEY=${CLIPROXY_API_KEY:-}
+      #
+      # CLIPROXY_AUTH_<name>_B64: base64-encoded OAuth auth JSON for each
+      #   subscription. Obtain by running the login flow locally:
+      #     docker compose exec corebrain-gateway \
+      #       /CLIProxyAPI/CLIProxyAPI -no-browser --claude-login
+      #   then: base64 -i /root/.cli-proxy-api/<file>.json
+      #   (Also available: --codex-login, --gemini-login, --qwen-login.)
+      - CLIPROXY_AUTH_CLAUDE_B64=${CLIPROXY_AUTH_CLAUDE_B64:-}
+      - CLIPROXY_AUTH_CODEX_B64=${CLIPROXY_AUTH_CODEX_B64:-}
+      - CLIPROXY_AUTH_GEMINI_B64=${CLIPROXY_AUTH_GEMINI_B64:-}
+      #
+      # CLIPROXY_OVERRIDE_CONFIG_B64: base64 of a full config.yaml. When
+      #   set, it completely replaces the generated config (including
+      #   api-keys, port, auth-dir, remote-management, etc.).
+      - CLIPROXY_OVERRIDE_CONFIG_B64=${CLIPROXY_OVERRIDE_CONFIG_B64:-}
     ports:
+      # nginx listens on 7787 and routes internally to gateway (:7788)
+      # and cliproxy (:8317). Only this single port needs to be published.
       - "${COREBRAIN_GATEWAY_HTTP_PORT:-7787}:7787"
     volumes:
       - workspace:/app


### PR DESCRIPTION
## Summary

- Merges CLIProxyAPI into the `core-gateway` Docker image — no separate Railway service needed for cliproxy
- nginx listens on the single external port `:7787` and routes by path prefix: `/llmproxy/*` → cliproxy (`:8317`), everything else → gateway (`:7788`)
- Gateway moves to internal port `7788` via `COREBRAIN_GATEWAY_HTTP_PORT=7788`

## Changes

**`docker/Dockerfile.gateway`**
- Multi-stage build: pulls `CLIProxyAPI` binary from `eceasy/cli-proxy-api:latest`
- Adds `nginx` to apt deps; installs `nginx-gateway.conf`; removes default nginx site
- Sets `COREBRAIN_GATEWAY_HTTP_PORT=7788` so nginx owns the external port

**`docker/nginx-gateway.conf`** (new)
- `location /llmproxy/` → strips prefix, proxies to cliproxy on `:8317`
- `location /` → proxies to gateway on `:7788` with WebSocket upgrade support

**`docker/entrypoint.sh`** (root phase)
- Writes `/CLIProxyAPI/config.yaml`: uses `CLIPROXY_OVERRIDE_CONFIG_B64` (full base64 config) if set, otherwise generates from `CLIPROXY_API_KEY` (auto-generates + prints to logs if unset)
- Seeds `CLIPROXY_AUTH_<name>_B64` env vars → `/home/corebrain/.cli-proxy-api/*.json` (seed-only; respects refreshed tokens on volume)
- Auth dir is `/home/corebrain/.cli-proxy-api` so tokens persist on the existing `corebrain-home` volume
- Starts cliproxy and nginx in background before dropping to `corebrain` user

**`hosting/gateway/docker-compose.yaml`**
- Adds `CLIPROXY_API_KEY`, `CLIPROXY_AUTH_CLAUDE_B64`, `CLIPROXY_AUTH_CODEX_B64`, `CLIPROXY_AUTH_GEMINI_B64`, `CLIPROXY_OVERRIDE_CONFIG_B64` with inline docs

## Usage after deploy

Set CORE's BYOK base URL to:
```
https://<gateway-host>/llmproxy/v1
```
API key = value of `CLIPROXY_API_KEY` (printed to logs on first boot if not pinned).

## Test plan

- [ ] Build image locally: `docker build -f docker/Dockerfile.gateway -t corebrain-gateway .`
- [ ] Boot with no cliproxy env vars — confirm auto-generated API key printed to logs
- [ ] Boot with `CLIPROXY_API_KEY` set — confirm key is used in generated config
- [ ] Boot with `CLIPROXY_OVERRIDE_CONFIG_B64` set — confirm custom config written verbatim
- [ ] Boot with `CLIPROXY_AUTH_CLAUDE_B64` set — confirm auth JSON seeded under `/home/corebrain/.cli-proxy-api/`
- [ ] Confirm gateway routes (`/healthz`, `/manifest`) still work on port 7787
- [ ] Confirm `/llmproxy/v1/models` reaches cliproxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)