### PR TITLE
fix(conversation): bridge row events from trigger.dev to the server's Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,13 @@ AWS_REGION=us-east-1
 
 QUEUE_PROVIDER=bullmq
 
+# Shared secret for the trigger.dev -> webapp conversation-events bridge.
+# Only needed when QUEUE_PROVIDER=trigger: those workers run against their
+# own Redis, so they POST conversation row events to the webapp and it
+# publishes them to the Redis the SSE subscribers are on. Set the SAME
+# value here and in the trigger.dev env dashboard (along with APP_ORIGIN).
+# INTERNAL_EVENTS_SECRET=
+
 # WhatsApp (Twilio)
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -128,6 +128,15 @@ const EnvironmentSchema = z
     TRIGGER_API_URL: z.string().optional(),
     TRIGGER_DB: z.string().default("trigger"),
 
+    // Shared secret for worker→webapp callbacks on
+    // /api/v1/internal/conversation-events. trigger.dev workers run
+    // against their own Redis, so they hand conversation row events to
+    // the webapp over HTTP and it publishes them onto the Redis the SSE
+    // subscribers are on. Set the SAME value here and in the trigger.dev
+    // env dashboard (alongside APP_ORIGIN). Unset = the bridge is off:
+    // the route 503s and workers log the dropped event.
+    INTERNAL_EVENTS_SECRET: z.string().optional(),
+
     // Model envs
     MODEL: z.string().default(LLMModelEnum.GPT41),
     EMBEDDING_MODEL: z.string().default("mxbai-embed-large"),

--- a/apps/webapp/app/lib/runtime.server.ts
+++ b/apps/webapp/app/lib/runtime.server.ts
@@ -1,0 +1,19 @@
+/**
+ * Which process are we? Not which queue is configured — which runtime is
+ * actually executing this code right now.
+ *
+ * `isTriggerDeployment()` in `~/lib/queue-adapter.server` answers a
+ * different question ("is QUEUE_PROVIDER=trigger"), and it is true in the
+ * webapp process too. Anything that depends on process-local resources —
+ * Redis being the one that bites — needs THIS check instead.
+ *
+ * `RUNNING_IN_TRIGGER` is set by the trigger.dev runtime (see
+ * `trigger.config.ts`) and is never set in the webapp server or in a
+ * BullMQ worker, both of which share the app's Redis. A trigger.dev
+ * worker runs in a separate runtime with its OWN Redis, so a publish
+ * from there lands on a bus nobody is listening to.
+ */
+export function isRunningInTrigger(): boolean {
+  const flag = process.env.RUNNING_IN_TRIGGER;
+  return flag === "1" || flag === "true";
+}

