### PR TITLE
fix(cli): make COREBRAIN_GATEWAY_SECURITY_KEY env var authoritative

### DIFF
--- a/packages/cli/src/utils/env-bootstrap.ts
+++ b/packages/cli/src/utils/env-bootstrap.ts
@@ -76,18 +76,23 @@ export function bootstrapFromEnv(): string[] {
 
 	// Security key. Without this every authed request returns 401, so make
 	// sure a fresh container always boots with one. Three cases:
-	//   1) Env var supplied → use it (user controls the value via Railway/Fly env).
-	//   2) Already on disk    → keep it.
-	//   3) Neither            → generate, persist the hash, print the raw key
-	//                           so the user can paste it into the webapp's
-	//                           "Register gateway" dialog.
+	//   1) Env var supplied → always wins, overwriting any existing hash. Lets
+	//                         ops rotate the key by changing the env var and
+	//                         redeploying without having to wipe the volume.
+	//   2) Already on disk  → keep it.
+	//   3) Neither          → generate, persist the hash, print the raw key
+	//                         so the user can paste it into the webapp's
+	//                         "Register gateway" dialog.
 	const envKey = process.env.COREBRAIN_GATEWAY_SECURITY_KEY;
 	let securityKeyPatch: {securityKeyHash?: string} = {};
 	let printRawKey: string | null = null;
-	if (envKey && !existing.securityKeyHash) {
-		securityKeyPatch.securityKeyHash = hashKey(envKey);
-		applied.push('COREBRAIN_GATEWAY_SECURITY_KEY');
-	} else if (!envKey && !existing.securityKeyHash) {
+	if (envKey) {
+		const envHash = hashKey(envKey);
+		if (existing.securityKeyHash !== envHash) {
+			securityKeyPatch.securityKeyHash = envHash;
+			applied.push('COREBRAIN_GATEWAY_SECURITY_KEY');
+		}
+	} else if (!existing.securityKeyHash) {
 		printRawKey = generateSecurityKey();
 		securityKeyPatch.securityKeyHash = hashKey(printRawKey);
 		applied.push('generated-security-key');


### PR DESCRIPTION
## Summary
- `COREBRAIN_GATEWAY_SECURITY_KEY` now always wins over the persisted `securityKeyHash` in `~/.corebrain/config.json`.
- Previously the env var was only applied on a *fresh* config, so once a container had generated (or been seeded with) a hash, later env-var changes were silently ignored and `/verify` returned 401 for the "new" key.
- Rotating the gateway key is now just: change the env var → redeploy. No volume wipe required.

## Test plan
- [ ] Boot gateway with `COREBRAIN_GATEWAY_SECURITY_KEY=key-A`, register in webapp — `/verify` returns 200.
- [ ] Restart with `COREBRAIN_GATEWAY_SECURITY_KEY=key-B` on the same persistent volume; webapp updated to use `key-B` — `/verify` returns 200, old key returns 401.
- [ ] Boot without the env var on a fresh volume — auto-generated key is printed in `docker logs` and works.
- [ ] Boot without the env var on a volume that already has a hash — persisted key still works (no regeneration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)