### PR TITLE
fix(webapp): stop Claude passing integration slug as accountId

### DIFF
--- a/apps/webapp/app/routes/api.v1.deep-search.tsx
+++ b/apps/webapp/app/routes/api.v1.deep-search.tsx
@@ -4,7 +4,8 @@ import { createActionApiRoute } from "~/services/routeBuilders/apiBuilder.server
 import { trackFeatureUsage } from "~/services/telemetry.server";
 
 import { logger } from "~/services/logger.service";
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 import { streamToUIResponse } from "~/services/agent/mastra-stream.server";
 import { searchMemoryWithAgent } from "~/services/agent/memory";
 
@@ -74,15 +75,22 @@ ${invalidatedFacts.length > 0 ? `INVALIDATED FACTS (outdated information):\n${in
 
 Provide a clear, helpful summary based ONLY on the memory above. Do not add any information not present in the memory.`;
 
+      const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+        authentication.workspaceId,
+        "chat",
+        "medium",
+      );
+      const agentOptions = apiKey
+        ? { apiKey, ...(baseUrl && { baseUrl }) }
+        : undefined;
+
       if (body.stream) {
-        const agent = createAgent(await resolveModelString("chat", "medium"), systemPrompt);
+        const agent = createAgent(modelId, systemPrompt, undefined, agentOptions);
         const result = await agent.stream([{ role: "user", content: userPrompt }]);
         return streamToUIResponse(result);
       } else {
-        const agent = createAgent(await resolveModelString("chat", "medium"), systemPrompt);
+        const agent = createAgent(modelId, systemPrompt, undefined, agentOptions);
         const { text } = await agent.generate(userPrompt);
-
-
         return json({ text });
       }
     } catch (error: any) {

--- a/apps/webapp/app/routes/api.v1.inbox.summarise.tsx
+++ b/apps/webapp/app/routes/api.v1.inbox.summarise.tsx
@@ -48,7 +48,7 @@ const { loader, action } = createHybridActionApiRoute(
       })
       .join("\n");
 
-    const summary = await summarize({ text: rendered });
+    const summary = await summarize({ text: rendered, workspaceId });
 
     // Stamp instead of delete: the rows stay around as a history of
     // what the user has been caught up on. Only unstamped rows are

--- a/apps/webapp/app/routes/api.v1.integration_account.$integrationAccountId.action.tsx
+++ b/apps/webapp/app/routes/api.v1.integration_account.$integrationAccountId.action.tsx
@@ -14,6 +14,17 @@ const ParamsSchema = z.object({
   integrationAccountId: z.string().min(1, "Integration account ID is required"),
 });
 
+// Route-builder's outer catch turns any thrown Error into 500 "Internal Server
+// Error", which strips the account-not-found message the orchestrator relies on
+// to hint the model back toward a valid UUID. Throwing a `Response` bypasses
+// that catch and preserves the message.
+function notFoundResponse(message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 404,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 const SearchParamsSchema = z.object({
   query: z.string().optional(),
 });
@@ -36,23 +47,36 @@ const loader = createHybridLoaderApiRoute(
     allowJWT: true,
     corsStrategy: "all",
     findResource: async (params, authentication) => {
-      return IntegrationLoader.getIntegrationAccountById(
-        params.integrationAccountId,
-        authentication.userId,
-      );
+      try {
+        return await IntegrationLoader.getIntegrationAccountById(
+          params.integrationAccountId,
+          authentication.userId,
+        );
+      } catch (error) {
+        throw notFoundResponse(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     },
   },
   async ({ params, searchParams, authentication }) => {
     const { integrationAccountId } = params;
     const { query } = searchParams;
 
-    const actions = await getIntegrationActions(
-      integrationAccountId,
-      query,
-      authentication.userId,
-    );
-
-    return json({ actions });
+    try {
+      const actions = await getIntegrationActions(
+        integrationAccountId,
+        query,
+        authentication.userId,
+      );
+      return json({ actions });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/not found or not active|Integration account .* not found/i.test(message)) {
+        throw notFoundResponse(message);
+      }
+      throw error;
+    }
   },
 );
 
@@ -78,15 +102,22 @@ const { action } = createHybridActionApiRoute(
         ? `oauth:${authentication.oauth2.clientId}`
         : undefined);
 
-    const result = await executeIntegrationAction(
-      integrationAccountId,
-      actionName,
-      parameters,
-      authentication.userId,
-      source,
-    );
-
-    return json({ result });
+    try {
+      const result = await executeIntegrationAction(
+        integrationAccountId,
+        actionName,
+        parameters,
+        authentication.userId,
+        source,
+      );
+      return json({ result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/not found or not active|Integration account .* not found/i.test(message)) {
+        throw notFoundResponse(message);
+      }
+      throw error;
+    }
   },
 );
 

