### PR TITLE
feat(onboarding): plan step + post-onboarding paywall

### DIFF
--- a/apps/webapp/app/components/conversation/conversation-view.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation-view.client.tsx
@@ -77,13 +77,13 @@ export function ConversationView({
   initialVoiceMode = false,
 }: ConversationViewProps) {
   const currentUser = useOptionalUser();
-  // Strict UI gate: disable the send when the visible balance is empty.
-  // We intentionally don't exempt BYOK here — the sidebar shows "0 credits"
-  // to BYOK workspaces the same way, and letting the button stay enabled
-  // there looks broken. Server-side gates keep the BYOK exemption so
-  // deductions stay correct.
+  // BYOK workspaces pay their own provider bills, so the credit balance
+  // is irrelevant to them — server-side hasCredits also bypasses BYOK,
+  // so disabling here would be a lie.
   const outOfCredits =
-    !!currentUser && (currentUser.availableCredits ?? 0) < 1;
+    !!currentUser &&
+    (currentUser.availableCredits ?? 0) < 1 &&
+    !currentUser.hasBYOK;
 
   // Local mirror of the loader-provided status — stays fresh across stop/
   // completion events without needing a route revalidation.

--- a/apps/webapp/app/components/conversation/conversation.client.tsx
+++ b/apps/webapp/app/components/conversation/conversation.client.tsx
@@ -82,8 +82,12 @@ export const ConversationNew = ({
   accentColor?: string;
 }) => {
   const currentUser = useOptionalUser();
+  // BYOK workspaces bypass the credit check server-side; mirror that here
+  // so the composer isn't disabled when their balance shows 0.
   const outOfCredits =
-    !!currentUser && (currentUser.availableCredits ?? 0) < 1;
+    !!currentUser &&
+    (currentUser.availableCredits ?? 0) < 1 &&
+    !currentUser.hasBYOK;
 
   const [content, setContent] = useState(defaultMessage ?? "");
   const [title, setTitle] = useState(defaultMessage ?? "");

--- a/apps/webapp/app/components/editor/conversation-popover.tsx
+++ b/apps/webapp/app/components/editor/conversation-popover.tsx
@@ -76,7 +76,9 @@ export function ConversationPopover({
   const open = !!conversationId && !!anchorRect;
   const currentUser = useOptionalUser();
   const outOfCredits =
-    !!currentUser && (currentUser.availableCredits ?? 0) < 1;
+    !!currentUser &&
+    (currentUser.availableCredits ?? 0) < 1 &&
+    !currentUser.hasBYOK;
   const [historyMessages, setHistoryMessages] = useState<UIMessage[]>([]);
   const [historyMeta, setHistoryMeta] = useState<Record<string, string>>({});
   const [loadingHistory, setLoadingHistory] = useState(false);

--- a/apps/webapp/app/components/layout/login-page-layout.tsx
+++ b/apps/webapp/app/components/layout/login-page-layout.tsx
@@ -1,4 +1,3 @@
-import Logo from "../logo/logo";
 
 export function LoginPageLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/webapp/app/components/onboarding/upgrade-required-modal.tsx
+++ b/apps/webapp/app/components/onboarding/upgrade-required-modal.tsx
@@ -1,0 +1,157 @@
+import { useFetcher } from "@remix-run/react";
+import { ArrowRight, ExternalLink } from "lucide-react";
+import { Dialog, DialogContent } from "~/components/ui/dialog";
+import { Button } from "~/components/ui/button";
+
+/**
+ * Blocks the /home surface for FREE users who haven't yet paid or set up
+ * BYOK. Non-dismissible — the app is unusable until they pick a path.
+ *
+ * Mirrors the visual language of the /onboarding/plan page so the two
+ * feel like one flow. Subscribe posts to /onboarding/plan (which returns
+ * a Stripe checkout URL and no-ops the already-set planStepComplete
+ * flag). BYOK is a plain link to the workspace models settings page.
+ */
+export function UpgradeRequiredModal() {
+  const fetcher = useFetcher<{ checkoutUrl?: string; error?: string }>();
+  const busy = fetcher.state !== "idle";
+
+  if (fetcher.data?.checkoutUrl) {
+    window.location.href = fetcher.data.checkoutUrl;
+  }
+
+  const subscribe = (planType: "PRO" | "MAX") => {
+    fetcher.submit(
+      { intent: "subscribe", planType },
+      { method: "POST", action: "/onboarding/plan" },
+    );
+  };
+
+  return (
+    <Dialog open onOpenChange={() => {}}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-4xl border-none bg-transparent p-0 shadow-none sm:max-w-4xl"
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <div className="rounded-2xl px-8 py-10 border-none">
+          <div className="flex flex-col gap-10">
+            <div className="mx-auto flex max-w-2xl flex-col items-center gap-3 text-center">
+
+              <h1 className="text-3xl font-semibold tracking-tight md:text-3xl">
+                power me up.
+              </h1>
+              <p className="text-muted-foreground text-base md:text-md">
+                to keep using the agent, subscribe to a CORE plan or bring
+                your own key from a provider you already pay for.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {/* CORE subscription — recommended */}
+              <div className="border-primary/40 bg-background-2 relative flex flex-col gap-6 overflow-hidden rounded-xl border-2 p-6">
+
+
+                <div className="flex flex-col gap-1">
+                  <h2 className="text-xl font-semibold">CORE subscription</h2>
+                  <p className="text-muted-foreground text-sm">
+                    managed cloud — models, gateway, credits, everything.
+                  </p>
+                </div>
+
+                <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+                  <li className="flex items-baseline gap-2">
+                    <span className="text-foreground w-8 font-medium">
+                      Pro
+                    </span>
+                    <span>10k credits/mo · $19</span>
+                  </li>
+                  <li className="flex items-baseline gap-2">
+                    <span className="text-foreground w-8 font-medium">
+                      Max
+                    </span>
+                    <span>100k credits/mo · $99</span>
+                  </li>
+                  <li className="flex items-baseline gap-2">
+                    <span className="text-foreground w-8" />
+                    <span>top up any time, credits never expire.</span>
+                  </li>
+                </ul>
+
+                <div className="mt-auto flex flex-col gap-2">
+                  <Button
+                    size="lg"
+                    onClick={() => subscribe("PRO")}
+                    disabled={busy}
+                    className="justify-between"
+                  >
+                    <span>Subscribe to Pro · $19/mo</span>
+                    <ArrowRight className="size-4" />
+                  </Button>
+                  <Button
+                    size="lg"
+                    variant="secondary"
+                    onClick={() => subscribe("MAX")}
+                    disabled={busy}
+                    className="justify-between"
+                  >
+                    <span>Subscribe to Max · $99/mo</span>
+                    <ArrowRight className="size-4" />
+                  </Button>
+                </div>
+              </div>
+
+              {/* BYOK */}
+              <div className="border-border bg-background-2 flex flex-col gap-6 rounded-xl border p-6">
+                <div className="flex flex-col gap-1">
+                  <h2 className="text-xl font-semibold">Bring your own key</h2>
+                  <p className="text-muted-foreground text-sm">
+                    point me at a provider you already pay for. you handle
+                    the bill, i skip CORE credits entirely.
+                  </p>
+                </div>
+
+                <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+                  <li>
+                    • OpenAI, Anthropic, OpenRouter, Ollama, Azure, and more.
+                  </li>
+                  <li>
+                    • already on Claude Max or ChatGPT with Codex?{" "}
+                    <a
+                      href="https://docs.getcore.me/gateway/subscription-proxy"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary inline-flex items-center gap-1 underline underline-offset-2"
+                    >
+                      reuse your subscription
+                      <ExternalLink className="size-3" />
+                    </a>{" "}
+                    — no separate API key.
+                  </li>
+                  <li>• unlimited use — no CORE credits touched.</li>
+                </ul>
+
+                <div className="mt-auto">
+                  <Button
+                    size="lg"
+                    variant="secondary"
+                    disabled={busy}
+                    onClick={() => {
+                      window.location.href = "/settings/workspace/models";
+                    }}
+                    className="w-full justify-between"
+                  >
+                    <span>Set up my own key</span>
+                    <ArrowRight className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/webapp/app/components/sidebar/app-sidebar.tsx
+++ b/apps/webapp/app/components/sidebar/app-sidebar.tsx
@@ -207,24 +207,26 @@ export function AppSidebar({
         <SidebarFooter className="flex flex-col gap-1 px-2 pb-0">
           <IngestionStatus />
 
-          {user.availableCredits < 1 && (
+          {!user.hasBYOK && user.availableCredits < 1 && (
             <OutOfCreditsCard
               agentName={agentName}
               onUpgrade={() => navigate("/settings/billing")}
             />
           )}
 
-          <div className="flex justify-end">
-            <Button
-              variant="ghost"
-              className="w-fit"
-              onClick={() => {
-                navigate("/settings/billing");
-              }}
-            >
-              <div>{user.availableCredits} credits</div>
-            </Button>
-          </div>
+          {!user.hasBYOK && (
+            <div className="flex justify-end">
+              <Button
+                variant="ghost"
+                className="w-fit"
+                onClick={() => {
+                  navigate("/settings/billing");
+                }}
+              >
+                <div>{user.availableCredits} credits</div>
+              </Button>
+            </div>
+          )}
         </SidebarFooter>
       </Sidebar>
 

--- a/apps/webapp/app/config/billing.server.ts
+++ b/apps/webapp/app/config/billing.server.ts
@@ -21,7 +21,7 @@ export const BILLING_CONFIG = {
   plans: {
     free: {
       name: "Free",
-      monthlyCredits: parseInt(process.env.FREE_PLAN_CREDITS || "200", 10),
+      monthlyCredits: parseInt(process.env.FREE_PLAN_CREDITS || "500", 10),
       features: {
         episodesPerMonth: 200,
         searchesPerMonth: 200,

--- a/apps/webapp/app/routes/_index.tsx
+++ b/apps/webapp/app/routes/_index.tsx
@@ -16,9 +16,14 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   if (!user.onboardingComplete) {
     return redirect(onboardingPath());
-  } else {
-    return redirect("/home/daily");
   }
+
+  const meta = (user.metadata ?? {}) as Record<string, unknown>;
+  if (!meta.planStepComplete) {
+    return redirect("/onboarding/plan");
+  }
+
+  return redirect("/home/daily");
 };
 
 export default function Index() {

--- a/apps/webapp/app/routes/home.tsx
+++ b/apps/webapp/app/routes/home.tsx
@@ -17,6 +17,9 @@ import { onboardingPath } from "~/utils/pathBuilder";
 import { getConversationSources } from "~/services/conversation.server";
 import { prisma } from "~/db.server";
 import { SetButlerNameModal } from "~/components/onboarding/set-butler-name-modal";
+import { UpgradeRequiredModal } from "~/components/onboarding/upgrade-required-modal";
+import { isBillingEnabled } from "~/config/billing.server";
+import { isWorkspaceBYOK } from "~/services/byok.server";
 import { CollabSocketProvider } from "~/components/editor/collab-socket-context";
 import React from "react";
 import { getIntegrationAccounts } from "~/services/integrationAccount.server";
@@ -96,23 +99,47 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   if (!user.onboardingComplete) {
     return redirect(onboardingPath());
-  } else {
-    return typedjson(
-      {
-        user,
-        workspace,
-        conversationSources,
-        models,
-        integrationAccountMap,
-        integrationFrontendMap,
-      },
-      {
-        headers: {
-          "Set-Cookie": await commitSession(await clearRedirectTo(request)),
-        },
-      },
-    );
   }
+
+  const userMeta = (user.metadata ?? {}) as Record<string, unknown>;
+  if (!userMeta.planStepComplete) {
+    return redirect("/onboarding/plan");
+  }
+
+  // Hard paywall for FREE users who haven't set up BYOK. The plan step
+  // marks them complete on click but doesn't guarantee they finished
+  // Stripe / added a key — this catches those drop-offs on every /home hit.
+  let needsUpgrade = false;
+  if (isBillingEnabled() && workspace.id) {
+    const [subscription, hasByok] = await Promise.all([
+      prisma.subscription.findUnique({
+        where: { workspaceId: workspace.id },
+        select: { planType: true },
+      }),
+      isWorkspaceBYOK(workspace.id),
+    ]);
+
+
+    const planType = subscription?.planType ?? "FREE";
+    needsUpgrade = planType === "FREE" && !hasByok;
+  }
+
+  return typedjson(
+    {
+      user,
+      workspace,
+      conversationSources,
+      models,
+      integrationAccountMap,
+      integrationFrontendMap,
+      needsUpgrade,
+    },
+    {
+      headers: {
+        "Set-Cookie": await commitSession(await clearRedirectTo(request)),
+      },
+    },
+  );
 };
 
 function HomeInner({
@@ -122,6 +149,7 @@ function HomeInner({
   agentName,
   accentColor,
   needsButlerName,
+  needsUpgrade,
   models,
   integrationAccountMap,
 }: {
@@ -131,6 +159,7 @@ function HomeInner({
   agentName: string;
   accentColor: string;
   needsButlerName: boolean;
+  needsUpgrade: boolean;
   models: LLMModel[];
   integrationAccountMap: Record<string, string>;
 }) {
@@ -153,6 +182,7 @@ function HomeInner({
           workspaceId={workspace.id}
         />
       )}
+      {needsUpgrade && <UpgradeRequiredModal />}
       <AppSidebar
         conversationSources={conversationSources}
         widgetsEnabled={!!meta.widgetsEnabled}
@@ -185,8 +215,13 @@ function HomeInner({
 }
 
 export default function Home() {
-  const { conversationSources, workspace, models, integrationAccountMap } =
-    useLoaderData<typeof loader>() as any;
+  const {
+    conversationSources,
+    workspace,
+    models,
+    integrationAccountMap,
+    needsUpgrade,
+  } = useLoaderData<typeof loader>() as any;
   const meta = (workspace?.metadata ?? {}) as Record<string, unknown>;
   const needsButlerName = !meta.onboardingV2Complete;
   const accentColor = (meta.accentColor as string) || "#c87844";
@@ -202,6 +237,7 @@ export default function Home() {
           agentName={agentName}
           accentColor={accentColor}
           needsButlerName={needsButlerName}
+          needsUpgrade={!!needsUpgrade}
           models={models}
           integrationAccountMap={integrationAccountMap}
         />

--- a/apps/webapp/app/routes/login._index.tsx
+++ b/apps/webapp/app/routes/login._index.tsx
@@ -14,7 +14,7 @@ import { env } from "~/env.server";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui";
 import { Mail, Shield, Lock } from "lucide-react";
-import Logo from "~/components/logo/logo";
+import { SamAvatar } from "~/components/ui/sam-avatar";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await getUserId(request);
@@ -53,7 +53,7 @@ function SecurityScreen({ onContinue }: { onContinue: () => void }) {
       <Card className="w-full max-w-[450px] rounded-md bg-transparent p-3">
         <CardHeader className="flex flex-col items-center">
           <div className="mb-4 flex justify-center">
-            <Logo size={60} />
+            <SamAvatar size={64} trackCursor />
           </div>
           <CardTitle className="text-3xl font-normal">Privacy</CardTitle>
         </CardHeader>
@@ -184,7 +184,7 @@ function DesktopLoginPage() {
       <Card className="w-full max-w-[350px] rounded-md bg-transparent p-3">
         <CardHeader className="flex flex-col items-center">
           <div className="mb-4 flex justify-center">
-            <Logo size={60} />
+            <SamAvatar size={64} trackCursor />
           </div>
           <CardTitle className="text-2xl font-normal">
             Welcome to CORE
@@ -277,7 +277,7 @@ export default function LoginPage() {
           <Fieldset className="w-full">
             <div className="flex flex-col gap-y-2">
               <div className="mb-10 flex justify-center">
-                <Logo size={60} />
+                <SamAvatar size={64} trackCursor />
               </div>
 
               <p className="text-muted-foreground/70 mb-2 text-center">

--- a/apps/webapp/app/routes/login.magic.tsx
+++ b/apps/webapp/app/routes/login.magic.tsx
@@ -29,7 +29,7 @@ import {
   getUserSession,
 } from "~/services/sessionStorage.server";
 import { env } from "~/env.server";
-import Logo from "~/components/logo/logo";
+import { SamAvatar } from "~/components/ui/sam-avatar";
 import { redirectCookie } from "./auth.google";
 import { requestUrl } from "~/utils/requestUrl.server";
 
@@ -165,7 +165,7 @@ export default function LoginMagicLinkPage() {
 
               <Fieldset className="flex w-full flex-col items-center gap-y-2 px-2">
                 <div className="mb-10 flex justify-center">
-                  <Logo size={60} />
+                  <SamAvatar size={64} trackCursor />
                 </div>
 
                 <p className="text-md text-muted-foreground text-center">
@@ -200,7 +200,7 @@ export default function LoginMagicLinkPage() {
               <CardContent className="pt-2 pl-2">
                 <Fieldset className="flex w-full flex-col items-center gap-y-2">
                   <div className="mb-10 flex justify-center">
-                    <Logo size={60} />
+                    <SamAvatar size={64} trackCursor />
                   </div>
 
                   <p className="text-muted-foreground/70 mb-2 text-center">

--- a/apps/webapp/app/routes/onboarding._index.tsx
+++ b/apps/webapp/app/routes/onboarding._index.tsx
@@ -42,7 +42,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const user = await requireUser(request);
 
   if (user.onboardingComplete) {
-    return redirect("/home/daily");
+    const meta = (user.metadata ?? {}) as Record<string, unknown>;
+    return redirect(meta.planStepComplete ? "/home/daily" : "/onboarding/plan");
   }
 
   const workspaceId = (await getWorkspaceId(
@@ -122,9 +123,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   const user = await requireUser(request);
 
+  const existingMetadata =
+    (user.metadata as Record<string, unknown> | null) ?? {};
+
   if (!user.onboardingComplete) {
-    const existingMetadata =
-      (user.metadata as Record<string, unknown> | null) ?? {};
     await prisma.user.update({
       where: { id: user.id },
       data: {
@@ -134,7 +136,9 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   }
 
-  return redirect("/home/daily");
+  return redirect(
+    existingMetadata.planStepComplete ? "/home/daily" : "/onboarding/plan",
+  );
 }
 
 export default function OnboardingChat() {
@@ -145,8 +149,11 @@ export default function OnboardingChat() {
 
   // After every streamed turn, re-run the loader. If the agent has
   // called complete_onboarding, the user.onboardingComplete flag will
-  // now be true and the loader will redirect to /home/daily.
-  const handleStreamComplete = useCallback(() => {}, [revalidator]);
+  // now be true and the loader will redirect us out (to /onboarding/plan
+  // when the plan step still needs picking, else /home/daily).
+  const handleStreamComplete = useCallback(() => {
+    revalidator.revalidate();
+  }, [revalidator]);
 
   if (typeof window === "undefined") return null;
 

--- a/apps/webapp/app/routes/onboarding.plan.tsx
+++ b/apps/webapp/app/routes/onboarding.plan.tsx
@@ -1,0 +1,255 @@
+import {
+  json,
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from "@remix-run/node";
+import { useFetcher } from "@remix-run/react";
+import { useTypedLoaderData } from "remix-typedjson";
+import { Prisma } from "@prisma/client";
+import type { LoaderData } from "~/utils/loader-data";
+import { requireUser } from "~/services/session.server";
+import { prisma } from "~/db.server";
+import { Button } from "~/components/ui/button";
+import { isBillingEnabled } from "~/config/billing.server";
+import { createCheckoutSession } from "~/services/stripe.server";
+import { ArrowRight, ExternalLink } from "lucide-react";
+
+type UserMetadata = Record<string, unknown>;
+
+const PLAN_STEP_KEY = "planStepComplete";
+
+async function markPlanStepComplete(
+  userId: string,
+  metadata: UserMetadata,
+  { zeroCredits }: { zeroCredits: boolean },
+) {
+  const next: UserMetadata = { ...metadata, [PLAN_STEP_KEY]: true };
+  await prisma.user.update({
+    where: { id: userId },
+    data: { metadata: next as Prisma.InputJsonValue },
+  });
+
+  if (zeroCredits) {
+    // Zero the free-tier credits granted at signup. From here, the user
+    // needs a paid plan (Stripe webhook tops up on upgrade) or BYOK
+    // (bypasses the credit check entirely) to keep using the agent.
+    await prisma.userUsage.updateMany({
+      where: { userId },
+      data: { availableCredits: 0 },
+    });
+  }
+}
+
+async function getWorkspacePlan(workspaceId: string | null) {
+  if (!workspaceId) return "FREE" as const;
+  const sub = await prisma.subscription.findUnique({
+    where: { workspaceId },
+    select: { planType: true },
+  });
+  return (sub?.planType ?? "FREE") as "FREE" | "PRO" | "MAX";
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireUser(request);
+
+  if (!user.onboardingComplete) {
+    return redirect("/onboarding");
+  }
+
+  const metadata = (user.metadata ?? {}) as UserMetadata;
+  if (metadata[PLAN_STEP_KEY]) {
+    return redirect("/home/daily");
+  }
+
+  // Self-hosted / billing disabled → nothing to sell. Mark complete and go.
+  if (!isBillingEnabled()) {
+    await markPlanStepComplete(user.id, metadata, { zeroCredits: false });
+    return redirect("/home/daily");
+  }
+
+  // Already on a paid plan (rare — e.g. team-provisioned workspace).
+  // Nothing to upsell; preserve their credits and move on.
+  const plan = await getWorkspacePlan(user.workspaceId ?? null);
+  if (plan !== "FREE") {
+    await markPlanStepComplete(user.id, metadata, { zeroCredits: false });
+    return redirect("/home/daily");
+  }
+
+  return json({});
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const user = await requireUser(request);
+  const formData = await request.formData();
+  const intent = formData.get("intent") as string;
+
+  const metadata = (user.metadata ?? {}) as UserMetadata;
+
+  if (intent === "subscribe") {
+    if (!user.workspaceId) {
+      return json({ error: "Workspace not found" }, { status: 400 });
+    }
+    const planType = (formData.get("planType") as "PRO" | "MAX") || "PRO";
+    const origin = new URL(request.url).origin;
+
+    // Mark up front so an abandoned checkout still lets them reach /home
+    // (they'll see the upgrade modal there until they actually pay). Zero
+    // the free credits — the Stripe webhook refills them on successful
+    // subscription creation.
+    await markPlanStepComplete(user.id, metadata, { zeroCredits: true });
+
+    const checkoutUrl = await createCheckoutSession({
+      workspaceId: user.workspaceId,
+      planType,
+      email: user.email,
+      successUrl: `${origin}/home/daily?checkout=success`,
+      cancelUrl: `${origin}/home/daily?checkout=canceled`,
+    });
+
+    return json({ checkoutUrl });
+  }
+
+  if (intent === "byok") {
+    // Same treatment as subscribe — they've made a choice, credits go to
+    // zero. BYOK bypasses the credit check, so once they add a key in
+    // settings they can use the agent freely.
+    await markPlanStepComplete(user.id, metadata, { zeroCredits: true });
+    return redirect("/settings/workspace/models?onboarding=1");
+  }
+
+  return json({ error: "Invalid intent" }, { status: 400 });
+}
+
+export default function OnboardingPlan() {
+  useTypedLoaderData<typeof loader>() as LoaderData<typeof loader>;
+  const fetcher = useFetcher<typeof action>();
+  const busy = fetcher.state !== "idle";
+
+  if (
+    fetcher.data &&
+    "checkoutUrl" in fetcher.data &&
+    fetcher.data.checkoutUrl
+  ) {
+    window.location.href = fetcher.data.checkoutUrl as string;
+  }
+
+  const submit = (intent: string, extra: Record<string, string> = {}) => {
+    fetcher.submit({ intent, ...extra }, { method: "POST" });
+  };
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-6 py-10">
+      <div className="flex w-full max-w-5xl flex-col gap-10">
+        <div className="mx-auto flex max-w-2xl flex-col items-center gap-3 text-center">
+
+          <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">
+            power me up.
+          </h1>
+          <p className="text-muted-foreground text-base md:text-lg">
+            i run on an LLM. pick a CORE plan, or bring your own key from a
+            provider you already pay for.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {/* CORE subscription — recommended */}
+          <div className="bg-background-2 relative flex flex-col gap-6 overflow-hidden rounded-xl border-2 p-6">
+
+
+            <div className="flex flex-col gap-1">
+              <h2 className="text-xl font-semibold">CORE subscription</h2>
+              <p className="text-muted-foreground text-sm">
+                managed cloud — models, gateway, credits, everything.
+              </p>
+            </div>
+
+            <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+              <li className="flex items-baseline gap-2">
+                <span className="text-foreground w-8 font-medium">Pro</span>
+                <span>10k credits/mo · $19</span>
+              </li>
+              <li className="flex items-baseline gap-2">
+                <span className="text-foreground w-8 font-medium">Max</span>
+                <span>100k credits/mo · $99</span>
+              </li>
+              <li className="flex items-baseline gap-2">
+                <span className="text-foreground w-8" />
+                <span>top up any time, credits never expire.</span>
+              </li>
+            </ul>
+
+            <div className="mt-auto flex flex-col gap-2">
+              <Button
+                size="lg"
+                onClick={() => submit("subscribe", { planType: "PRO" })}
+                disabled={busy}
+                className="justify-between"
+              >
+                <span>Subscribe to Pro · $19/mo</span>
+                <ArrowRight className="size-4" />
+              </Button>
+              <Button
+                size="lg"
+                variant="secondary"
+                onClick={() => submit("subscribe", { planType: "MAX" })}
+                disabled={busy}
+                className="justify-between"
+              >
+                <span>Subscribe to Max · $99/mo</span>
+                <ArrowRight className="size-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* BYOK */}
+          <div className="border-border bg-background-2 flex flex-col gap-6 rounded-xl border p-6">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-xl font-semibold">Bring your own key</h2>
+              <p className="text-muted-foreground text-sm">
+                point me at a provider you already pay for. you handle the
+                bill, i skip CORE credits entirely.
+              </p>
+            </div>
+
+            <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+              <li>• OpenAI, Anthropic, OpenRouter, Ollama, Azure, and more.</li>
+              <li>
+                • already on Claude Max or ChatGPT with Codex?{" "}
+                <a
+                  href="https://docs.getcore.me/gateway/subscription-proxy"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary inline-flex items-center gap-1 underline underline-offset-2"
+                >
+                  reuse your subscription
+                  <ExternalLink className="size-3" />
+                </a>{" "}
+                — no separate API key.
+              </li>
+              <li>• unlimited use — no CORE credits touched.</li>
+            </ul>
+
+            <div className="mt-auto">
+              <Button
+                size="lg"
+                variant="secondary"
+                onClick={() => submit("byok")}
+                disabled={busy}
+                className="w-full justify-between"
+              >
+                <span>Set up my own key</span>
+                <ArrowRight className="size-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-muted-foreground text-center text-xs">
+          you have 500 free credits — enough to try me a few times. after that
+          i'll need a plan or your own key.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/app/routes/onboarding.tsx
+++ b/apps/webapp/app/routes/onboarding.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useFetcher, useLocation } from "@remix-run/react";
 import Logo from "~/components/logo/logo";
 import { Button } from "~/components/ui/button";
+import { SamAvatar } from "~/components/ui/sam-avatar";
 
 export default function OnboardingLayout() {
   const fetcher = useFetcher();
@@ -18,7 +19,7 @@ export default function OnboardingLayout() {
       <div className="flex items-center justify-between px-6 md:px-10">
         <div className="flex items-center gap-2 py-4">
           <div className="flex size-8 items-center justify-center rounded-md">
-            <Logo size={60} />
+            <SamAvatar size={28} trackCursor />
           </div>
           <span className="font-mono font-medium">CORE</span>
         </div>

--- a/apps/webapp/app/routes/settings.billing.tsx
+++ b/apps/webapp/app/routes/settings.billing.tsx
@@ -628,7 +628,7 @@ export default function BillingSettings() {
               </div>
               <ul className="mb-6 space-y-2 text-sm">
                 <li className="flex items-start gap-2">
-                  <span>Credits: 3k/mo</span>
+                  <span>500 credits · one-time</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <span>Top up any time</span>

--- a/apps/webapp/app/services/billing.server.ts
+++ b/apps/webapp/app/services/billing.server.ts
@@ -220,6 +220,13 @@ export async function hasCredits(
     },
   });
 
+  // Onboarding chat runs on the house — the plan step (which zeroes credits
+  // for FREE users) happens AFTER complete_onboarding fires, so gating here
+  // would kill the first conversation.
+  if (user && !user.onboardingComplete) {
+    return true;
+  }
+
   if (!user?.UserUsage || !workspace?.Subscription) {
     return false;
   }


### PR DESCRIPTION
## Summary

- Adds a final onboarding step at `/onboarding/plan` that offers the FREE user either a **CORE subscription** (Pro/Max via Stripe checkout) or **BYOK**. Skipped automatically when billing is disabled (self-hosted) or the workspace is already on PRO/MAX.
- Onboarding chat runs credit-free — `hasCredits` bypasses the gate while `user.onboardingComplete === false` — and credits drop to `0` the moment the user picks a plan path.
- Adds a non-dismissible `UpgradeRequiredModal` on `/home` that blocks the app for FREE users without BYOK. Catches Stripe drop-offs and "clicked BYOK but never added a key" cases. Cleared once webhook flips them to PRO/MAX or a workspace BYOK key exists.
- FREE plan default cut 200 → 500 credits (one-time), display copy updated.
- BYOK users no longer see the sidebar `OutOfCreditsCard`, the credits pill, or a disabled conversation textarea — server already exempts them from `hasCredits`, UI now matches.
- Onboarding chat's `handleStreamComplete` now actually calls `revalidator.revalidate()`, so `complete_onboarding` routes to the plan step without a manual click.
- Swaps `Logo` for `SamAvatar` on the login screens and the onboarding header.

## Test plan

- [ ] New user signs up → onboarding chat runs to completion even with < 1 credit → lands on `/onboarding/plan`.
- [ ] Subscribe → Stripe checkout URL returned → webhook flips plan to PRO → credits restored → paywall modal gone.
- [ ] Cancel Stripe → return to `/home` → paywall modal blocks the surface.
- [ ] BYOK path → `/settings/workspace/models` → add key → return to `/home` → no paywall, no `0 credits` pill, textarea enabled.
- [ ] Self-hosted (`ENABLE_BILLING=false`) → plan step auto-skips to `/home/daily`.
- [ ] Workspace already on PRO/MAX → plan step auto-skips without zeroing credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)