### PR TITLE
ci(gateway): build linux/arm64 alongside amd64

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -50,6 +50,9 @@ jobs:
         with:
           ref: main
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -63,13 +66,14 @@ jobs:
         id: ver
         run: echo "tag=${GITHUB_REF_NAME#gateway-}" >> "$GITHUB_OUTPUT"
 
-      # Gateway is amd64-only: Brave's apt repo doesn't ship arm64.
+      # Multi-arch: Dockerfile.gateway installs Brave on amd64 and Debian's
+      # chromium on arm64 (Brave's apt repo doesn't ship arm64).
       - name: Build and Push Gateway Docker Image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile.gateway
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: redplanethq/core-gateway:${{ steps.ver.outputs.tag }}
           cache-from: type=registry,ref=redplanethq/core-gateway:buildcache

--- a/docker/Dockerfile.gateway
+++ b/docker/Dockerfile.gateway
@@ -40,7 +40,12 @@
 # Extract the CLIProxyAPI binary from the upstream image.
 FROM eceasy/cli-proxy-api:latest AS cliproxy-upstream
 
-FROM --platform=linux/amd64 node:22-slim
+FROM node:22-slim
+
+# TARGETARCH is populated automatically by buildx (amd64 / arm64). We fan
+# out on it below so the same Dockerfile builds a multi-arch image: Brave
+# on amd64 (their apt repo is amd64-only), Debian's chromium on arm64.
+ARG TARGETARCH
 
 # System dependencies — git for repo work, ca-certs for HTTPS, build tools
 # for node-pty's rebuild fallback on unusual platforms, python3 for node-gyp.
@@ -88,20 +93,25 @@ COPY docker/llmproxy-providers.json /etc/gateway/llmproxy-providers.json
 RUN rm -f /etc/nginx/sites-enabled/default \
     && mkdir -p /etc/gateway
 
-# Browser — Brave (Chromium-based, so Playwright's `chromium.launchPersistentContext`
-# drives it via `executablePath`). We deliberately skip Playwright's bundled
-# Chromium download: the apt install of brave-browser pulls in every
-# Chromium runtime lib transitively, and the gateway always launches Brave.
-#
-# NOTE: Brave's apt repo is amd64-only. This image must build on linux/amd64
-# (use `docker buildx build --platform=linux/amd64 …` on ARM64 hosts).
-RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
-        https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" \
-        > /etc/apt/sources.list.d/brave-browser-release.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends brave-browser \
-    && rm -rf /var/lib/apt/lists/*
+# Browser — Chromium-based, driven by Playwright's `chromium.launchPersistentContext`
+# via `executablePath`. Brave's apt repo ships amd64 only, so on arm64 we
+# install Debian's `chromium` package instead. Either way we skip Playwright's
+# bundled Chromium download: the system package pulls in every Chromium
+# runtime lib transitively, and the gateway launches the system binary.
+# The entrypoint picks the right one via `corebrain browser set-browser`.
+RUN set -eux; \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
+            https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg; \
+        echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" \
+            > /etc/apt/sources.list.d/brave-browser-release.list; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends brave-browser; \
+    else \
+        apt-get update; \
+        apt-get install -y --no-install-recommends chromium; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
 
 # Pre-approved coding workspace. Folders added via the webapp UI or cloned
 # via `POST /api/folders/git` land under this directory. Mount a Docker

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -221,15 +221,23 @@ if any(data.get(k) != v for k, v in patch.items()):
         json.dump(data, f, indent=2)
 PY
 
-# ---------- pin Brave as the browser ----------
-# The image ships Brave instead of Playwright's bundled Chromium. Run the
-# CLI's set-browser command so prefs.browser.{browserType,browserExecutable}
+# ---------- pin the system browser ----------
+# The image ships a system Chromium build (Brave on amd64, Debian's
+# chromium package on arm64) instead of Playwright's bundled Chromium. Run
+# the CLI's set-browser command so prefs.browser.{browserType,browserExecutable}
 # are populated; downstream code reads these via `getBrowserExecutable()` and
 # passes the path into Playwright's `executablePath` at launch. Idempotent —
 # rewrites the same prefs every boot, which lets us survive a wiped
 # /home/corebrain volume without losing the setting.
-echo "[entrypoint] running corebrain browser set-browser brave"
-corebrain browser set-browser brave >/dev/null 2>&1 || true
+if [ -x /usr/bin/brave-browser ]; then
+    echo "[entrypoint] running corebrain browser set-browser brave"
+    corebrain browser set-browser brave >/dev/null 2>&1 || true
+elif [ -x /usr/bin/chromium ]; then
+    echo "[entrypoint] running corebrain browser set-browser custom /usr/bin/chromium"
+    corebrain browser set-browser custom /usr/bin/chromium >/dev/null 2>&1 || true
+else
+    echo "[entrypoint] no system chromium/brave found; leaving browser prefs untouched" >&2
+fi
 
 # ---------- hand off to the gateway ----------
 # nginx owns port 7787 externally. Force the gateway onto 7788 regardless


### PR DESCRIPTION
## Summary
- Adds `linux/arm64` to the gateway image build (was `linux/amd64` only).
- `Dockerfile.gateway` now installs Brave on amd64 and Debian's `chromium` on arm64 — Brave's apt repo doesn't ship arm64, which was the original blocker.
- Entrypoint picks whichever browser binary is present and pins it via `corebrain browser set-browser`.
- Workflow adds a `docker/setup-qemu-action` step so the amd64 runner can cross-build arm64.

## Test plan
- [ ] `workflow_dispatch` run of `Build Docker Images` produces a manifest list for `redplanethq/core-gateway` with both `linux/amd64` and `linux/arm64` entries.
- [ ] Pull the image on an arm64 host (`docker pull redplanethq/core-gateway:<tag>`), boot it, verify the entrypoint logs `set-browser custom /usr/bin/chromium` and the gateway starts.
- [ ] Pull on an amd64 host, verify entrypoint still logs `set-browser brave` and Brave launches as before.
- [ ] Smoke-test a Playwright-driven action (e.g. a gateway browser skill) on the arm64 image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)