### PR TITLE
fix(webapp): thread workspaceId through persona generation + improvePersonality for BYOK

### DIFF
--- a/apps/webapp/app/jobs/spaces/aspect-persona-generation.ts
+++ b/apps/webapp/app/jobs/spaces/aspect-persona-generation.ts
@@ -12,7 +12,8 @@
 
 import { logger } from "~/services/logger.service";
 import { createBatch, getBatch } from "~/lib/batch.server";
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 import { z } from "zod";
 
 // Flag to bypass the OpenAI batch API and run full-refresh through direct
@@ -22,10 +23,22 @@ import { z } from "zod";
 //   PERSONA_USE_BATCH unset/true → batch mode (existing behaviour)
 const USE_BATCH = false;
 
-async function directLLMCall(message: ModelMessage): Promise<string | null> {
+async function directLLMCall(
+  message: ModelMessage,
+  workspaceId?: string,
+): Promise<string | null> {
   try {
-    const modelId = await resolveModelString("chat", "medium");
-    const agent = createAgent(modelId);
+    const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+      workspaceId,
+      "chat",
+      "medium",
+    );
+    const agent = createAgent(
+      modelId,
+      undefined,
+      undefined,
+      apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
+    );
     const result = await agent.generate(message);
     return result.text ?? null;
   } catch (err) {
@@ -896,6 +909,7 @@ function chunkAspectData(aspectData: AspectData): ChunkData[] {
 async function generateSectionWithChunking(
   aspectData: AspectData,
   userContext: UserContext,
+  workspaceId?: string,
 ): Promise<string | null> {
   const { aspect, statements, episodes } = aspectData;
   const sectionInfo = ASPECT_SECTION_MAP[aspect];
@@ -961,7 +975,10 @@ async function generateSectionWithChunking(
     // Direct mode: fan out chunk summaries in parallel via plain LLM calls.
     const directResults = await Promise.all(
       chunks.map((chunk) =>
-        directLLMCall(buildChunkSummaryPrompt(aspect, chunk, userContext)),
+        directLLMCall(
+          buildChunkSummaryPrompt(aspect, chunk, userContext),
+          workspaceId,
+        ),
       ),
     );
     for (const content of directResults) {
@@ -1015,6 +1032,7 @@ async function generateSectionWithChunking(
 
   const merged = await directLLMCall(
     buildMergePrompt(aspect, chunkSummaries, userContext),
+    workspaceId,
   );
   return merged ?? chunkSummaries[0];
 }
@@ -1025,6 +1043,7 @@ async function generateSectionWithChunking(
 async function generateAllAspectSections(
   aspectDataMap: Map<StatementAspect, AspectData>,
   userContext: UserContext,
+  workspaceId?: string,
 ): Promise<PersonaSectionResult[]> {
   const sections: PersonaSectionResult[] = [];
 
@@ -1078,7 +1097,7 @@ async function generateAllAspectSections(
   // Task for each large section (chunking handled internally)
   for (const aspectData of largeAspects) {
     parallelTasks.push(
-      generateSectionWithChunking(aspectData, userContext).then((content) => {
+      generateSectionWithChunking(aspectData, userContext, workspaceId).then((content) => {
         if (content && !content.includes("INSUFFICIENT_DATA")) {
           const sectionInfo = ASPECT_SECTION_MAP[aspectData.aspect];
           return [
@@ -1180,7 +1199,10 @@ async function generateAllAspectSections(
 
           const directResults = await Promise.all(
             sortedSmallAspects.map((aspectData) =>
-              directLLMCall(buildAspectSectionPrompt(aspectData, userContext)),
+              directLLMCall(
+                buildAspectSectionPrompt(aspectData, userContext),
+                workspaceId,
+              ),
             ),
           );
 
@@ -1288,6 +1310,7 @@ async function pollBatchCompletion(batchId: string, maxPollingTime: number) {
  */
 export async function generateAspectBasedPersona(
   userId: string,
+  workspaceId?: string,
 ): Promise<string> {
   logger.info("Starting aspect-based persona generation", { userId });
 
@@ -1366,7 +1389,11 @@ export async function generateAspectBasedPersona(
   }
 
   // Step 3: Generate all sections
-  const sections = await generateAllAspectSections(aspectDataMap, userContext);
+  const sections = await generateAllAspectSections(
+    aspectDataMap,
+    userContext,
+    workspaceId,
+  );
   logger.info("Generated persona sections", {
     sectionCount: sections.length,
     sections: sections.map((s) => s.title),

--- a/apps/webapp/app/jobs/spaces/persona-generation.logic.ts
+++ b/apps/webapp/app/jobs/spaces/persona-generation.logic.ts
@@ -172,7 +172,7 @@ export async function processPersonaGeneration(
   if (!existing) {
     // First-time generation.
     logger.info("Running first-time persona generation", { userId });
-    const summary = await generateAspectBasedPersona(userId);
+    const summary = await generateAspectBasedPersona(userId, workspaceId);
     await savePersonaDocument(workspaceId, userId, summary, labelId);
     await updateLastPersonaGenerationTime(workspaceId);
     return {
@@ -273,12 +273,15 @@ export async function processPersonaGeneration(
       const looseIdToText = new Map(
         structure.looseFacts.map((l) => [l.id, l.text]),
       );
-      const decision = await placeFactInPersona({
-        aspect,
-        fact: facts[0],
-        structure,
-        filterGuidance: ASPECT_SECTION_MAP[aspect].filterGuidance,
-      });
+      const decision = await placeFactInPersona(
+        {
+          aspect,
+          fact: facts[0],
+          structure,
+          filterGuidance: ASPECT_SECTION_MAP[aspect].filterGuidance,
+        },
+        workspaceId,
+      );
       if (!decision) continue;
       doc = applyPlacementDecision(doc, title, decision, looseIdToText);
       continue;
@@ -288,13 +291,16 @@ export async function processPersonaGeneration(
     // structure between each so a `promote` followed by `append_to_subsection`
     // referencing the new subsection name resolves correctly.
     const initialStructure = parseSectionStructure(doc, title);
-    const decisions = await placeFactsInPersona({
-      aspect,
-      facts,
-      structure: initialStructure,
-      filterGuidance: ASPECT_SECTION_MAP[aspect].filterGuidance,
-      episodeContent,
-    });
+    const decisions = await placeFactsInPersona(
+      {
+        aspect,
+        facts,
+        structure: initialStructure,
+        filterGuidance: ASPECT_SECTION_MAP[aspect].filterGuidance,
+        episodeContent,
+      },
+      workspaceId,
+    );
     if (!decisions || decisions.length === 0) continue;
 
     for (const decision of decisions) {

--- a/apps/webapp/app/jobs/spaces/persona-llm-placement.ts
+++ b/apps/webapp/app/jobs/spaces/persona-llm-placement.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { logger } from "~/services/logger.service";
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 import type { StatementAspect } from "@core/types";
 import type { SectionStructure } from "./persona-bullet-ops";
 
@@ -353,11 +354,21 @@ function truncateForPrompt(s: string, max: number): string {
  */
 export async function placeFactsInPersona(
   input: BatchPlacementInput,
+  workspaceId?: string,
 ): Promise<PlacementDecision[] | null> {
   if (input.facts.length === 0) return [];
   try {
-    const modelId = await resolveModelString("chat", "medium");
-    const agent = createAgent(modelId);
+    const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+      workspaceId,
+      "chat",
+      "medium",
+    );
+    const agent = createAgent(
+      modelId,
+      undefined,
+      undefined,
+      apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
+    );
     const prompt = buildBatchPlacementPrompt(input);
     const result = await agent.generate({ role: "user", content: prompt });
     const raw = result.text;
@@ -411,10 +422,20 @@ export async function placeFactsInPersona(
  */
 export async function placeFactInPersona(
   input: PlacementInput,
+  workspaceId?: string,
 ): Promise<PlacementDecision | null> {
   try {
-    const modelId = await resolveModelString("chat", "medium");
-    const agent = createAgent(modelId);
+    const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+      workspaceId,
+      "chat",
+      "medium",
+    );
+    const agent = createAgent(
+      modelId,
+      undefined,
+      undefined,
+      apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
+    );
     const prompt = buildPlacementPrompt(input);
     const result = await agent.generate({ role: "user", content: prompt });
     const raw = result.text;

--- a/apps/webapp/app/models/personality.server.ts
+++ b/apps/webapp/app/models/personality.server.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "~/db.server";
-import { createAgent, resolveModelString } from "~/lib/model.server";
+import { createAgent } from "~/lib/model.server";
+import { resolveModelForWorkspace } from "~/services/llm-provider.server";
 
 export interface CustomPersonality {
   id: string;
@@ -201,8 +202,19 @@ Never use horizontal rules, em dashes as separators, or markdown headers anywher
 export async function improvePersonality(
   name: string,
   text: string,
+  workspaceId?: string,
 ): Promise<{ text: string }> {
-  const agent = createAgent(await resolveModelString("chat", "medium"), IMPROVE_SYSTEM_PROMPT);
+  const { modelId, apiKey, baseUrl } = await resolveModelForWorkspace(
+    workspaceId,
+    "chat",
+    "medium",
+  );
+  const agent = createAgent(
+    modelId,
+    IMPROVE_SYSTEM_PROMPT,
+    undefined,
+    apiKey ? { apiKey, ...(baseUrl && { baseUrl }) } : undefined,
+  );
 
   const result = await agent.generate([
     {

--- a/apps/webapp/app/routes/settings.workspace.agent.tsx
+++ b/apps/webapp/app/routes/settings.workspace.agent.tsx
@@ -222,7 +222,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return json({ error: "Missing name or text" }, { status: 400 });
     }
 
-    const improved = await improvePersonality(name, text);
+    const improved = await improvePersonality(name, text, user.workspaceId);
     return json({ success: true, improved });
   }
 


### PR DESCRIPTION
## Summary

Same silent-BYOK-fallback bug that hit the orchestrator paths — persona generation and personality-improve calls resolved a model name via `resolveModelString` but never passed `workspaceId`, so the workspace's `apiKey`/`baseUrl` were dropped and every call fell back to the server default model even for workspaces with BYOK configured.

## Sites fixed

- **`jobs/spaces/aspect-persona-generation.ts`** — persona-generation background job (fires per episode via ingest)
  - `directLLMCall(message)` → `(message, workspaceId?)` — this is the path actually running today, since `USE_BATCH = false` disables the batch code path
  - `generateAspectBasedPersona(userId)` → `(userId, workspaceId?)`
  - `generateSectionWithChunking` + `generateAllAspectSections` plumb `workspaceId` down to every `directLLMCall` site (chunk summaries, merge, small-aspect fan-out)
- **`jobs/spaces/persona-generation.logic.ts`** — passes `payload.workspaceId` to `generateAspectBasedPersona` and to both `placeFactInPersona` / `placeFactsInPersona`
- **`jobs/spaces/persona-llm-placement.ts`** — `placeFactInPersona` / `placeFactsInPersona` accept `workspaceId?` and resolve via `resolveModelForWorkspace`
- **`models/personality.server.ts`** — `improvePersonality(name, text)` → `(name, text, workspaceId?)` (interactive: Agent Settings → "Improve personality")
- **`routes/settings.workspace.agent.tsx`** — passes `user.workspaceId`

## Deliberately skipped

- **Batch code path** (`lib/batch/*`) — disabled by `USE_BATCH = false`, and would need a separate "does the workspace's BYOK key support /v1/batches?" policy before it's worth wiring (proxies like CLIProxyAPI/Vercel AI Gateway don't implement it)
- **`models/onboarding.server.ts` `generateButlerName`** — no callers, dead code
- **`getModel()` in `model.server.ts`** — reached only from server-level fallback branches inside `createAgent`/`resolveModelConfig`, both of which already handled BYOK higher up. Correct as-is.

## Test plan

- [ ] For a workspace with BYOK configured (e.g. an OpenAI-compatible proxy), trigger persona generation via a memory ingest — logs should show the workspace's BYOK model, not the server default.
- [ ] Same workspace: open Agent Settings → "Improve personality" — should use BYOK.
- [ ] Workspace with no BYOK: same flows should silently use the server default, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)