### PR TITLE
fix(webapp): offline retry + integration search tokenization + connect-another

### DIFF
--- a/apps/webapp/app/components/common/no-internet.tsx
+++ b/apps/webapp/app/components/common/no-internet.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Button } from "~/components/ui/button";
 import { SamAvatar } from "~/components/ui/sam-avatar";
 
 /**
@@ -12,6 +13,8 @@ import { SamAvatar } from "~/components/ui/sam-avatar";
  * as "sleeping / waiting" rather than looking like the normal app.
  */
 export function NoInternet({ message }: { message?: string } = {}) {
+  const [retrying, setRetrying] = React.useState(false);
+
   React.useEffect(() => {
     if (typeof window === "undefined") return;
     const reload = () => {
@@ -27,6 +30,11 @@ export function NoInternet({ message }: { message?: string } = {}) {
     return () => window.removeEventListener("online", reload);
   }, []);
 
+  const handleRetry = () => {
+    setRetrying(true);
+    window.location.reload();
+  };
+
   return (
     <div className="bg-background-2 flex h-full min-h-screen w-full flex-col items-center justify-center gap-4 p-6 text-center">
       <SamAvatar size={120} eye="bot-zen" eyeColor="#9CA3AF" />
@@ -37,6 +45,14 @@ export function NoInternet({ message }: { message?: string } = {}) {
             "We lost the connection. This page will refresh automatically as soon as you're back online."}
         </p>
       </div>
+      <Button
+        variant="secondary"
+        onClick={handleRetry}
+        disabled={retrying}
+        className="mt-2"
+      >
+        {retrying ? "Retrying..." : "Retry"}
+      </Button>
     </div>
   );
 }

--- a/apps/webapp/app/components/conversation/suggest-integrations-cards.tsx
+++ b/apps/webapp/app/components/conversation/suggest-integrations-cards.tsx
@@ -208,12 +208,21 @@ export function SuggestIntegrationsCards({
                 <span className="font-medium">{card.name}</span>
                 <p className="text-muted-foreground text-sm">{card.reason}</p>
               </div>
-              <div className="shrink-0">
+              <div className="flex shrink-0 items-center gap-2">
                 {isConnected ? (
-                  <span className="text-success bg-success/10 inline-flex items-center gap-1 rounded px-2 py-1 text-sm">
-                    <Check size={14} />
-                    Connected
-                  </span>
+                  <>
+                    <span className="text-success bg-success/10 inline-flex items-center gap-1 rounded px-2 py-1 text-sm">
+                      <Check size={14} />
+                      Connected
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setOpenCard(card)}
+                    >
+                      Connect another
+                    </Button>
+                  </>
                 ) : (
                   <Button variant="secondary" onClick={() => setOpenCard(card)}>
                     Connect

--- a/apps/webapp/app/services/agent/tools/onboarding-tools.ts
+++ b/apps/webapp/app/services/agent/tools/onboarding-tools.ts
@@ -65,13 +65,22 @@ export function getListAvailableIntegrationsTool(
         accounts.map((a) => [a.integrationDefinitionId, a.id]),
       );
 
-      const lowerQuery = query?.trim().toLowerCase();
-      const filtered = lowerQuery
-        ? defs.filter(
-            (d) =>
-              d.slug.toLowerCase().includes(lowerQuery) ||
-              d.name.toLowerCase().includes(lowerQuery),
-          )
+      // Match if ANY whitespace-separated token appears in slug, name,
+      // or description. Single-substring matching missed multi-word
+      // queries like "email gmail" (no field contains that phrase), and
+      // AND-matching missed them too (Gmail's description is "Gmail
+      // integration for Core", no "email"). OR gives the agent the
+      // Gmail hit it's looking for plus any other email-adjacent
+      // integrations to consider.
+      const tokens = (query ?? "")
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean);
+      const filtered = tokens.length
+        ? defs.filter((d) => {
+            const haystack = `${d.slug} ${d.name} ${d.description ?? ""}`.toLowerCase();
+            return tokens.some((t) => haystack.includes(t));
+          })
         : defs;
 
       const integrations = filtered.map((d) => {


### PR DESCRIPTION
## Summary
- **Offline page:** manual Retry button so users aren't stuck when the browser `online` event doesn't fire or the server itself was the drop.
- **`list_available_integrations`:** tokenize the query on whitespace, then match if any token appears in slug/name/description. Fixes queries like `"email gmail"` returning 0 results (Gmail's description is "Gmail integration for Core" — no substring or AND-token strategy matched).
- **`SuggestIntegrationsCards`:** when a suggested integration is already connected, keep the Connected badge and add a small "Connect another" button so users can add a second account from the same card instead of the card looking like a broken suggestion.

## Test plan
- [ ] Force offline in devtools → confirm Retry button reloads the page; "Retrying..." state during reload
- [ ] Ask the agent something that triggers `list_available_integrations` with a multi-word query like `"email gmail"` → confirm Gmail (and any email-adjacent integrations) come back
- [ ] With Gmail already connected, trigger a `suggest_integrations` that includes Gmail → confirm Connected badge + "Connect another" button both render and the button opens the connect modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)