### PR TITLE
fix(billing): bypass credit gate for BYOK workspaces inside hasCredits

### DIFF
--- a/apps/webapp/app/services/billing.server.ts
+++ b/apps/webapp/app/services/billing.server.ts
@@ -14,6 +14,7 @@ import {
 } from "~/config/billing.server";
 import type { PlanType, Subscription } from "@prisma/client";
 import Stripe from "stripe";
+import { isWorkspaceBYOK } from "~/services/byok.server";
 
 export type CreditOperation = "addEpisode" | "search" | "chatMessage";
 
@@ -199,6 +200,11 @@ export async function hasCredits(
 ): Promise<boolean> {
   // If billing is disabled, always return true
   if (!isBillingEnabled()) {
+    return true;
+  }
+
+  // BYOK workspaces pay their own provider bills — bypass credit gating.
+  if (await isWorkspaceBYOK(workspaceId)) {
     return true;
   }
 

--- a/apps/webapp/app/trigger/utils/utils.ts
+++ b/apps/webapp/app/trigger/utils/utils.ts
@@ -9,6 +9,7 @@ import { customAlphabet } from "nanoid";
 import { prisma } from "~/db.server";
 import { BILLING_CONFIG, isBillingEnabled } from "~/config/billing.server";
 import { getSubscriptionAmount } from "~/services/billing.server";
+import { isWorkspaceBYOK } from "~/services/byok.server";
 
 // Token generation utilities
 const tokenValueLength = 40;
@@ -356,6 +357,11 @@ export async function hasCredits(
 ): Promise<boolean> {
   // If billing is disabled, always return true
   if (!isBillingEnabled()) {
+    return true;
+  }
+
+  // BYOK workspaces pay their own provider bills — bypass credit gating.
+  if (await isWorkspaceBYOK(workspaceId)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- Audited all six `hasCredits` call sites: four already guarded with `!isWorkspaceBYOK(...)`, but `addToQueue` (`apps/webapp/app/trigger/utils/queue.ts:25`) and `handleMemoryIngest` (`apps/webapp/app/utils/mcp/memory-operations.ts:66`) didn't — so BYOK workspaces with empty balances would hit "no credits" on ingest paths that were meant to be free for them.
- Push the BYOK short-circuit into both `hasCredits` implementations (`services/billing.server.ts:194`, `trigger/utils/utils.ts:351`) so every caller is consistent.
- Makes the pre-existing client-side comment ("server-side hasCredits also bypasses BYOK", `conversation-view.client.tsx:81`) actually true.

The four outer BYOK guards at the already-safe call sites are now redundant but harmless — left in place for a follow-up cleanup.

## Test plan
- [ ] BYOK workspace with 0 credits can call `memory_ingest` via MCP without hitting the credit error
- [ ] BYOK workspace with 0 credits can enqueue an episode via `addToQueue` (trigger path)
- [ ] Non-BYOK workspace with 0 credits still gets refused on all six call sites
- [ ] Non-BYOK workspace with credits still passes the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)