--- a/apps/webapp/app/routes/__tests__/internal-conversation-events.test.ts
+++ b/apps/webapp/app/routes/__tests__/internal-conversation-events.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Auth and validation for the trigger.dev → webapp pubsub bridge.
+ *
+ * This route is the one place a process outside the webapp can push onto
+ * `conv:{conversationId}`, so the shared-secret check is the whole
+ * security boundary — it gets tested harder than the happy path.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { publishToRedisMock, loggerMock, envMock } = vi.hoisted(() => ({
+  publishToRedisMock: vi.fn<(...args: any[]) => Promise<number>>(async () => 2),
+  loggerMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  envMock: { INTERNAL_EVENTS_SECRET: "s3cret" as string | undefined },
+}));
+
+vi.mock("~/env.server", () => ({ env: envMock }));
+vi.mock("~/services/logger.service", () => ({ logger: loggerMock }));
+vi.mock("~/services/conversation-pubsub.server", () => ({
+  publishRowEventToRedis: publishToRedisMock,
+}));
+
+import { action } from "../api.v1.internal.conversation-events";
+
+const event = {
+  type: "row-upsert",
+  rowId: "row-1",
+  conversationId: "conv-1",
+  agentId: "agent-1",
+  status: "done",
+  ts: 1_700_000_000_000,
+};
+
+function post(
+  body: unknown,
+  { secret, method = "POST" }: { secret?: string; method?: string } = {
+    secret: "s3cret",
+  },
+) {
+  return new Request("https://app.example.com/api/v1/internal/conversation-events", {
+    method,
+    headers: {
+      "content-type": "application/json",
+      ...(secret ? { authorization: `Bearer ${secret}` } : {}),
+    },
+    body: method === "POST" ? JSON.stringify(body) : undefined,
+  });
+}
+
+const run = (request: Request) =>
+  action({ request, params: {}, context: {} } as any);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  publishToRedisMock.mockResolvedValue(2);
+  envMock.INTERNAL_EVENTS_SECRET = "s3cret";
+});
+
+describe("POST /api/v1/internal/conversation-events", () => {
+  it("publishes the envelope and returns the receiver count", async () => {
+    const res = await run(post(event, { secret: "s3cret" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, receiverCount: 2 });
+    expect(publishToRedisMock).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: "conv-1", rowId: "row-1" }),
+    );
+  });
+
+  it("rejects a wrong secret", async () => {
+    const res = await run(post(event, { secret: "wrong-length-secret" }));
+
+    expect(res.status).toBe(401);
+    expect(publishToRedisMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a same-length-but-wrong secret", async () => {
+    const res = await run(post(event, { secret: "s3cre7" }));
+
+    expect(res.status).toBe(401);
+    expect(publishToRedisMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing Authorization header", async () => {
+    const res = await run(post(event, {}));
+
+    expect(res.status).toBe(401);
+    expect(publishToRedisMock).not.toHaveBeenCalled();
+  });
+
+  it("503s when the bridge secret is not configured on the server", async () => {
+    envMock.INTERNAL_EVENTS_SECRET = undefined;
+
+    const res = await run(post(event, { secret: "s3cret" }));
+
+    expect(res.status).toBe(503);
+    expect(publishToRedisMock).not.toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalled();
+  });
+
+  it("rejects non-POST methods", async () => {
+    const res = await run(post(event, { secret: "s3cret", method: "GET" }));
+
+    expect(res.status).toBe(405);
+  });
+
+  it("400s on a malformed envelope", async () => {
+    const res = await run(
+      post({ type: "row-upsert", conversationId: "conv-1" }, { secret: "s3cret" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(publishToRedisMock).not.toHaveBeenCalled();
+  });
+
+  it("400s on a body that isn't JSON", async () => {
+    const request = new Request(
+      "https://app.example.com/api/v1/internal/conversation-events",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer s3cret",
+        },
+        body: "not json",
+      },
+    );
+
+    const res = await run(request);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("500s when the publish fails, so the failure lands in both logs", async () => {
+    publishToRedisMock.mockRejectedValue(new Error("redis down"));
+
+    const res = await run(post(event, { secret: "s3cret" }));
+
+    expect(res.status).toBe(500);
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      "internal conversation-events: publish failed",
+      expect.objectContaining({ conversationId: "conv-1" }),
+    );
+  });
+});

--- a/apps/webapp/app/routes/api.v1.internal.conversation-events.tsx
+++ b/apps/webapp/app/routes/api.v1.internal.conversation-events.tsx
@@ -1,0 +1,99 @@
+/**
+ * `POST /api/v1/internal/conversation-events`
+ *
+ * Server-side end of the trigger.dev → webapp pubsub bridge. A trigger
+ * worker runs against its own Redis, so `publishRowEvent` there can't
+ * reach the SSE subscribers on `conv:{conversationId}`; it POSTs the
+ * envelope here instead and this route does the PUBLISH in-process.
+ *
+ * Auth is a shared secret (`INTERNAL_EVENTS_SECRET`), not the API-key
+ * flow `internal.coding-events` uses: that authenticates a *user*, and a
+ * background worker publishing on behalf of a job has no user context.
+ * The envelope carries no authority of its own — worst case a leaked
+ * secret lets someone nudge a client to refetch a conversation it can
+ * already read (the SSE route still does its own ownership check).
+ *
+ * Responds with the Redis receiver count so the worker's
+ * "receiverCount: 0 means nobody was listening" diagnostic survives the
+ * extra hop.
+ */
+
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+
+import { env } from "~/env.server";
+import {
+  publishRowEventToRedis,
+  type ConversationRowEvent,
+} from "~/services/conversation-pubsub.server";
+import { logger } from "~/services/logger.service";
+
+const EventSchema = z.object({
+  type: z.literal("row-upsert"),
+  rowId: z.string().min(1),
+  conversationId: z.string().min(1),
+  agentId: z.string().nullish(),
+  status: z.string().nullish(),
+  ts: z.number(),
+});
+
+/** Length-guarded constant-time compare. `timingSafeEqual` throws on
+ *  length mismatch, and the length itself isn't worth protecting. */
+function secretMatches(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, { status: 405 });
+  }
+
+  const expected = env.INTERNAL_EVENTS_SECRET;
+  if (!expected) {
+    logger.error(
+      "internal conversation-events: INTERNAL_EVENTS_SECRET not configured — bridge is off",
+    );
+    return json({ error: "bridge not configured" }, { status: 503 });
+  }
+
+  const header = request.headers.get("authorization") ?? "";
+  const presented = header.startsWith("Bearer ") ? header.slice(7) : "";
+  if (!presented || !secretMatches(presented, expected)) {
+    return json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return json({ error: "invalid json" }, { status: 400 });
+  }
+
+  const parsed = EventSchema.safeParse(payload);
+  if (!parsed.success) {
+    return json(
+      { error: "invalid event", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const receiverCount = await publishRowEventToRedis(
+      parsed.data as ConversationRowEvent,
+    );
+    return json({ ok: true, receiverCount });
+  } catch (err) {
+    // The worker swallows this, but a 500 gets it into both logs — and
+    // it's the honest status: we accepted the event and failed to fan out.
+    logger.error("internal conversation-events: publish failed", {
+      error: err instanceof Error ? err.message : String(err),
+      conversationId: parsed.data.conversationId,
+      rowId: parsed.data.rowId,
+    });
+    return json({ error: "publish failed" }, { status: 500 });
+  }
+}

--- a/apps/webapp/app/services/__tests__/conversation-pubsub.test.ts
+++ b/apps/webapp/app/services/__tests__/conversation-pubsub.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Transport selection for conversation row events.
+ *
+ * The bug this guards: trigger.dev workers run against their own Redis,
+ * so a direct PUBLISH from a job succeeds and reaches nobody — the UI
+ * sits on "Working…" until you refresh. `publishRowEvent` must pick the
+ * HTTP bridge in that runtime and plain Redis everywhere else, and must
+ * stay fire-and-forget on both branches so a transport outage can never
+ * fail the DB write that preceded it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { publishMock, duplicateMock, loggerMock, envMock, runtimeMock } =
+  vi.hoisted(() => {
+    const publish = vi.fn<(...args: any[]) => Promise<number>>(async () => 1);
+    const publisher = { publish, on: vi.fn() };
+    return {
+      publishMock: publish,
+      duplicateMock: vi.fn(() => publisher),
+      loggerMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      envMock: {
+        APP_ORIGIN: "https://app.example.com",
+        INTERNAL_EVENTS_SECRET: "s3cret" as string | undefined,
+      },
+      runtimeMock: { inTrigger: false },
+    };
+  });
+
+vi.mock("~/bullmq/connection", () => ({
+  getRedisConnection: () => ({ duplicate: duplicateMock }),
+}));
+vi.mock("~/services/logger.service", () => ({ logger: loggerMock }));
+vi.mock("~/env.server", () => ({ env: envMock }));
+vi.mock("~/lib/runtime.server", () => ({
+  isRunningInTrigger: () => runtimeMock.inTrigger,
+}));
+
+import {
+  INTERNAL_EVENTS_PATH,
+  publishRowEvent,
+  publishRowEventToRedis,
+  type ConversationRowEvent,
+} from "../conversation-pubsub.server";
+
+const event: ConversationRowEvent = {
+  type: "row-upsert",
+  rowId: "row-1",
+  conversationId: "conv-1",
+  agentId: "agent-1",
+  status: "done",
+  ts: 1_700_000_000_000,
+};
+
+const fetchMock = vi.fn<(...args: any[]) => Promise<any>>();
+
+const okResponse = (body: unknown = { ok: true, receiverCount: 2 }) => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => body,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  publishMock.mockResolvedValue(1);
+  envMock.APP_ORIGIN = "https://app.example.com";
+  envMock.INTERNAL_EVENTS_SECRET = "s3cret";
+  runtimeMock.inTrigger = false;
+  fetchMock.mockResolvedValue(okResponse());
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+describe("publishRowEvent — webapp / BullMQ runtime", () => {
+  it("publishes straight onto Redis and never calls the bridge", async () => {
+    await publishRowEvent(event);
+
+    expect(publishMock).toHaveBeenCalledWith(
+      "conv:conv-1",
+      JSON.stringify(event),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "conversation-pubsub publish",
+      expect.objectContaining({ transport: "redis", receiverCount: 1 }),
+    );
+  });
+
+  it("swallows a Redis failure instead of failing the caller's write", async () => {
+    publishMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(publishRowEvent(event)).resolves.toBeUndefined();
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "conversation-pubsub publish failed",
+      expect.objectContaining({ transport: "redis" }),
+    );
+  });
+});
+
+describe("publishRowEvent — trigger.dev runtime", () => {
+  beforeEach(() => {
+    runtimeMock.inTrigger = true;
+  });
+
+  it("POSTs the envelope to the webapp instead of its own Redis", async () => {
+    await publishRowEvent(event);
+
+    expect(publishMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`https://app.example.com${INTERNAL_EVENTS_PATH}`);
+    expect(init.method).toBe("POST");
+    expect(init.headers.authorization).toBe("Bearer s3cret");
+    expect(init.headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual(event);
+    // A worker blocked on a publish is a worker not finishing its run.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("relays the receiver count the webapp reports back", async () => {
+    fetchMock.mockResolvedValue(okResponse({ ok: true, receiverCount: 3 }));
+
+    await publishRowEvent(event);
+
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "conversation-pubsub publish",
+      expect.objectContaining({ transport: "http", receiverCount: 3 }),
+    );
+  });
+
+  it("does not double up slashes when APP_ORIGIN has a trailing one", async () => {
+    envMock.APP_ORIGIN = "https://app.example.com/";
+
+    await publishRowEvent(event);
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `https://app.example.com${INTERNAL_EVENTS_PATH}`,
+    );
+  });
+
+  it("names itself in the logs when the shared secret is missing", async () => {
+    envMock.INTERNAL_EVENTS_SECRET = undefined;
+
+    await publishRowEvent(event);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.stringContaining("INTERNAL_EVENTS_SECRET unset"),
+      expect.objectContaining({ conversationId: "conv-1" }),
+    );
+  });
+
+  it("swallows a non-2xx bridge response", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: async () => ({}),
+    });
+
+    await expect(publishRowEvent(event)).resolves.toBeUndefined();
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "conversation-pubsub publish failed",
+      expect.objectContaining({ transport: "http" }),
+    );
+  });
+
+  it("swallows a bridge that is unreachable entirely", async () => {
+    fetchMock.mockRejectedValue(new Error("fetch failed"));
+
+    await expect(publishRowEvent(event)).resolves.toBeUndefined();
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+});
+
+describe("publishRowEventToRedis", () => {
+  it("returns the subscriber count and propagates errors to its caller", async () => {
+    publishMock.mockResolvedValue(4);
+    await expect(publishRowEventToRedis(event)).resolves.toBe(4);
+
+    publishMock.mockRejectedValue(new Error("down"));
+    await expect(publishRowEventToRedis(event)).rejects.toThrow("down");
+  });
+
+  it("stays on Redis even inside the trigger runtime, so the route can't loop", async () => {
+    runtimeMock.inTrigger = true;
+
+    await publishRowEventToRedis(event);
+
+    expect(publishMock).toHaveBeenCalledWith(
+      "conv:conv-1",
+      JSON.stringify(event),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/services/conversation-pubsub.server.ts
+++ b/apps/webapp/app/services/conversation-pubsub.server.ts
@@ -16,13 +16,40 @@
  * Dedicated `duplicate()` connections for publisher and per-subscriber
  * so pub/sub traffic doesn't contend with BullMQ commands on the shared
  * ioredis socket — same pattern as `getResumableStreamContext()`.
+ *
+ * ## Two transports
+ *
+ * Publishers don't all live in the webapp process. Jobs that run on
+ * trigger.dev (`run-agent-turn`, `task`, `case`, `scratchpad-scan` — every
+ * caller of `upsertConversationHistory`) execute in a separate runtime
+ * wired to a DIFFERENT Redis. A `PUBLISH` from there succeeds and reaches
+ * nobody, which surfaces as "conversation stuck on Working…, refresh shows
+ * the reply". So `publishRowEvent` picks its transport by runtime:
+ *
+ *   webapp / BullMQ worker → PUBLISH straight onto the shared Redis
+ *   trigger.dev worker     → POST the same envelope to the webapp, which
+ *                            does the PUBLISH on the caller's behalf
+ *                            (`/api/v1/internal/conversation-events`)
+ *
+ * Both branches stay fire-and-forget: a transport outage logs and is
+ * swallowed, never failing the DB write that preceded it.
  */
 
 import type { Redis } from "ioredis";
 import { getRedisConnection } from "~/bullmq/connection";
+import { env } from "~/env.server";
+import { isRunningInTrigger } from "~/lib/runtime.server";
 import { logger } from "~/services/logger.service";
 
 const CHANNEL_PREFIX = "conv:";
+
+/** Route the trigger.dev bridge POSTs to. Must match the resource route
+ *  filename `api.v1.internal.conversation-events.tsx`. */
+export const INTERNAL_EVENTS_PATH = "/api/v1/internal/conversation-events";
+
+/** A worker blocked on a publish is a worker not finishing its run. The
+ *  DB row is already committed by this point, so giving up is cheap. */
+const HTTP_PUBLISH_TIMEOUT_MS = 5_000;
 
 /** Envelope shape published on every ConversationHistory row upsert. Kept
  *  small — clients refetch the full row via loader if they need details
@@ -50,25 +77,91 @@ function getPublisher(): Redis {
 }
 
 /**
+ * PUBLISH onto the app's Redis and return the subscriber count.
+ *
+ * Exported for the internal-events route, which is the server-side end of
+ * the trigger.dev bridge — it must land here directly rather than
+ * re-entering `publishRowEvent`, or a misconfigured `RUNNING_IN_TRIGGER`
+ * on the webapp would have the route POST to itself in a loop.
+ *
+ * Throws on Redis failure; `publishRowEvent` is the layer that swallows.
+ */
+export async function publishRowEventToRedis(
+  event: ConversationRowEvent,
+): Promise<number> {
+  const pub = getPublisher();
+  return await pub.publish(
+    `${CHANNEL_PREFIX}${event.conversationId}`,
+    JSON.stringify(event),
+  );
+}
+
+/**
+ * Hand the envelope to the webapp over HTTP so it can publish onto the
+ * Redis the SSE subscribers are actually on. Returns the receiver count
+ * the webapp reports back, or null when it didn't report one.
+ */
+async function publishRowEventOverHttp(
+  event: ConversationRowEvent,
+): Promise<number | null> {
+  const secret = env.INTERNAL_EVENTS_SECRET;
+  if (!secret) {
+    // Loud on purpose. The pre-bridge failure mode was a silent no-op
+    // that only showed up as a stuck spinner in the UI — a missing
+    // secret should name itself in the worker logs instead.
+    logger.error(
+      "conversation-pubsub: INTERNAL_EVENTS_SECRET unset in trigger runtime — row event dropped",
+      { conversationId: event.conversationId, rowId: event.rowId },
+    );
+    return null;
+  }
+
+  const url = `${env.APP_ORIGIN.replace(/\/+$/, "")}${INTERNAL_EVENTS_PATH}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${secret}`,
+    },
+    body: JSON.stringify(event),
+    signal: AbortSignal.timeout(HTTP_PUBLISH_TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `conversation-events responded ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const body = (await res.json().catch(() => null)) as {
+    receiverCount?: unknown;
+  } | null;
+  return typeof body?.receiverCount === "number" ? body.receiverCount : null;
+}
+
+/**
  * Fire an envelope onto `conv:{conversationId}`. Fire-and-forget —
  * failures are logged but never surfaced to callers, so a publish outage
  * can never break a DB write. Callers should invoke AFTER the write
  * commits (so subscribers who refetch the row see it).
+ *
+ * Transport is chosen per runtime — see the module header.
  */
 export async function publishRowEvent(
   event: ConversationRowEvent,
 ): Promise<void> {
+  const viaHttp = isRunningInTrigger();
   try {
-    const pub = getPublisher();
-    const receiverCount = await pub.publish(
-      `${CHANNEL_PREFIX}${event.conversationId}`,
-      JSON.stringify(event),
-    );
+    const receiverCount = viaHttp
+      ? await publishRowEventOverHttp(event)
+      : await publishRowEventToRedis(event);
     // Log the receiver count — Redis PUBLISH returns the number of
-    // subscribers that got the message. Zero = nobody was listening
-    // (client not subscribed yet, cross-process env mismatch, etc). This
-    // is the single clearest signal for "the pubsub isn't wired right."
+    // subscribers that got the message, and the bridge route passes that
+    // number back through. Zero = nobody was listening (client not
+    // subscribed yet, cross-process env mismatch, etc). This is the
+    // single clearest signal for "the pubsub isn't wired right."
     logger.info("conversation-pubsub publish", {
+      transport: viaHttp ? "http" : "redis",
       conversationId: event.conversationId,
       rowId: event.rowId,
       status: event.status,
@@ -77,6 +170,7 @@ export async function publishRowEvent(
   } catch (err) {
     logger.warn("conversation-pubsub publish failed", {
       err,
+      transport: viaHttp ? "http" : "redis",
       conversationId: event.conversationId,
       rowId: event.rowId,
     });


### PR DESCRIPTION
## Summary

trigger.dev workers run in a separate runtime wired to their **own** Redis. The fire-and-forget `PUBLISH` inside `upsertConversationHistory` therefore succeeded and reached nobody — the conversation view sat on "Working…" until you refreshed, and the reply was already in the DB the whole time. With BullMQ the worker shares the app's Redis, so the identical code path works and the bug never shows up there.

Commit `664c6126` had stripped `REDIS_HOST/PORT/PASSWORD` from `trigger.config.ts`'s `syncEnvVars`, leaving an empty block whose comment still described the exact failure mode.

`publishRowEvent` now picks its transport by runtime:

| Runtime | Transport |
|---|---|
| webapp / BullMQ worker | `PUBLISH conv:{conversationId}` on the shared Redis (unchanged) |
| trigger.dev worker | `POST /api/v1/internal/conversation-events` → webapp publishes on its behalf |

Every caller upstream is untouched — `upsertConversationHistory` and its call sites in `run-agent-turn`, `task`, `case`, and `scratchpad-scan` are unchanged.

### Design notes

- **Detection is `RUNNING_IN_TRIGGER`, not `REDIS_HOST`.** The worker has `REDIS_HOST` set too — pointing at the wrong Redis — so presence proves nothing. It is also deliberately distinct from `queue-adapter`'s `isTriggerDeployment()`, which reports the *configured provider* and is true in the webapp process; conflating the two is what would reintroduce this bug.
- **The route calls `publishRowEventToRedis`, not `publishRowEvent`.** A stray `RUNNING_IN_TRIGGER` on the webapp would otherwise have the route POST to itself in a loop. There's a test for this.
- **Shared-secret auth, not the API-key flow** `internal/coding-events` uses — that authenticates a *user*, and a worker publishing on behalf of a job has none. The envelope carries no authority of its own; the SSE route still does its own ownership check.
- **Receiver count is relayed through the hop**, so the "receiverCount: 0 means nobody was listening" diagnostic still works from a worker.
- **Both transports stay fire-and-forget.** A bridge outage logs and is swallowed, never failing the DB write that preceded it. A missing secret now logs loudly instead of silently no-opping — that silence is what made the original bug hard to see.

### Blast radius

Every other Redis touchpoint (`jobManager`, `ingestionLogs`, `task-scheduler`) is behind a `provider === "bullmq"` guard and inert in trigger mode. `publishRowEvent` is the only Redis dependency a trigger worker actually hits.

## Required configuration

Not in this PR — needs to be set separately:

1. `RUNNING_IN_TRIGGER` set by the trigger runtime (`init` hook in `trigger.config.ts`).
2. `INTERNAL_EVENTS_SECRET` (same value on server and in the trigger.dev env dashboard) and `APP_ORIGIN` pointing at the publicly reachable webapp.

Until both are set the bridge is off: the route 503s and workers log the dropped event. Behaviour for BullMQ / self-hosted deployments is unchanged either way.

## Test plan

- [x] 19 new tests, all passing — `app/services/__tests__/conversation-pubsub.test.ts` (10) and `app/routes/__tests__/internal-conversation-events.test.ts` (9)
- [x] Covers both transport branches, missing secret, non-2xx and unreachable bridge, trailing-slash `APP_ORIGIN`, the anti-loop guarantee, and the auth boundary including a same-length-but-wrong secret
- [x] Typecheck adds zero errors (450 pre-existing before and after — unbuilt workspace packages)
- [ ] **Not verified:** the actual end-to-end hop, which needs a live trigger worker

### Pre-existing test failures (not from this branch)

The suite has 11 failing files / 2 failing tests on `main` as well. Verified by running the same suite with these changes stashed:

| | Failed files | Failed tests | Passed |
|---|---|---|---|
| Baseline (stashed) | 11 | 2 | 186 |
| With this branch | 11 | 2 | 205 |

Identical failure set; the +19 are the new tests. Remaining failures are collection errors from unbuilt workspace packages plus assertion failures in `message-tools` / `persona-generation`, none of which this branch touches. Left alone rather than fixed here.

## Not included

- `updateConversationStatus` still publishes nothing. `run-agent-turn` upserts the row immediately before flipping status, so the client's refetch picks up the terminal status.
- Server → worker cancellation still goes through `runs.cancel()` in `jobManager` and is unaffected. This bridge is one-way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143wvcb51LzYpw99QUrrzsE