--- a/apps/webapp/app/routes/api.v1.integration_account.$integrationAccountId.action.tsx
+++ b/apps/webapp/app/routes/api.v1.integration_account.$integrationAccountId.action.tsx
@@ -68,6 +68,7 @@ const loader = createHybridLoaderApiRoute(
         integrationAccountId,
         query,
         authentication.userId,
+        authentication.workspaceId,
       );
       return json({ actions });
     } catch (error) {

--- a/apps/webapp/app/routes/api.v1.skills.generate.tsx
+++ b/apps/webapp/app/routes/api.v1.skills.generate.tsx
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { createHybridActionApiRoute } from "~/services/routeBuilders/apiBuilder.server";
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 import { streamToUIResponse } from "~/services/agent/mastra-stream.server";
 import { getConnectedIntegrationAccounts } from "~/services/integrationAccount.server";
 import { SKILL_GENERATOR_SYSTEM_PROMPT } from "~/utils/skill-generator-prompt";
@@ -46,9 +47,16 @@ const { action } = createHybridActionApiRoute(
 
     const userMessage = `User intent: ${validatedData.prompt}${toolsContext}${existingContext}`;
 
+    const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+      authentication.workspaceId,
+      "chat",
+      "low",
+    );
     const agent = createAgent(
-      await resolveModelString("chat", "low"),
+      modelId,
       SKILL_GENERATOR_SYSTEM_PROMPT,
+      undefined,
+      apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
     );
     const result = await agent.stream([{ role: "user", content: userMessage }]);
     return streamToUIResponse(result);

--- a/apps/webapp/app/services/agent/agents/decision.ts
+++ b/apps/webapp/app/services/agent/agents/decision.ts
@@ -13,8 +13,11 @@
  */
 
 import { Agent } from "@mastra/core/agent";
-import { toRouterString, resolveModelString } from "~/lib/model.server";
-import { type ModelConfig } from "~/services/llm-provider.server";
+import { resolveModelString } from "~/lib/model.server";
+import {
+  resolveModelConfig,
+  type ModelConfig,
+} from "~/services/llm-provider.server";
 import { getMastra } from "../mastra";
 
 import {
@@ -177,11 +180,15 @@ export async function createThinkAgent(
       )
     : "Analyze triggers and produce structured JSON action plans.";
 
-  const model = await resolveModelString("chat", "low");
+  const modelString = await resolveModelString("chat", "low", workspaceId);
+  const { modelConfig: resolvedModelConfig } = await resolveModelConfig(
+    modelString,
+    workspaceId,
+  );
   const thinkAgent = new Agent({
     id: "thinking-agent",
     name: "Think",
-    model: modelConfig ?? toRouterString(model),
+    model: modelConfig ?? resolvedModelConfig,
     instructions,
     agents: { gather_context: gatherContextAgent },
     tools: { get_skill: getSkillTool(workspaceId) },

--- a/apps/webapp/app/services/agent/agents/orchestrator.ts
+++ b/apps/webapp/app/services/agent/agents/orchestrator.ts
@@ -575,7 +575,7 @@ export async function createOrchestratorAgent(
       }),
       execute: async (inputData) => {
         logger.info(`Orchestrator: web search - ${inputData.query}`);
-        const result = await runWebExplorer(inputData.query, timezone);
+        const result = await runWebExplorer(inputData.query, timezone, workspaceId);
         return result.success ? result.data : "web search unavailable";
       },
     });

--- a/apps/webapp/app/services/agent/agents/orchestrator.ts
+++ b/apps/webapp/app/services/agent/agents/orchestrator.ts
@@ -438,6 +438,7 @@ export async function createOrchestratorAgent(
           inputData.accountId,
           inputData.query,
           userId,
+          workspaceId,
         );
         // Unwrap MCP response format { content: [{ text }], isError }
         if (

--- a/apps/webapp/app/services/agent/agents/orchestrator.ts
+++ b/apps/webapp/app/services/agent/agents/orchestrator.ts
@@ -125,10 +125,12 @@ YESTERDAY: ${yesterdayDate}
 
   const integrationInstructions = `
 INTEGRATION WORKFLOW:
-1. Call get_integration_actions with the accountId and describe what you want to do
+1. Call get_integration_actions with the accountId (the UUID under "accountId:" in CONNECTED INTEGRATIONS — NOT the slug like "github"/"gmail") and describe what you want to do
 2. Review the returned actions and their inputSchema
 3. Call execute_integration_action with exact parameters matching the schema
 4. If you need more detail (e.g., full email body), call get_integration_actions again to find the "get by id" action
+
+⚠️ ACCOUNT ID: Always pass the UUID from "accountId:" in the CONNECTED INTEGRATIONS list above. Passing the slug ("github", "gmail", "slack") will fail. The examples below use "<slack-uuid>" / "<github-uuid>" as placeholders — substitute the actual UUID from the list.
 
 ⚠️ DATE/TIME QUERIES: Be cautious with datetime filters - each integration has different date formats and query syntax. Check the inputSchema carefully. Relative terms like "newer_than:1d" can be unreliable. Prefer explicit date ranges when available.
 
@@ -185,12 +187,12 @@ EXAMPLES:
 
 Action: "send a slack message to #general saying standup in 5"
 Step 1: memory_search("user's preferences for slack messages")
-Step 2: get_integration_actions(slack accountId, "send message")
-Step 3: execute_integration_action(slack accountId, "send_message", { channel: "#general", text: "standup in 5" })
+Step 2: get_integration_actions(accountId="<slack-uuid-from-list>", query="send message")
+Step 3: execute_integration_action(accountId="<slack-uuid-from-list>", action="send_message", parameters={ channel: "#general", text: "standup in 5" })
 
 Action: "create a github issue for auth bug in core repo"
-Step 1: get_integration_actions(github accountId, "create issue")
-Step 2: execute_integration_action(github accountId, "create_issue", { repo: "core", title: "auth bug", ... })
+Step 1: get_integration_actions(accountId="<github-uuid-from-list>", query="create issue")
+Step 2: execute_integration_action(accountId="<github-uuid-from-list>", action="create_issue", parameters={ repo: "core", title: "auth bug", ... })
 
 RULES:
 - Execute the action. No personality.
@@ -243,18 +245,18 @@ GOOD (clear intent):
 EXAMPLES:
 
 Intent: "Show me my upcoming meetings this week"
-Step 1: get_integration_actions(google-calendar accountId, "list events this week")
-Step 2: execute_integration_action(google-calendar accountId, "list_events", { timeMin: "...", timeMax: "..." })
+Step 1: get_integration_actions(accountId="<google-calendar-uuid-from-list>", query="list events this week")
+Step 2: execute_integration_action(accountId="<google-calendar-uuid-from-list>", action="list_events", parameters={ timeMin: "...", timeMax: "..." })
 
 Intent: "What's in the email from John"
-Step 1: get_integration_actions(gmail accountId, "search emails from John")
-Step 2: execute_integration_action(gmail accountId, "search_emails", { query: "from:john" })
-Step 3: get_integration_actions(gmail accountId, "get email by id")
-Step 4: execute_integration_action(gmail accountId, "get_email", { id: "..." })
+Step 1: get_integration_actions(accountId="<gmail-uuid-from-list>", query="search emails from John")
+Step 2: execute_integration_action(accountId="<gmail-uuid-from-list>", action="search_emails", parameters={ query: "from:john" })
+Step 3: get_integration_actions(accountId="<gmail-uuid-from-list>", query="get email by id")
+Step 4: execute_integration_action(accountId="<gmail-uuid-from-list>", action="get_email", parameters={ id: "..." })
 
 Intent: "what's the status of the rerank evaluation work"
 Step 1: memory_search("past discussions and decisions about the rerank evaluation — approach chosen, metrics discussed, next steps")
-Step 2: get_integration_actions(github accountId, "search PRs for rerank")  [only if memory points at open work]
+Step 2: get_integration_actions(accountId="<github-uuid-from-list>", query="search PRs for rerank")  [only if memory points at open work]
 
 Intent: "What's the weather in SF"
 → web_search (real-time data)
@@ -319,7 +321,7 @@ export async function createOrchestratorAgent(
   const integrationsList = connectedIntegrations
     .map(
       (int, index) =>
-        `${index + 1}. **${int.integrationDefinition.name}** (Account ID: ${int.id}) (Identifier: ${int.accountId})`,
+        `${index + 1}. **${int.integrationDefinition.name}** — accountId: ${int.id} (pass this UUID to get_integration_actions/execute_integration_action; user identifier for reference: ${int.accountId})`,
     )
     .join("\n");
 
@@ -418,7 +420,7 @@ export async function createOrchestratorAgent(
       accountId: z
         .string()
         .describe(
-          "Integration account ID from the connected integrations list",
+          "The UUID from the accountId field in CONNECTED INTEGRATIONS (e.g. 'a1b2c3d4-...'). Do NOT pass the integration slug ('github', 'gmail', 'slack') — pass the UUID.",
         ),
       query: z
         .string()
@@ -468,7 +470,11 @@ export async function createOrchestratorAgent(
     description:
       "Execute an action on a connected integration. Use the inputSchema from get_integration_actions to know what parameters to pass. If this fails, check the error and retry with corrected parameters.",
     inputSchema: z.object({
-      accountId: z.string().describe("Integration account ID"),
+      accountId: z
+        .string()
+        .describe(
+          "The UUID from the accountId field in CONNECTED INTEGRATIONS. Do NOT pass the integration slug ('github', 'gmail', 'slack') — pass the UUID.",
+        ),
       action: z.string().describe("Action name from get_integration_actions"),
       parameters: z
         .string()

--- a/apps/webapp/app/services/agent/context.ts
+++ b/apps/webapp/app/services/agent/context.ts
@@ -302,7 +302,7 @@ export async function buildAgentContext({
   const integrationsList = connectedIntegrations
     .map((int, index) =>
       "integrationDefinition" in int
-        ? `${index + 1}. **${int.integrationDefinition.name}** (Account ID: ${int.id})`
+        ? `${index + 1}. **${int.integrationDefinition.name}** — accountId: ${int.id}`
         : "",
     )
     .join("\n");

--- a/apps/webapp/app/services/agent/executors/base.ts
+++ b/apps/webapp/app/services/agent/executors/base.ts
@@ -85,6 +85,7 @@ export abstract class OrchestratorTools {
     accountId: string,
     query: string,
     userId: string,
+    workspaceId?: string,
   ): Promise<unknown>;
 
   /** Execute an action on an integration account. */

--- a/apps/webapp/app/services/agent/executors/direct.ts
+++ b/apps/webapp/app/services/agent/executors/direct.ts
@@ -112,8 +112,14 @@ export class DirectOrchestratorTools extends OrchestratorTools {
     accountId: string,
     query: string,
     userId: string,
+    workspaceId?: string,
   ): Promise<unknown> {
-    return handleGetIntegrationActions({ accountId, query, userId });
+    return handleGetIntegrationActions({
+      accountId,
+      query,
+      userId,
+      workspaceId,
+    });
   }
 
   async executeIntegrationAction(

--- a/apps/webapp/app/services/agent/executors/http.ts
+++ b/apps/webapp/app/services/agent/executors/http.ts
@@ -36,11 +36,23 @@ export class HttpOrchestratorTools extends OrchestratorTools {
   ): Promise<string> {
     try {
       const result = await this.client.search({ query });
-      // Format episodes to text
       const episodes = (result as any).episodes ?? [];
       if (!episodes.length) return "nothing found";
+      // Keep this format aligned with the direct path
+      // (apps/webapp/app/services/agent/memory.ts formatEpisodes) so the
+      // relevanceScore and UUID surface to the agent regardless of executor.
       return episodes
-        .map((ep: any, i: number) => `### Episode ${i + 1}\n${ep.content}`)
+        .map((ep: any, i: number) => {
+          const created = ep.createdAt
+            ? new Date(ep.createdAt).toLocaleString()
+            : null;
+          const header = [`### Episode ${i + 1}`];
+          if (ep.uuid) header.push(`**UUID**: ${ep.uuid}`);
+          if (created) header.push(`**Created**: ${created}`);
+          if (ep.relevanceScore != null)
+            header.push(`**Relevance**: ${ep.relevanceScore}`);
+          return `${header.join("\n")}\n\n${ep.content}`;
+        })
         .join("\n\n");
     } catch (error) {
       logger.warn("HttpOrchestratorTools: memory search failed", { error });
@@ -87,8 +99,16 @@ export class HttpOrchestratorTools extends OrchestratorTools {
     accountId: string,
     query: string,
     _userId: string,
+    _workspaceId?: string,
   ): Promise<unknown> {
-    const response = await this.client.getIntegrationActions({ accountId, query });
+    // BYOK note: the SDK POST/GET here does not currently forward workspaceId
+    // — the API route reads workspaceId from the authenticated session/JWT and
+    // uses that for model resolution. Passing it as a parameter here would be
+    // ignored server-side.
+    const response = await this.client.getIntegrationActions({
+      accountId,
+      query,
+    });
     return response;
   }
 

--- a/apps/webapp/app/services/agent/explorers/web-explorer.ts
+++ b/apps/webapp/app/services/agent/explorers/web-explorer.ts
@@ -4,7 +4,8 @@ import { createTool } from "@mastra/core/tools";
 import Exa from "exa-js";
 import { logger } from "~/services/logger.service";
 import { env } from "~/env.server";
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 import { ExplorerResult } from "../types";
 
 const WEB_COMPLEXITY = "medium";
@@ -47,6 +48,7 @@ RULES:
 export async function runWebExplorer(
   query: string,
   timezone: string = "UTC",
+  workspaceId?: string,
 ): Promise<ExplorerResult> {
   const startTime = Date.now();
   let toolCalls = 0;
@@ -155,10 +157,19 @@ ${r.text || "No content available"}`;
   };
 
   try {
-    const model = await resolveModelString("chat", WEB_COMPLEXITY);
-    logger.info(`complexity: ${WEB_COMPLEXITY}, model: ${model}`);
+    const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+      workspaceId,
+      "chat",
+      WEB_COMPLEXITY,
+    );
+    logger.info(`complexity: ${WEB_COMPLEXITY}, model: ${modelId}`);
 
-    const agent = createAgent(model, getWebExplorerPrompt(timezone), tools);
+    const agent = createAgent(
+      modelId,
+      getWebExplorerPrompt(timezone),
+      tools,
+      apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
+    );
     const result = await agent.generate(query, { maxSteps: 6 });
     const { text } = result;
 

--- a/apps/webapp/app/services/agent/tools/onboarding-tools.ts
+++ b/apps/webapp/app/services/agent/tools/onboarding-tools.ts
@@ -31,7 +31,7 @@ export function getListAvailableIntegrationsTool(
 ): Tool {
   return tool({
     description:
-      "Get the catalog of integrations the user's workspace can connect. Returns slug, name, description, and whether the user already has it connected. Call this before suggest_integrations whenever you need to verify which slugs are valid or to avoid recommending something already wired up. Pass an optional query string to filter by slug or name (case-insensitive substring).",
+      "Get the catalog of integrations the user's workspace can connect. Returns slug, name, description, whether the user already has it connected, and — for connected ones — the integrationAccountId to pass into get_integration_actions / execute_integration_action. Call this before suggest_integrations to verify which slugs are valid or to avoid recommending something already wired up, and call it before invoking integration actions to grab the accountId. Pass an optional query string to filter by slug or name (case-insensitive substring).",
     inputSchema: z.object({
       query: z
         .string()
@@ -57,12 +57,12 @@ export function getListAvailableIntegrationsTool(
         }),
         prisma.integrationAccount.findMany({
           where: { integratedById: userId, workspaceId, isActive: true },
-          select: { integrationDefinitionId: true },
+          select: { id: true, integrationDefinitionId: true },
         }),
       ]);
 
-      const connectedDefIds = new Set(
-        accounts.map((a) => a.integrationDefinitionId),
+      const accountByDefId = new Map(
+        accounts.map((a) => [a.integrationDefinitionId, a.id]),
       );
 
       const lowerQuery = query?.trim().toLowerCase();
@@ -74,12 +74,16 @@ export function getListAvailableIntegrationsTool(
           )
         : defs;
 
-      const integrations = filtered.map((d) => ({
-        slug: d.slug,
-        name: d.name,
-        description: d.description,
-        isConnected: connectedDefIds.has(d.id),
-      }));
+      const integrations = filtered.map((d) => {
+        const integrationAccountId = accountByDefId.get(d.id) ?? null;
+        return {
+          slug: d.slug,
+          name: d.name,
+          description: d.description,
+          isConnected: integrationAccountId !== null,
+          integrationAccountId,
+        };
+      });
 
       logger.info(
         `list_available_integrations: ${integrations.length} match${query ? ` (query="${query}")` : ""}`,

--- a/apps/webapp/app/services/agent/tools/skill-tools.ts
+++ b/apps/webapp/app/services/agent/tools/skill-tools.ts
@@ -9,7 +9,8 @@ import { z } from "zod";
 import { prisma } from "~/db.server";
 import { logger } from "~/services/logger.service";
 import { createSkill, updateSkill, getSkill } from "~/services/skills.server";
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 import { getConnectedIntegrationAccounts } from "~/services/integrationAccount.server";
 import { SKILL_GENERATOR_SYSTEM_PROMPT } from "~/utils/skill-generator-prompt";
 import {
@@ -108,7 +109,17 @@ export function createSkillTool(workspaceId: string, userId: string): Tool {
 
           const userMessage = `User intent: ${intent}${toolsContext}`;
 
-          const agent = createAgent(await resolveModelString("chat", "low"), SKILL_GENERATOR_SYSTEM_PROMPT);
+          const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+            workspaceId,
+            "chat",
+            "low",
+          );
+          const agent = createAgent(
+            modelId,
+            SKILL_GENERATOR_SYSTEM_PROMPT,
+            undefined,
+            apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
+          );
           const { text: generatedContent } = await agent.generate(userMessage);
 
           if (!generatedContent) {

--- a/apps/webapp/app/services/summarize.server.ts
+++ b/apps/webapp/app/services/summarize.server.ts
@@ -14,7 +14,8 @@
  * as other lightweight calls in the codebase.
  */
 
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 import { logger } from "~/services/logger.service";
 
 const VOICE_INSTRUCTIONS = `You are the user's chief of staff giving a one-breath spoken catchup. You've already read everything — you're surfacing what matters, in the order they should think about it. Your output is both spoken via TTS AND shown on a card the user reads along with, so each sentence is one beat.
@@ -33,15 +34,27 @@ Output format:
 - No bullet markers ("-", "•"), no numbering, no markdown. Just sentences separated by newlines.
 - Output the catchup text only. Nothing else.`;
 
-export async function summarize(params: { text: string }): Promise<string> {
-  const { text } = params;
+export async function summarize(params: {
+  text: string;
+  workspaceId?: string;
+}): Promise<string> {
+  const { text, workspaceId } = params;
 
   const trimmed = text.trim();
   if (!trimmed) return "";
 
   try {
-    const modelString = await resolveModelString("chat", "low");
-    const agent = createAgent(modelString, VOICE_INSTRUCTIONS);
+    const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+      workspaceId,
+      "chat",
+      "low",
+    );
+    const agent = createAgent(
+      modelId,
+      VOICE_INSTRUCTIONS,
+      undefined,
+      apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
+    );
     const { text: out } = await agent.generate(trimmed);
     return (out ?? "").trim();
   } catch (error) {

--- a/apps/webapp/app/utils/mcp/memory.ts
+++ b/apps/webapp/app/utils/mcp/memory.ts
@@ -146,7 +146,7 @@ export const memoryTools = [
         accountId: {
           type: "string",
           description:
-            "Account ID (UUID) from get_integrations. This identifies the specific integration account to use.",
+            "Account ID (UUID) from the `id` field returned by get_integrations. This identifies the specific integration account to use. Do NOT pass the integration slug ('github', 'gmail', 'slack') — pass the UUID.",
         },
         query: {
           type: "string",
@@ -172,7 +172,7 @@ export const memoryTools = [
         accountId: {
           type: "string",
           description:
-            "Account ID (UUID) from get_integrations. This identifies the specific integration account to use.",
+            "Account ID (UUID) from the `id` field returned by get_integrations. This identifies the specific integration account to use. Do NOT pass the integration slug ('github', 'gmail', 'slack') — pass the UUID.",
         },
         action: {
           type: "string",

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -20,7 +20,7 @@
     "@ai-sdk/azure": "3.0.50",
     "@ai-sdk/google": "^3.0.6",
     "@ai-sdk/openai": "^3.0.27",
-    "@ai-sdk/openai-compatible": "2.0.29",
+    "@ai-sdk/openai-compatible": "3.0.12",
     "@ai-sdk/react": "3.0.230",
     "@anthropic-ai/sdk": "^0.74.0",
     "@aws-sdk/client-s3": "3.879.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: ^3.0.27
         version: 3.0.27(zod@4.3.6)
       '@ai-sdk/openai-compatible':
-        specifier: 2.0.29
-        version: 2.0.29(zod@4.3.6)
+        specifier: 3.0.12
+        version: 3.0.12(zod@4.3.6)
       '@ai-sdk/react':
         specifier: 3.0.230
         version: 3.0.230(react@19.2.4)(zod@4.3.6)
@@ -1271,9 +1271,9 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.29':
-    resolution: {integrity: sha512-yoZ+jxBzVA7cQIrcOn2ZXAVeqsNdhqFGWW3VwTJwNnmeOLCACoz6+pu58LY/zjxEJGVrl5X+JazdY5LhDMey8A==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai-compatible@3.0.12':
+    resolution: {integrity: sha512-tN9BUb4jUGjqtbRPUsziLxASfogLNICcq/Qrwr55vpnzKvprV6Ukl8ynED2lZaNrAHU5U4zlGnyU/iuYrjQK6g==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -1340,6 +1340,12 @@ packages:
   '@ai-sdk/provider-utils@4.0.4':
     resolution: {integrity: sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.11':
+    resolution: {integrity: sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -16296,10 +16302,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/openai-compatible@2.0.29(zod@4.3.6)':
+  '@ai-sdk/openai-compatible@3.0.12(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai@3.0.27(zod@4.3.6)':
@@ -16339,7 +16345,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.7
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.14(zod@4.3.6)':
@@ -16375,6 +16381,14 @@ snapshots:
       '@ai-sdk/provider': 3.0.2
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.11(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@5.0.7(zod@4.3.6)':


### PR DESCRIPTION
## Summary

Claude was calling `get_integration_actions` / `execute_integration_action` with the integration slug (`"github"`, `"gmail"`, `"google-calendar"`) as the `accountId`, then hitting an opaque "Internal Server Error" and giving up. GPT worked because it loosely substituted the UUID. Two root causes fixed here:

1. **Prompt/schema ambiguity** — the examples in `orchestrator.ts` were pseudocode (`get_integration_actions(github accountId, "create issue")`), which Claude read literally as the string `"github"`. Rewrote all four example blocks (write + read modes) with explicit UUID placeholders (`accountId="<github-uuid-from-list>"`), tightened the Zod field descriptions to say "Do NOT pass the slug", and reformatted the CONNECTED INTEGRATIONS list so `accountId:` is the labelled field. Same tightening applied to `context.ts` (main agent list) and the memory tool descriptions in `memory.ts` for consistency. `list_available_integrations` now also returns `integrationAccountId` for connected integrations so the onboarding agent has the UUID to hand off.

2. **Error swallowing** — when `IntegrationLoader.getIntegrationAccountById` threw `"Integration account 'github' not found or not active."`, the shared apiBuilder's outer catch converted it into a generic `{error: "Internal Server Error"}` 500, stripping the useful message that the orchestrator's `enrichAccountNotFound` regex relies on to append the list of valid UUIDs and let Claude retry. The route now throws a `Response` (the outer catch passes those through untouched), so the useful message reaches the SDK, the regex matches, and Claude is told which UUID to use.

## Test plan

- [ ] Trigger a Claude-model orchestrator turn that reads Gmail / Calendar / GitHub — should call the tools with the real UUID and succeed on the first try.
- [ ] Force a bad `accountId` (pass `"github"` manually via a test harness or observe existing behavior) — response should be a 404 with `{error: "Integration account 'github' not found or not active."}` rather than a 500 with `{error: "Internal Server Error"}`, and the orchestrator should surface the valid UUIDs and retry.
- [ ] Confirm GPT-based orchestrator turns still work (nothing about the tool contract or wire format changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)