### PR TITLE
fix(chat): return all connected accounts per integration in list_available_integrations

### DIFF
--- a/apps/webapp/app/services/agent/tools/onboarding-tools.ts
+++ b/apps/webapp/app/services/agent/tools/onboarding-tools.ts
@@ -31,7 +31,7 @@ export function getListAvailableIntegrationsTool(
 ): Tool {
   return tool({
     description:
-      "Get the catalog of integrations the user's workspace can connect. Returns slug, name, description, whether the user already has it connected, and — for connected ones — the integrationAccountId to pass into get_integration_actions / execute_integration_action. Call this before suggest_integrations to verify which slugs are valid or to avoid recommending something already wired up, and call it before invoking integration actions to grab the accountId. Pass an optional query string to filter by slug or name (case-insensitive substring).",
+      "Catalog of integrations this workspace can connect. Each entry: slug, name, description, isConnected, and `accounts[]` — one per connected account, since a user can connect the same integration multiple times (e.g. work + personal Gmail). Each account has `integrationAccountId` (UUID for get_integration_actions / execute_integration_action) and `accountLabel` (external handle, e.g. email/username). Call before suggest_integrations to validate slugs, and before executing an action to grab the accountId. If multiple accounts exist and the user's intent doesn't pick one, ask. Optional `query` filters by slug/name (case-insensitive substring).",
     inputSchema: z.object({
       query: z
         .string()
@@ -57,13 +57,31 @@ export function getListAvailableIntegrationsTool(
         }),
         prisma.integrationAccount.findMany({
           where: { integratedById: userId, workspaceId, isActive: true },
-          select: { id: true, integrationDefinitionId: true },
+          select: {
+            id: true,
+            accountId: true,
+            integrationDefinitionId: true,
+          },
+          orderBy: { createdAt: "asc" },
         }),
       ]);
 
-      const accountByDefId = new Map(
-        accounts.map((a) => [a.integrationDefinitionId, a.id]),
-      );
+      // A user CAN have multiple IntegrationAccount rows per definition
+      // (schema uniques on accountId+definition+workspace, not on
+      // definition+workspace). Group into an array so the caller can
+      // see all of them instead of silently collapsing to one.
+      const accountsByDefId = new Map<
+        string,
+        { integrationAccountId: string; accountLabel: string | null }[]
+      >();
+      for (const a of accounts) {
+        const list = accountsByDefId.get(a.integrationDefinitionId) ?? [];
+        list.push({
+          integrationAccountId: a.id,
+          accountLabel: a.accountId ?? null,
+        });
+        accountsByDefId.set(a.integrationDefinitionId, list);
+      }
 
       // Match if ANY whitespace-separated token appears in slug, name,
       // or description. Single-substring matching missed multi-word
@@ -84,13 +102,13 @@ export function getListAvailableIntegrationsTool(
         : defs;
 
       const integrations = filtered.map((d) => {
-        const integrationAccountId = accountByDefId.get(d.id) ?? null;
+        const defAccounts = accountsByDefId.get(d.id) ?? [];
         return {
           slug: d.slug,
           name: d.name,
           description: d.description,
-          isConnected: integrationAccountId !== null,
-          integrationAccountId,
+          isConnected: defAccounts.length > 0,
+          accounts: defAccounts,
         };
       });
 


### PR DESCRIPTION
## Summary
- `list_available_integrations` (the agent tool the chat calls before picking an integration) built a `Map<integrationDefinitionId, accountId>`, silently collapsing to whichever account Prisma returned last when a user had more than one row for the same definition
- Schema (`packages/database/prisma/schema.prisma:313-335`) uniques `IntegrationAccount` on `(accountId, integrationDefinitionId, workspaceId)`, so multiple accounts per definition (work + personal Gmail, two GitHub logins, etc.) are legal — the tool just wasn't surfacing them
- Now returns `accounts: [{ integrationAccountId, accountLabel }]` per definition, and the tool description tells the agent to disambiguate (or ask) when multiple accounts exist

## Test plan
- [ ] Connect a second GitHub account for a user that already has one, call the chat with an integration prompt, confirm both accounts appear in `list_available_integrations` output
- [ ] Confirm `suggest_integrations` still uses `isConnected` correctly (unchanged flag semantics)
- [ ] Verify `get_integration_actions` / `execute_integration_action` still work when the agent passes an `integrationAccountId` from the new array shape

## Not in scope (follow-up)
The onboarding-side single-account assumptions (`getIntegrationAccountBySlugAndUser` used by `onboarding._index.tsx` and `onboarding.gmail.tsx`, plus `activeAccounts[0]` in `home.integration.$slug.tsx`) — flagged by the audit but need product decisions before touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)